### PR TITLE
Alternative, rendered, JSON formatting implementation

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -98,6 +98,11 @@ impl<'a> Event<'a> {
     pub fn message_template(&self) -> &templates::MessageTemplate {
         &self.message_template
     }
+
+    pub fn message(&self) -> String {
+        let repl = self.message_template.parse();
+        repl.replace(self.properties())
+    }
     
     pub fn properties(&self) -> &collections::BTreeMap<&'a str, Value> {
         &self.properties

--- a/src/formatters/json/mod.rs
+++ b/src/formatters/json/mod.rs
@@ -1,9 +1,13 @@
 use std::io::Write;
+use std::num::Wrapping;
 use events::Event;
 use std::error::Error;
 use serde_json;
 use LogLevel;
 
+/// Translate events into a compact JSON format. A message template and
+/// associated properties are recorded. To include the rendered message
+/// and computed event type instead, see `RenderedJsonFormatter`.
 pub struct JsonFormatter {}
 
 impl JsonFormatter {
@@ -38,15 +42,74 @@ impl super::WriteEvent for JsonFormatter {
     }
 }
 
+/// Translate events into a compact JSON format. The message is rendered
+/// into text and a 32-bit _event type_ is computed from the original
+/// message template. To record the template itself instead, see `JsonFormatter`.
+pub struct RenderedJsonFormatter {}
+
+impl RenderedJsonFormatter {
+    pub fn new() -> RenderedJsonFormatter {
+        RenderedJsonFormatter{}
+    }
+}
+
+fn jenkins_hash(text: &str) -> u32 {
+    let mut hash = Wrapping(0u32);
+    for ch in text.chars() {
+        hash += Wrapping(ch as u32);
+        hash += hash << 10;
+        hash ^= hash >> 6;
+    }
+    hash += hash << 3;
+    hash ^= hash >> 11;
+    hash += hash << 15;
+    hash.0
+}
+
+impl super::WriteEvent for RenderedJsonFormatter {
+    fn write_event(&self, event: &Event<'static>, to: &mut Write) -> Result<(), Box<Error>> {
+        let message = try!(serde_json::to_string(&event.message()));
+        let id = jenkins_hash(&event.message_template().text());
+        let isots = event.timestamp().format("%FT%T%.3fZ");
+
+        try!(write!(to, "{{\"@t\":\"{}\",\"@m\":{},\"@i\":\"{:08x}\"", isots, message, id));
+
+        if event.level() != LogLevel::Info {
+            try!(write!(to, ",\"@l\":\"{}\"", event.level()));
+        }
+
+        for (n,v) in event.properties() {
+            let bytes = n.as_bytes();
+            if bytes.len() > 0 && bytes[0] == b'@' {
+                try!(write!(to, ",\"@{}\":{}", n, v.to_json()));            
+            } else {
+                try!(write!(to, ",\"{}\":{}", n, v.to_json()));            
+            }
+        }
+                    
+        try!(write!(to, "}}"));
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use formatters::WriteEvent;
-    use super::JsonFormatter;
+    use super::{JsonFormatter,RenderedJsonFormatter};
     use test_support;
 
     #[test]
     fn json_is_produced() {        
         let fmt = JsonFormatter::new();
+        let evt = test_support::some_event();
+        let mut content = vec![];
+        fmt.write_event(&evt, &mut content).is_ok();
+    }
+
+    #[test]
+    fn rendered_json_is_produced() {        
+        let fmt = RenderedJsonFormatter::new();
         let evt = test_support::some_event();
         let mut content = vec![];
         fmt.write_event(&evt, &mut content).is_ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ mod tests {
     use std::env;
     use LogLevelFilter;
     use collectors::stdio::StdioCollector;
-    use formatters::json::JsonFormatter;
+    use formatters::json::{JsonFormatter,RenderedJsonFormatter};
     use formatters::text::PlainTextFormatter;
     use formatters::raw::RawFormatter;
 
@@ -321,6 +321,7 @@ mod tests {
             .pipe(Box::new(FixedPropertyEnricher::new("app", &"Test")))
             .write_to(StdioCollector::new(PlainTextFormatter::new()))
             .write_to(StdioCollector::new(JsonFormatter::new()))
+            .write_to(StdioCollector::new(RenderedJsonFormatter::new()))
             .write_to(StdioCollector::new(RawFormatter::new()))
             .init();
 

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -37,6 +37,10 @@ impl MessageTemplate {
     pub fn text(&self) -> &String {
         &self.text
     }
+
+    pub fn parse<'a>(&'a self) -> repl::MessageTemplateRepl<'a> {
+        repl::MessageTemplateRepl::new(&self.text)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements the "rendered" variant of the JSON format specified in: https://github.com/serilog/serilog-formatting-compact
