### PR TITLE
Support completing spans as results

### DIFF
--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -174,10 +174,7 @@ fn print_event(
         write_plain(buf, " ");
     }
 
-    if let Some(kind) = evt.props().get(KEY_EVENT_KIND) {
-        write_fg(buf, kind, KIND);
-        write_plain(buf, " ");
-    }
+    write_fg(buf, format_args!("{} ", evt.module().root()), MODULE);
 
     let mut lvl = None;
     if let Some(level) = evt.props().pull::<emit::Level, _>(KEY_LVL) {
@@ -187,7 +184,10 @@ fn print_event(
         write_plain(buf, " ");
     }
 
-    write_fg(buf, format_args!("{} ", evt.module().root()), MODULE);
+    if let Some(kind) = evt.props().get(KEY_EVENT_KIND) {
+        write_fg(buf, kind, KIND);
+        write_plain(buf, " ");
+    }
 
     let _ = evt.msg().write(Writer { buf });
     write_plain(buf, "\n");

--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -174,8 +174,6 @@ fn print_event(
         write_plain(buf, " ");
     }
 
-    write_fg(buf, format_args!("{} ", evt.module().root()), MODULE);
-
     let mut lvl = None;
     if let Some(level) = evt.props().pull::<emit::Level, _>(KEY_LVL) {
         lvl = level_color(&level).map(Color::Ansi256);
@@ -429,7 +427,6 @@ impl<'a> emit::template::Write for Writer<'a> {
     }
 }
 
-const MODULE: Color = Color::Ansi256(244);
 const KIND: Color = Color::Ansi256(174);
 
 const TEXT: Color = Color::Ansi256(69);

--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -51,6 +51,10 @@ name = "filter_per_emitter"
 path = "filter_per_emitter.rs"
 
 [[example]]
+name = "span_auto_result_completion"
+path = "span_auto_result_completion.rs"
+
+[[example]]
 name = "span_manual_completion"
 path = "span_manual_completion.rs"
 

--- a/examples/common_patterns/span_auto_result_completion.rs
+++ b/examples/common_patterns/span_auto_result_completion.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+#[derive(thiserror::Error, Debug)]
+#[error("invalid number {n}")]
+struct Error {
+    n: i32,
+}
+
+// The `guard` control parameter binds an `emit::Span` that you can use
+// to manually complete your span, adding extra properties if needed.
+//
+// If you don't complete the span manually then it will complete on its
+// own when it falls out of scope.
+#[emit::span(
+    ok_lvl: emit::Level::Info,
+    err_lvl: emit::Level::Error,
+    "Running an example",
+    i,
+)]
+fn example(i: i32) -> Result<(), Error> {
+    let r = i + 1;
+
+    if r == 4 {
+        Err(Error { n: r })
+    } else {
+        Ok(())
+    }
+}
+
+fn main() {
+    let rt = emit::setup().emit_to(emit_term::stdout()).init();
+
+    let _ = example(1);
+    let _ = example(3);
+
+    rt.blocking_flush(Duration::from_secs(5));
+}

--- a/examples/common_patterns/span_auto_result_completion.rs
+++ b/examples/common_patterns/span_auto_result_completion.rs
@@ -6,11 +6,9 @@ struct Error {
     n: i32,
 }
 
-// The `guard` control parameter binds an `emit::Span` that you can use
-// to manually complete your span, adding extra properties if needed.
-//
-// If you don't complete the span manually then it will complete on its
-// own when it falls out of scope.
+// The `ok_lvl` and `err_lvl` control parameters can be used on functions
+// returning a `Result` to change the level based on the result returned.
+// `err_lvl` also attaches the error as a property.
 #[emit::span(
     ok_lvl: emit::Level::Info,
     err_lvl: emit::Level::Error,

--- a/examples/common_patterns/span_manual.rs
+++ b/examples/common_patterns/span_manual.rs
@@ -8,7 +8,7 @@ fn example(i: i32) {
     let ctxt = emit::SpanCtxt::current(emit::ctxt()).new_child(emit::rng());
 
     // Push into the ambient context, so emitted events see the trace and span ids
-    ctxt.push(emit::ctxt(), emit::props! {}).call(|| {
+    ctxt.push(emit::ctxt()).call(|| {
         let r = i + 1;
 
         if r == 4 {

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -113,7 +113,7 @@ impl Arg<TokenStream> {
         {
             use syn::spanned::Spanned;
 
-            if let Some(value) = self.take() {
+            if let Some(value) = self.value {
                 Err(syn::Error::new(
                     value.span(),
                     format!(

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -80,10 +80,13 @@ impl Arg<TokenStream> {
         Arg::new(key, to_tokens)
     }
 
-    pub fn take_when(self) -> TokenStream {
+    /**
+    Returns `Some(#tokens)` if the arg was present, or `None::<emit::Empty>` if it wasn't.
+    */
+    pub fn take_some_or_empty(self) -> TokenStream {
         self.take()
             .map(|tokens| quote!(Some(#tokens)))
-            .unwrap_or_else(|| quote!(None::<emit::empty::Empty>))
+            .unwrap_or_else(|| quote!(None::<emit::Empty>))
     }
 
     pub fn take_rt(self) -> Result<TokenStream, syn::Error> {
@@ -98,6 +101,29 @@ impl Arg<TokenStream> {
             use proc_macro2::Span;
 
             self.take().ok_or_else(|| syn::Error::new(Span::call_site(), "a runtime must be specified by the `rt` parameter unless the `implicit_rt` feature of `emit` is enabled"))
+        }
+    }
+
+    pub fn take_if_std(self) -> Result<Option<TokenStream>, syn::Error> {
+        #[cfg(feature = "std")]
+        {
+            Ok(self.take())
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            use syn::spanned::Spanned;
+
+            if let Some(value) = self.take() {
+                Err(syn::Error::new(
+                    value.span(),
+                    format!(
+                        "capturing `{}` is only possible when the `std` Cargo feature is enabled",
+                        self.key
+                    ),
+                ))
+            } else {
+                Ok(None)
+            }
         }
     }
 }

--- a/macros/src/emit.rs
+++ b/macros/src/emit.rs
@@ -79,7 +79,7 @@ impl Parse for Args {
             props: props.take().unwrap_or_else(|| quote!(emit::empty::Empty)),
             event: event.take(),
             rt: rt.take_rt()?,
-            when: when.take_when(),
+            when: when.take_some_or_empty(),
         })
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -358,6 +358,8 @@ This macro accepts the following optional control parameters:
 - `module: impl Into<emit::Path>`: The module the event belongs to. If unspecified the current module path is used.
 - `when: impl emit::Filter`: A filter to use instead of the one configured on the runtime.
 - `arg`: An identifier to bind an `emit::Span` to in the body of the span for manual completion.
+- `ok_lvl`: Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.
+- `err_lvl`. Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.
 
 # Template
 

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -601,6 +601,52 @@ pub fn __private_complete_span<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock,
     );
 }
 
+#[track_caller]
+#[cfg(feature = "std")]
+pub fn __private_complete_span_ok<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rng>(
+    rt: &'a Runtime<E, F, C, T, R>,
+    span: Span<'static, Empty>,
+    tpl: Template<'b>,
+    evt_props: impl Props,
+    lvl: &impl ToValue,
+) {
+    __private_emit(
+        rt,
+        span.module(),
+        Some(crate::filter::always()),
+        span.extent(),
+        tpl,
+        (crate::well_known::KEY_LVL, lvl)
+            .and_props(evt_props)
+            .and_props(&span),
+    );
+}
+
+#[track_caller]
+#[cfg(feature = "std")]
+pub fn __private_complete_span_err<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rng>(
+    rt: &'a Runtime<E, F, C, T, R>,
+    span: Span<'static, Empty>,
+    tpl: Template<'b>,
+    evt_props: impl Props,
+    lvl: &impl ToValue,
+    err: &(impl std::error::Error + Send + Sync + 'static),
+) {
+    __private_emit(
+        rt,
+        span.module(),
+        Some(crate::filter::always()),
+        span.extent(),
+        tpl,
+        [
+            (crate::well_known::KEY_LVL, Value::from_any(lvl)),
+            (crate::well_known::KEY_ERR, Value::capture_error(err)),
+        ]
+        .and_props(evt_props)
+        .and_props(&span),
+    );
+}
+
 #[repr(transparent)]
 pub struct __PrivateMacroProps<'a>([(Str<'a>, Option<Value<'a>>)]);
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -308,6 +308,72 @@ if let (Some(trace_id), Some(span_id)) = (trace_id, span_id) {
 # }
 ```
 
+# Completing spans for fallible functions
+
+The `ok_lvl` and `err_lvl` control parameters can be applied to span macros to assign a level based on whether the annotated function returned `Ok` or `Err`:
+
+```
+# #[cfg(not(feature = "std"))] fn main() {}
+# #[cfg(feature = "std")] fn main() {
+# use std::{io, thread, time::Duration};
+#[emit::span(
+    ok_lvl: emit::Level::Info,
+    err_lvl: emit::Level::Error,
+    "wait a bit",
+    sleep_ms,
+)]
+fn wait_a_bit(sleep_ms: u64) -> Result<(), io::Error> {
+    if sleep_ms > 500 {
+        return Err(io::Error::new(io::ErrorKind::Other, "the wait is too long"));
+    }
+
+    thread::sleep(Duration::from_millis(sleep_ms));
+
+    Ok(())
+}
+
+let _ = wait_a_bit(100);
+let _ = wait_a_bit(1200);
+# }
+```
+
+```text
+Event {
+    module: "my_app",
+    tpl: "wait a bit",
+    extent: Some(
+        "2024-06-12T21:43:03.556361000Z".."2024-06-12T21:43:03.661164000Z",
+    ),
+    props: {
+        "lvl": info,
+        "event_kind": span,
+        "span_name": "wait a bit",
+        "trace_id": 6a3fc0e46bfa1da71537e39e3bf1942c,
+        "span_id": f5bcc5821c6c3227,
+        "sleep_ms": 100,
+    },
+}
+Event {
+    module: "my_app",
+    tpl: "wait a bit",
+    extent: Some(
+        "2024-06-12T21:43:03.661850000Z".."2024-06-12T21:43:03.661986000Z",
+    ),
+    props: {
+        "lvl": error,
+        "err": Custom {
+            kind: Other,
+            error: "the wait is too long",
+        },
+        "event_kind": span,
+        "span_name": "wait a bit",
+        "trace_id": 3226b70b45ff90f92f4feccee4325d4d,
+        "span_id": 3702ba2429f9a7b7,
+        "sleep_ms": 1200,
+    },
+}
+```
+
 # Completing spans manually
 
 The `guard` control parameter can be applied to span macros to bind an identifier in the body of the annotated function for the [`Span`] that's created for it. This span can be completed manually, changing properties of the span along the way:


### PR DESCRIPTION
Closes #48 

This PR introduces the `ok_lvl` and `err_lvl` control parameters that can complete spans instrumenting fallible functions:

```rust
#[emit::span(
    ok_lvl: emit::Level::Info,
    err_lvl: emit::Level::Error,
    "Running an example",
    i,
)]
fn example(i: i32) -> Result<(), Error> {
    let r = i + 1;

    if r == 4 {
        Err(Error { n: r })
    } else {
        Ok(())
    }
}
```