### PR TITLE
Parameterize Event with the lifetime bound of its property names

### DIFF
--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -7,7 +7,7 @@ use pipeline::chain::{PipelineElement, ChainedElement};
 
 pub trait Collector {
     // Could use a signature re-think here
-    fn dispatch(&self, events: &[Event]) -> Result<(), Box<Error>>;
+    fn dispatch(&self, events: &[Event<'static>]) -> Result<(), Box<Error>>;
 }
 
 pub struct CollectorElement<T: Collector + Sync> {
@@ -21,7 +21,7 @@ impl<T: Collector + Sync> CollectorElement<T> {
 }
 
 impl<T: Collector + Sync> PipelineElement for CollectorElement<T> {
-    fn emit(&self, event: Event, next: &ChainedElement) {
+    fn emit(&self, event: Event<'static>, next: &ChainedElement) {
         let mut batch = vec![event];
         if let Err(e) = self.collector.dispatch(&batch) {
             error!("Could not dispatch events: {}", e);

--- a/src/collectors/seq/mod.rs
+++ b/src/collectors/seq/mod.rs
@@ -62,7 +62,7 @@ const FOOTER: &'static str = "]}";
 const FOOTER_LEN: usize = 2;
 
 impl super::Collector for SeqCollector {
-    fn dispatch(&self, events: &[events::Event]) -> Result<(), Box<Error>> {
+    fn dispatch(&self, events: &[events::Event<'static>]) -> Result<(), Box<Error>> {
         let mut next = HEADER.to_owned();
         let mut count = HEADER_LEN + FOOTER_LEN;
         let mut delim = "";

--- a/src/collectors/stdio/mod.rs
+++ b/src/collectors/stdio/mod.rs
@@ -18,7 +18,7 @@ impl StdioCollector {
 }
 
 impl super::Collector for StdioCollector {
-    fn dispatch(&self, events: &[events::Event]) -> Result<(), Box<Error>> {
+    fn dispatch(&self, events: &[events::Event<'static>]) -> Result<(), Box<Error>> {
         let out = io::stdout();
         let mut handle = out.lock();
         for event in events {

--- a/src/enrichers/fixed_property/mod.rs
+++ b/src/enrichers/fixed_property/mod.rs
@@ -15,7 +15,7 @@ impl FixedPropertyEnricher {
 }
 
 impl PipelineElement for FixedPropertyEnricher {
-    fn emit(&self, event: Event, next: &ChainedElement) {
+    fn emit(&self, event: Event<'static>, next: &ChainedElement) {
         let mut e = event;
         e.add_or_update_property(self.name, self.value.clone());
         next.emit(e);

--- a/src/events.rs
+++ b/src/events.rs
@@ -12,15 +12,15 @@ pub fn capture_property_value<T: serde::ser::Serialize>(v: &T) -> String {
     serde_json::to_string(v).unwrap()
 }
 
-pub struct Event {
+pub struct Event<'a> {
     timestamp: DateTime<UTC>,
     level: LogLevel,
     message_template: templates::MessageTemplate,
-    properties: collections::BTreeMap<&'static str, String>
+    properties: collections::BTreeMap<&'a str, String>
 }
 
-impl Event {
-    pub fn new(timestamp: DateTime<UTC>, level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'static str, String>) -> Event {
+impl<'a> Event<'a> {
+    pub fn new(timestamp: DateTime<UTC>, level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, String>) -> Event<'a> {
         Event {
             timestamp: timestamp,
             level: level,
@@ -29,7 +29,7 @@ impl Event {
         }
     }
     
-    pub fn new_now(level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'static str, String>) -> Event {
+    pub fn new_now(level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, String>) -> Event<'a> {
         Self::new(UTC::now(), level, message_template, properties)
     }
     
@@ -45,18 +45,18 @@ impl Event {
         &self.message_template
     }
     
-    pub fn properties(&self) -> &collections::BTreeMap<&'static str, String> {
+    pub fn properties(&self) -> &collections::BTreeMap<&'a str, String> {
         &self.properties
     }
     
-    pub fn add_or_update_property(&mut self, name: &'static str, value: String) {
+    pub fn add_or_update_property(&mut self, name: &'a str, value: String) {
         match self.properties.entry(name) {
             Entry::Vacant(v) => {v.insert(value);},
             Entry::Occupied(mut o) => {o.insert(value);}
         }
     }
     
-    pub fn add_property_if_absent(&mut self, name: &'static str, value: String) {
+    pub fn add_property_if_absent(&mut self, name: &'a str, value: String) {
         if !self.properties.contains_key(name) {
             self.properties.insert(name, value);
         }

--- a/src/pipeline/ambient.rs
+++ b/src/pipeline/ambient.rs
@@ -26,7 +26,7 @@ pub fn is_enabled(level: log::LogLevel) -> bool {
     }
 }
     
-pub fn emit(event: Event) {
+pub fn emit(event: Event<'static>) {
     let p = get_ambient_ref();    
     if p != 0 as *const PipelineRef {
         unsafe {

--- a/src/pipeline/async.rs
+++ b/src/pipeline/async.rs
@@ -8,7 +8,7 @@ use pipeline::chain::ChainedElement;
 
 pub enum Item {
     Done,
-    Emit(Event)
+    Emit(Event<'static>)
 }
 
 pub struct AsyncCollector{
@@ -65,7 +65,7 @@ impl SenderElement {
 }
 
 impl ChainedElement for SenderElement {
-    fn emit(&self, event: Event) {
+    fn emit(&self, event: Event<'static>) {
         self.chan.lock().unwrap().send(Item::Emit(event)).expect("The event could not be emitted to the pipeline");
     }
 }

--- a/src/pipeline/chain.rs
+++ b/src/pipeline/chain.rs
@@ -2,13 +2,13 @@ use events::Event;
 
 /// A link to the next element in a processing chain.
 pub trait ChainedElement : Sync {
-    fn emit(&self, event: Event);
+    fn emit(&self, event: Event<'static>);
 }
 
 /// An element within the processing chain that controls
 /// how an `Event` is passed through.
 pub trait PipelineElement : Sync {
-    fn emit(&self, event: Event, next: &ChainedElement);
+    fn emit(&self, event: Event<'static>, next: &ChainedElement);
 }
 
 struct ChainedPipelineElement {
@@ -17,7 +17,7 @@ struct ChainedPipelineElement {
 }
 
 impl ChainedElement for ChainedPipelineElement {
-    fn emit(&self, event: Event) {
+    fn emit(&self, event: Event<'static>) {
         self.current.emit(event, &*self.next);
     }
 }
@@ -26,7 +26,7 @@ struct TerminatingElement {}
 
 impl ChainedElement for TerminatingElement {
     #[allow(unused_variables)]
-    fn emit(&self, event: Event) {
+    fn emit(&self, event: Event<'static>) {
     }
 }
 

--- a/src/pipeline/reference.rs
+++ b/src/pipeline/reference.rs
@@ -25,7 +25,7 @@ impl PipelineRef {
     
     /// Emit an event through the pipeline. Code wishing to _conditionally_
     /// emit events based on the level should call `is_enabled()` first.
-    pub fn emit(&self, event: Event) {
+    pub fn emit(&self, event: Event<'static>) {
         self.head.emit(event);
     }
 }


### PR DESCRIPTION
First step for #12. While `Event` is now generic in `'a`, usages thoughout the library specify the concrete `'static` bound.

Next step is to parameterize the pipeline itself.