### PR TITLE
Introduce events::Value to distinguish between raw string, JSON, and values

### DIFF
--- a/src/collectors/seq/mod.rs
+++ b/src/collectors/seq/mod.rs
@@ -114,7 +114,7 @@ fn format_payload(event: &events::Event) -> String {
             first = false;
         }
         
-        write!(&mut body, "\"{}\":{}", n, v).is_ok();            
+        write!(&mut body, "\"{}\":{}", n, v.to_json()).is_ok();            
     }
              
     body.push_str("}}");
@@ -151,8 +151,8 @@ mod tests {
     #[test]
     fn events_are_formatted() {
         let timestamp = UTC.ymd(2014, 7, 8).and_hms(9, 10, 11);  
-        let mut properties: collections::BTreeMap<&'static str, String> = collections::BTreeMap::new();
-        properties.insert("number", "42".to_owned());
+        let mut properties = collections::BTreeMap::new();
+        properties.insert("number", "42".into());
         let evt = events::Event::new(timestamp, log::LogLevel::Warn, templates::MessageTemplate::new("The number is {number}"), properties);
         let payload = format_payload(&evt);
         assert_eq!(payload, "{\"Timestamp\":\"2014-07-08T09:10:11Z\",\"Level\":\"Warning\",\"MessageTemplate\":\"The number is {number}\",\"Properties\":{\"number\":42}}".to_owned());

--- a/src/enrichers/fixed_property/mod.rs
+++ b/src/enrichers/fixed_property/mod.rs
@@ -1,11 +1,11 @@
 use events;
-use events::Event;
+use events::{Event,Value};
 use pipeline::chain::{Emit,Propagate};
 use serde;
 
 pub struct FixedPropertyEnricher<'a> {
     name: &'a str,
-    value: String
+    value: Value
 }
 
 impl<'a> FixedPropertyEnricher<'a> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,22 +5,76 @@ use log::LogLevel;
 use serde;
 use serde_json;
 use templates;
+use std::fmt;
+use std::convert::Into;
 
 /// Converts an arbitrary serializable object into the internal property format
 /// carried on events (currently JSON values...)
-pub fn capture_property_value<T: serde::ser::Serialize>(v: &T) -> String {
-    serde_json::to_string(v).unwrap()
+pub fn capture_property_value<T: serde::ser::Serialize>(v: &T) -> Value {
+    Value::Json(serde_json::to_string(v).unwrap())
+}
+
+/// Currently just used as a marker; plan is to
+/// adopt the same scheme as serde_json's Value: https://github.com/serde-rs/json/blob/master/json/src/value.rs
+#[derive(Clone, PartialEq)]
+pub enum Value {
+    Json(String)
+}
+
+impl Value {
+    // JSON serialization belongs elsewhere, but keeps
+    // the distinction between regular string and JSON data clear.
+    pub fn to_json<'a>(&'a self) -> &'a str {
+        match self {
+            &Value::Json(ref s) => &s
+        }
+    }
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Value::Json(ref s) => write!(f, "Value({})", s)
+        }
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Value::Json(ref s) => {                    
+                let bytes = s.as_bytes();            
+                if bytes.len() > 1 && bytes[0] == b'"' {
+                    write!(f, "{}", &s[1..s.len() - 1])
+                } else {
+                    write!(f, "{}", s)
+                }
+            }
+        }
+    }
+}
+
+impl Into<Value> for String {
+    fn into(self) -> Value {
+        Value::Json(self)
+    }
+}
+
+impl<'a> Into<Value> for &'a str {
+    fn into(self) -> Value {
+        Value::Json(self.into())
+    }
 }
 
 pub struct Event<'a> {
     timestamp: DateTime<UTC>,
     level: LogLevel,
     message_template: templates::MessageTemplate,
-    properties: collections::BTreeMap<&'a str, String>
+    properties: collections::BTreeMap<&'a str, Value>
 }
 
 impl<'a> Event<'a> {
-    pub fn new(timestamp: DateTime<UTC>, level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, String>) -> Event<'a> {
+    pub fn new(timestamp: DateTime<UTC>, level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, Value>) -> Event<'a> {
         Event {
             timestamp: timestamp,
             level: level,
@@ -29,7 +83,7 @@ impl<'a> Event<'a> {
         }
     }
     
-    pub fn new_now(level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, String>) -> Event<'a> {
+    pub fn new_now(level: LogLevel, message_template: templates::MessageTemplate, properties: collections::BTreeMap<&'a str, Value>) -> Event<'a> {
         Self::new(UTC::now(), level, message_template, properties)
     }
     
@@ -45,18 +99,18 @@ impl<'a> Event<'a> {
         &self.message_template
     }
     
-    pub fn properties(&self) -> &collections::BTreeMap<&'a str, String> {
+    pub fn properties(&self) -> &collections::BTreeMap<&'a str, Value> {
         &self.properties
     }
     
-    pub fn add_or_update_property(&mut self, name: &'a str, value: String) {
+    pub fn add_or_update_property(&mut self, name: &'a str, value: Value) {
         match self.properties.entry(name) {
             Entry::Vacant(v) => {v.insert(value);},
             Entry::Occupied(mut o) => {o.insert(value);}
         }
     }
     
-    pub fn add_property_if_absent(&mut self, name: &'a str, value: String) {
+    pub fn add_property_if_absent(&mut self, name: &'a str, value: Value) {
         if !self.properties.contains_key(name) {
             self.properties.insert(name, value);
         }

--- a/src/formatters/json/mod.rs
+++ b/src/formatters/json/mod.rs
@@ -26,9 +26,9 @@ impl super::WriteEvent for JsonFormatter {
         for (n,v) in event.properties() {
             let bytes = n.as_bytes();
             if bytes.len() > 0 && bytes[0] == b'@' {
-                try!(write!(to, ",\"@{}\":{}", n, v));            
+                try!(write!(to, ",\"@{}\":{}", n, v.to_json()));            
             } else {
-                try!(write!(to, ",\"{}\":{}", n, v));            
+                try!(write!(to, ",\"{}\":{}", n, v.to_json()));            
             }
         }
                     

--- a/src/formatters/raw/mod.rs
+++ b/src/formatters/raw/mod.rs
@@ -14,7 +14,7 @@ impl super::WriteEvent for RawFormatter {
     fn write_event(&self, event: &Event<'static>, to: &mut Write) -> Result<(), Box<Error>> {
         try!(writeln!(to, "emit {} {:5} {}", event.timestamp().format("%FT%T%.9fZ"), event.level(), event.message_template().text()));
         for (n,v) in event.properties() {                
-            try!(writeln!(to, "  {}: {}", n, v));            
+            try!(writeln!(to, "  {}: {}", n, v.to_json()));            
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ macro_rules! __emit_get_event_data {
 
         // Underscores avoid the unused_mut warning
         let mut _names: Vec<&str> = vec![];
-        let mut properties: collections::BTreeMap<&'static str, String> = collections::BTreeMap::new();
+        let mut properties: collections::BTreeMap<&'static str, $crate::events::Value> = collections::BTreeMap::new();
 
         $(
             _names.push(stringify!($n));
@@ -305,8 +305,8 @@ mod tests {
 
         let (template, properties) = __emit_get_event_data!("t", "User {} exceeded quota of {}!", user: u, quota: q);
         assert_eq!(template.text(), "User {user} exceeded quota of {quota}!");
-        assert_eq!(properties.get("user"), Some(&"\"nblumhardt\"".to_owned()));
-        assert_eq!(properties.get("quota"), Some(&"42".to_owned()));
+        assert_eq!(properties.get("user"), Some(&"\"nblumhardt\"".into()));
+        assert_eq!(properties.get("quota"), Some(&"42".into()));
         assert_eq!(properties.len(), 3);
     }
 

--- a/src/pipeline/builder.rs
+++ b/src/pipeline/builder.rs
@@ -35,25 +35,25 @@ impl PipelineBuilder {
     }
 
     /// Set the logging level used by the pipeline. The default is `log::LogLevel::Info`.
-    pub fn at_level(mut self, level: log::LogLevel) -> PipelineBuilder {
+    pub fn at_level(mut self, level: log::LogLevel) -> Self {
         self.level = level;
         self
     }
     
     /// Add a processing element to the pipeline. Elements run in the order in which they
     /// are added, so the output of one `pipe()`d element is fed into the next.
-    pub fn pipe(mut self, element: Box<Propagate + Sync>) -> PipelineBuilder {
+    pub fn pipe(mut self, element: Box<Propagate + Sync>) -> Self {
         self.elements.push(element);
         self
     }
     
     /// Write to a collector, synchronously.
-    pub fn write_to<T: AcceptEvents + Sync + 'static>(self, collector: T) -> PipelineBuilder {
+    pub fn write_to<T: AcceptEvents + Sync + 'static>(self, collector: T) -> Self {
         self.pipe(Box::new(CollectorElement::<T>::new(collector)))
     }
 
     /// Send events to a collector, asynchronously. At present only one collector may receive events this way.
-    pub fn send_to<T: AcceptEvents + Send + 'static>(mut self, collector: T) -> PipelineBuilder {
+    pub fn send_to<T: AcceptEvents + Send + 'static>(mut self, collector: T) -> Self {
         let (tx, rx) = channel::<Item>();
         self.terminator = Some(Box::new(SenderElement::new(tx.clone())));
         self.async_collector = Some(AsyncCollector::new(collector, tx, rx));
@@ -77,4 +77,3 @@ impl PipelineBuilder {
         flush
     }
 }
-

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -6,6 +6,6 @@ use log::LogLevel;
 pub fn some_event() -> Event<'static> {
     let mt = MessageTemplate::new("Hello, {name}");
     let mut props = BTreeMap::new();
-    props.insert("name", "Alice".to_string());
+    props.insert("name", "Alice".into());
     Event::new_now(LogLevel::Info, mt, props)
 }


### PR DESCRIPTION
Fixes #23. Further, removes spurious quotes from the plain text formatted messages.
