### PR TITLE
Breaks the dependency on `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ keywords = ["log", "logging"]
 serde = "0.7"
 serde_json = "0.7"
 chrono = "0.2"
-log = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # emit  [![Join the chat at https://gitter.im/serilog/serilog](https://img.shields.io/gitter/room/emit/emit-rs.svg)](https://gitter.im/emit-rs/emit) [![Crates.io](https://img.shields.io/crates/v/emit.svg)](https://crates.io/crates/emit) [![Build status](https://travis-ci.org/emit-rs/emit.svg?branch=master)](https://travis-ci.org/emit-rs/emit)
 
-This crate implements a structured logging API similar to the one in [Serilog](http://serilog.net). In systems programming, this style of logging is most often found in Windows' [ETW](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363668(v=vs.85).aspx). Web and distributed applications use similar techniques to improve machine-readabililty when dealing with large event volumes.
+This crate implements a structured logging API similar to the one in [Serilog](http://serilog.net). Web and distributed applications use structured logging to improve machine-readabililty when dealing with large event volumes. Unlike many structured logging APIs, `emit`'s does this without sacrificing human-friendliness.
 
-"Emitted" log events consist of a _format_ and list of _named properties_, as in the `eminfo!()` call below.
+"Emitted" log events consist of a _format_ and list of _named properties_, as in the `info!()` call below.
 
 ```rust
 #[macro_use]
@@ -18,11 +18,11 @@ fn main() {
         .send_to(seq::SeqCollector::new_local())
         .init();
             
-    eminfo!("Hello, {}!", name: env::var("USERNAME").unwrap());
+    info!("Hello, {}!", name: env::var("USERNAME").unwrap());
 }
 ```
 
-The named arguments are captured as key/value properties that can be rendered in a structured format such as JSON:
+The event can be rendered into human-friendly text, while the named arguments are also captured as key/value properties when rendered in a structured format like JSON:
 
 ```json
 {
@@ -39,7 +39,7 @@ This makes log searches in an appropriate back-end collector much simpler:
 
 ### Collectors
 
-Collectors render or store events to a wide range of targets. A `StdioCollector` is currently included in the `emit` crate and supports plain text or JSON formatting:
+Collectors render or store events to a wide range of targets. A `StdioCollector` is included in the `emit` crate and supports plain text or JSON formatting:
 
 ```rust
 use emit::collectors::stdio::StdioCollector;
@@ -89,4 +89,4 @@ There's no way for a log processing system to later pull the username value from
 
 The idea of `emit` is that rendering _can_ happen at any point - but the original values are preserved for easy machine processing as well.
 
-To keep these two worlds in harmony, `emit` will be able to mirror events to `log` in future ( #7).
+To keep these two worlds in harmony, `emit` may eventually be able to mirror events to `log` in future ( #7).

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -19,11 +19,11 @@ impl<T: AcceptEvents + Sync> CollectorElement<T> {
 }
 
 impl<T: AcceptEvents + Sync> Propagate for CollectorElement<T> {
+    #[allow(unused_must_use)]
     fn propagate(&self, event: Event<'static>, next: &Emit) {
         let mut batch = vec![event];
-        if let Err(e) = self.collector.accept_events(&batch) {
-            error!("Could not dispatch events: {}", e);
-        }
+        // TODO - self-log
+        self.collector.accept_events(&batch);
         next.emit(batch.pop().unwrap());
     }
 }

--- a/src/enrichers/fixed_property/mod.rs
+++ b/src/enrichers/fixed_property/mod.rs
@@ -10,7 +10,7 @@ pub struct FixedPropertyEnricher<'a> {
 
 impl<'a> FixedPropertyEnricher<'a> {
     pub fn new<T: serde::ser::Serialize>(name: &'a str, value: &T) -> FixedPropertyEnricher<'a> {
-        FixedPropertyEnricher { name: name, value: events::capture_property_value(value) }
+        FixedPropertyEnricher { name: name, value: events::Value::capture(value) }
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,18 +1,12 @@
 use chrono::{DateTime,UTC};
 use std::collections;
 use std::collections::btree_map::Entry;
-use log::LogLevel;
+use LogLevel;
 use serde;
 use serde_json;
 use templates;
 use std::fmt;
 use std::convert::Into;
-
-/// Converts an arbitrary serializable object into the internal property format
-/// carried on events (currently JSON values...)
-pub fn capture_property_value<T: serde::ser::Serialize>(v: &T) -> Value {
-    Value::Json(serde_json::to_string(v).unwrap())
-}
 
 /// Currently just used as a marker; plan is to
 /// adopt the same scheme as serde_json's Value: https://github.com/serde-rs/json/blob/master/json/src/value.rs
@@ -28,6 +22,12 @@ impl Value {
         match self {
             &Value::Json(ref s) => &s
         }
+    }
+    
+    /// Converts an arbitrary serializable object into the internal property format
+    /// carried on events (currently JSON values...)
+    pub fn capture<T: serde::ser::Serialize>(v: &T) -> Value {
+        Value::Json(serde_json::to_string(v).unwrap())
     }
 }
 

--- a/src/formatters/json/mod.rs
+++ b/src/formatters/json/mod.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use events::Event;
 use std::error::Error;
-use log;
 use serde_json;
+use LogLevel;
 
 pub struct JsonFormatter {}
 
@@ -19,7 +19,7 @@ impl super::WriteEvent for JsonFormatter {
 
         try!(write!(to, "{{\"@t\":\"{}\",\"@mt\":{}", isots, template));
 
-        if event.level() != log::LogLevel::Info {
+        if event.level() != LogLevel::Info {
             try!(write!(to, ",\"@l\":\"{}\"", event.level()));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,12 +196,10 @@ macro_rules! emit {
 #[macro_export]
 macro_rules! error {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Error, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!($crate::LogLevel::Error, $s, $($n: $v),*);
     }};
 }
@@ -218,12 +216,10 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Warn, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!($crate::LogLevel::Warn, $s, $($n: $v),*);
     }};
 }
@@ -240,12 +236,10 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Info, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!($crate::LogLevel::Info, $s, $($n: $v),*);
     }};
 }
@@ -262,12 +256,10 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Debug, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!($crate::LogLevel::Debug, $s, $($n: $v),*);
     }};
 }
@@ -284,12 +276,10 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Trace, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
-        #[allow(unused_imports)]
         emit!($crate::LogLevel::Trace, $s, $($n: $v),*);
     }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! The arguments passed to `emit` are named:
 //!
 //! ```ignore
-//! eminfo!("Hello, {}!", user: env::var("USERNAME").unwrap());
+//! info!("Hello, {}!", user: env::var("USERNAME").unwrap());
 //! ```
 //!
 //! This event can be rendered into text identically to the `log` example, but structured data collectors also capture the
@@ -58,7 +58,7 @@
 //!         .write_to(StdioCollector::new(RawFormatter::new()))
 //!         .init();
 //!
-//!     eminfo!("Hello, {}!", name: env::var("USERNAME").unwrap_or("User".to_string()));
+//!     info!("Hello, {}!", name: env::var("USERNAME").unwrap_or("User".to_string()));
 //! }
 //! ```
 //!
@@ -191,10 +191,10 @@ macro_rules! emit {
 /// The example below will be emitted at the `emit::LogLevel::Error` level.
 ///
 /// ```ignore
-/// emerror!("Could not start {} on {}", cmd: "emitd", machine: "s123456");
+/// error!("Could not start {} on {}", cmd: "emitd", machine: "s123456");
 /// ```
 #[macro_export]
-macro_rules! emerror {
+macro_rules! error {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Error, $s, $($n: $v),*);
@@ -213,10 +213,10 @@ macro_rules! emerror {
 /// The example below will be emitted at the `emit::LogLevel::Warn` level.
 ///
 /// ```ignore
-/// emwarn!("SQL query took {} ms", elapsed: 7890);
+/// warn!("SQL query took {} ms", elapsed: 7890);
 /// ```
 #[macro_export]
-macro_rules! emwarn {
+macro_rules! warn {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Warn, $s, $($n: $v),*);
@@ -235,10 +235,10 @@ macro_rules! emwarn {
 /// The example below will be emitted at the `emit::LogLevel::Info` level.
 ///
 /// ```ignore
-/// eminfo!("Hello, {}!", user: env::var("USERNAME").unwrap());
+/// info!("Hello, {}!", user: env::var("USERNAME").unwrap());
 /// ```
 #[macro_export]
-macro_rules! eminfo {
+macro_rules! info {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Info, $s, $($n: $v),*);
@@ -257,10 +257,10 @@ macro_rules! eminfo {
 /// The example below will be emitted at the `emit::LogLevel::Debug` level.
 ///
 /// ```ignore
-/// emdebug!("Opening config file {}", filename: "dir/config.json");
+/// debug!("Opening config file {}", filename: "dir/config.json");
 /// ```
 #[macro_export]
-macro_rules! emdebug {
+macro_rules! debug {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Debug, $s, $($n: $v),*);
@@ -282,7 +282,7 @@ macro_rules! emdebug {
 /// emdtrace!("{} called with arg {}", method: "start_frobbles()", count: 123);
 /// ```
 #[macro_export]
-macro_rules! emtrace {
+macro_rules! trace {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
         emit!(target: $target, $crate::LogLevel::Trace, $s, $($n: $v),*);
@@ -334,6 +334,6 @@ mod tests {
             .write_to(StdioCollector::new(RawFormatter::new()))
             .init();
 
-        eminfo!("Hello, {} at {} in {}!", name: env::var("USERNAME").unwrap_or("User".to_string()), time: 2139, room: "office");
+        info!("Hello, {} at {} in {}!", name: env::var("USERNAME").unwrap_or("User".to_string()), time: 2139, room: "office");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,10 @@
 //!
 //! ```js
 //! {
-//!   "timestamp": "2016-03-17T00:17:01Z",
-//!   "messageTemplate": "Hello, {user}!",
-//!   "properties": {
-//!     "user": "nblumhardt",
-//!     "target": "example_app"
-//!   }
+//!   "@t": "2016-03-17T00:17:01.333Z",
+//!   "@mt": "Hello, {user}!",
+//!   "user": "nblumhardt",
+//!   "target": "example_app"
 //! }
 //! ```
 //!
@@ -49,7 +47,6 @@
 //! ```
 //! #[macro_use]
 //! extern crate emit;
-//! # extern crate log;
 //!
 //! use std::env;
 //! use emit::PipelineBuilder;
@@ -78,9 +75,6 @@ extern crate serde;
 extern crate serde_json;
 extern crate chrono;
 
-#[macro_use]
-extern crate log;
-
 pub mod templates;
 pub mod events;
 pub mod pipeline;
@@ -91,9 +85,42 @@ pub mod formatters;
 #[cfg(test)]
 mod test_support;
 
-/// Re-exports `log::LogLevel` so that users can initialize the emit
-/// crate without extra imports.
-pub use log::LogLevel;
+use std::fmt;
+
+#[repr(usize)]
+#[derive(Copy, Eq, Debug, PartialEq, Clone, Ord, PartialOrd)]
+pub enum LogLevel {
+    Error = 1, 
+    Warn, 
+    Info, 
+    Debug, 
+    Trace
+}
+
+#[repr(usize)]
+#[derive(Copy, Eq, Debug, PartialEq, Clone, Ord, PartialOrd)]
+pub enum LogLevelFilter {
+    Off,
+    Error, 
+    Warn, 
+    Info, 
+    Debug, 
+    Trace
+}
+
+static LOG_LEVEL_NAMES: [&'static str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", LOG_LEVEL_NAMES[*self as usize])
+    }
+}
+
+impl LogLevelFilter {
+    pub fn is_enabled(self, level: LogLevel) -> bool {
+        self as usize >= level as usize
+    }
+}
 
 /// Re-export `pipeline::builder::PipelineBuilder` so that clients don't need to
 /// fully-qualify the hierarchy.
@@ -113,10 +140,10 @@ macro_rules! __emit_get_event_data {
 
         $(
             _names.push(stringify!($n));
-            properties.insert(stringify!($n), $crate::events::capture_property_value(&$v));
+            properties.insert(stringify!($n), $crate::events::Value::capture(&$v));
         )*
 
-        properties.insert("target", $crate::events::capture_property_value(&$target));
+        properties.insert("target", $crate::events::Value::capture(&$target));
 
         let template = $crate::templates::MessageTemplate::from_format($s, &_names);
 
@@ -170,14 +197,12 @@ macro_rules! emit {
 macro_rules! emerror {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(target: $target, log::LogLevel::Error, $s, $($n: $v),*);
+        emit!(target: $target, $crate::LogLevel::Error, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(log::LogLevel::Error, $s, $($n: $v),*);
+        emit!($crate::LogLevel::Error, $s, $($n: $v),*);
     }};
 }
 
@@ -194,14 +219,12 @@ macro_rules! emerror {
 macro_rules! emwarn {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(target: $target, log::LogLevel::Warn, $s, $($n: $v),*);
+        emit!(target: $target, $crate::LogLevel::Warn, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(log::LogLevel::Warn, $s, $($n: $v),*);
+        emit!($crate::LogLevel::Warn, $s, $($n: $v),*);
     }};
 }
 
@@ -218,14 +241,12 @@ macro_rules! emwarn {
 macro_rules! eminfo {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(target: $target, log::LogLevel::Info, $s, $($n: $v),*);
+        emit!(target: $target, $crate::LogLevel::Info, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(log::LogLevel::Info, $s, $($n: $v),*);
+        emit!($crate::LogLevel::Info, $s, $($n: $v),*);
     }};
 }
 
@@ -242,14 +263,12 @@ macro_rules! eminfo {
 macro_rules! emdebug {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(target: $target, log::LogLevel::Debug, $s, $($n: $v),*);
+        emit!(target: $target, $crate::LogLevel::Debug, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(log::LogLevel::Debug, $s, $($n: $v),*);
+        emit!($crate::LogLevel::Debug, $s, $($n: $v),*);
     }};
 }
 
@@ -266,14 +285,12 @@ macro_rules! emdebug {
 macro_rules! emtrace {
     (target: $target:expr, $s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(target: $target, log::LogLevel::Trace, $s, $($n: $v),*);
+        emit!(target: $target, $crate::LogLevel::Trace, $s, $($n: $v),*);
     }};
 
     ($s:expr, $($n:ident: $v:expr),*) => {{
         #[allow(unused_imports)]
-        use log;
-        emit!(log::LogLevel::Trace, $s, $($n: $v),*);
+        emit!($crate::LogLevel::Trace, $s, $($n: $v),*);
     }};
 }
 
@@ -282,7 +299,7 @@ mod tests {
     use enrichers::fixed_property::FixedPropertyEnricher;
     use pipeline::builder::PipelineBuilder;
     use std::env;
-    use log;
+    use LogLevelFilter;
     use collectors::stdio::StdioCollector;
     use formatters::json::JsonFormatter;
     use formatters::text::PlainTextFormatter;
@@ -310,7 +327,7 @@ mod tests {
     #[test]
     fn pipeline_example() {
         let _flush = PipelineBuilder::new()
-            .at_level(log::LogLevel::Info)
+            .at_level(LogLevelFilter::Info)
             .pipe(Box::new(FixedPropertyEnricher::new("app", &"Test")))
             .write_to(StdioCollector::new(PlainTextFormatter::new()))
             .write_to(StdioCollector::new(JsonFormatter::new()))

--- a/src/pipeline/ambient.rs
+++ b/src/pipeline/ambient.rs
@@ -1,6 +1,6 @@
 use events::Event;
 use std::sync::atomic;
-use log;
+use LogLevel;
 use std::mem;
 use pipeline::reference::PipelineRef;
 
@@ -15,7 +15,7 @@ pub fn set_ambient_ref(pref: PipelineRef) {
     PIPELINE_REF.store(unsafe { mem::transmute::<Box<PipelineRef>, *const PipelineRef>(bpref) } as usize, atomic::Ordering::SeqCst);
 }
 
-pub fn is_enabled(level: log::LogLevel) -> bool {
+pub fn is_enabled(level: LogLevel) -> bool {
     let p = get_ambient_ref();    
     if p != 0 as *const PipelineRef {
         unsafe {

--- a/src/pipeline/async.rs
+++ b/src/pipeline/async.rs
@@ -27,6 +27,7 @@ impl Drop for AsyncCollector{
 }
 
 impl AsyncCollector{
+    #[allow(unused_must_use)]
     pub fn new<T: collectors::AcceptEvents + Send + 'static>(collector: T, tx: Sender<Item>, rx: Receiver<Item>) -> AsyncCollector{
         let coll = collector;
         let child = thread::spawn(move|| {
@@ -34,9 +35,8 @@ impl AsyncCollector{
                 let done = match rx.recv().unwrap() {
                     Item::Done => true,
                     Item::Emit(payload) => {
-                        if let Err(e) = coll.accept_events(&vec![payload]) {
-                            error!("Could not dispatch events: {}", e);
-                        }
+                        // TODO - self-log
+                        coll.accept_events(&vec![payload]);
                         false
                     }
                 };

--- a/src/pipeline/builder.rs
+++ b/src/pipeline/builder.rs
@@ -1,5 +1,5 @@
 use std::sync::mpsc::channel;
-use log;
+use LogLevelFilter;
 use collectors::{AcceptEvents,CollectorElement};
 use pipeline::chain;
 use pipeline::chain::{Emit,Propagate};
@@ -18,7 +18,7 @@ pub struct AsyncFlushHandle {
 /// for use by the `emit!()` family of macros. Calling `detach()` will return an independent pipeline that
 /// can be used in isolation.
 pub struct PipelineBuilder {
-    level: log::LogLevel,
+    level: LogLevelFilter,
     elements: Vec<Box<Propagate + Sync>>,
     terminator: Option<Box<Emit + Sync>>,
     async_collector: Option<AsyncCollector>
@@ -27,15 +27,15 @@ pub struct PipelineBuilder {
 impl PipelineBuilder {
     pub fn new() -> PipelineBuilder {
         PipelineBuilder { 
-            level: log::LogLevel::Info,
+            level: LogLevelFilter::Info,
             elements: vec![],
             terminator: None,
             async_collector: None
         }
     }
 
-    /// Set the logging level used by the pipeline. The default is `log::LogLevel::Info`.
-    pub fn at_level(mut self, level: log::LogLevel) -> Self {
+    /// Set the logging level used by the pipeline. The default is `LogLevelFilter::Info`.
+    pub fn at_level(mut self, level: LogLevelFilter) -> Self {
         self.level = level;
         self
     }

--- a/src/pipeline/reference.rs
+++ b/src/pipeline/reference.rs
@@ -1,26 +1,26 @@
 use events::Event;
 use pipeline::chain::Emit;
-use log;
+use super::super::{LogLevel,LogLevelFilter};
 
 /// `PipelineRef` is "mouth" of the pipeline, into which events are fed.
 pub struct PipelineRef {
     head: Box<Emit + Sync>,
-    filter: log::LogLevelFilter
+    filter: LogLevelFilter
 }
 
 //unsafe impl Sync for PipelineRef { }
 
 impl PipelineRef {
-    pub fn new(head: Box<Emit + Sync>, level: log::LogLevel) -> PipelineRef {
+    pub fn new(head: Box<Emit + Sync>, level: LogLevelFilter) -> PipelineRef {
         PipelineRef {
             head: head,
-            filter: level.to_log_level_filter()
+            filter: level
         }
     }
     
     /// Check if the specified log level is enabled for the pipeline.
-    pub fn is_enabled(&self, level: log::LogLevel) -> bool {
-        self.filter >= level
+    pub fn is_enabled(&self, level: LogLevel) -> bool {
+        self.filter.is_enabled(level)
     }
     
     /// Emit an event through the pipeline. Code wishing to _conditionally_
@@ -33,24 +33,24 @@ impl PipelineRef {
 #[cfg(test)]
 mod tests {
     use pipeline::builder::PipelineBuilder;
-    use log;
+    use LogLevel;
     
     #[test]
     fn info_is_enabled_at_info() {
         let (p, _flush) = PipelineBuilder::new().detach();
-        assert!(p.is_enabled(log::LogLevel::Info));
+        assert!(p.is_enabled(LogLevel::Info));
     }
     
     #[test]
     fn warn_is_enabled_at_info() {
         let (p, _flush) = PipelineBuilder::new().detach();
-        assert!(p.is_enabled(log::LogLevel::Warn));
+        assert!(p.is_enabled(LogLevel::Warn));
     }  
       
     #[test]
     fn debug_is_disabled_at_info() {
         let (p, _flush) = PipelineBuilder::new().detach();
-        assert!(!p.is_enabled(log::LogLevel::Debug));
+        assert!(!p.is_enabled(LogLevel::Debug));
     }
 }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use events::Event;
 use templates::MessageTemplate;
-use log::LogLevel;
+use LogLevel;
 
 pub fn some_event() -> Event<'static> {
     let mt = MessageTemplate::new("Hello, {name}");


### PR DESCRIPTION
Part of #29.

I'm keen to rename `eminfo` -> `info` etc. as part of this ticket - thoughts?