### PR TITLE
Default Template formatting to braced and rename event to evt

### DIFF
--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -333,7 +333,7 @@ pub trait Write: fmt::Write {
     This method is called for any [`Part::hole`] in the template where a matching property doesn't exist.
     */
     fn write_hole_label(&mut self, label: &str) -> fmt::Result {
-        self.write_fmt(format_args!("`{}`", label))
+        self.write_fmt(format_args!("{{{}}}", label))
     }
 }
 
@@ -399,68 +399,6 @@ impl<W: fmt::Write> fmt::Write for WriteEscaped<W> {
         }
 
         Ok(())
-    }
-}
-
-struct WriteBraced<W>(W);
-
-impl<W: fmt::Write> WriteBraced<W> {
-    pub fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
-        self.0.write_fmt(args)
-    }
-}
-
-impl<W: fmt::Write> fmt::Write for WriteBraced<W> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.0.write_str(s)
-    }
-
-    fn write_char(&mut self, c: char) -> fmt::Result {
-        self.0.write_char(c)
-    }
-
-    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
-        self.write_fmt(args)
-    }
-}
-
-impl<W: Write> Write for WriteBraced<W> {
-    fn write_text(&mut self, text: &str) -> fmt::Result {
-        self.0.write_text(text)
-    }
-
-    fn write_hole_value(&mut self, label: &str, value: Value) -> fmt::Result {
-        self.0.write_hole_value(label, value)
-    }
-
-    fn write_hole_fmt(&mut self, label: &str, value: Value, formatter: Formatter) -> fmt::Result {
-        self.0.write_hole_fmt(label, value, formatter)
-    }
-
-    fn write_hole_label(&mut self, label: &str) -> fmt::Result {
-        self.0.write_fmt(format_args!("{{{}}}", label))
-    }
-}
-
-/**
-The result of [`Render::braced`].
-
-This type will render a template by wrapping hole labels in braces where a matching property doesn't exist.
-*/
-pub struct Braced<'a, P>(Render<'a, P>);
-
-impl<'a, P> Render<'a, P> {
-    /**
-    Render holes that have missing properties between braces, like `Hello, {user}`.
-    */
-    pub fn braced(self) -> Braced<'a, P> {
-        Braced(self)
-    }
-}
-
-impl<'a, P: Props> fmt::Display for Braced<'a, P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.write(WriteBraced(f))
     }
 }
 

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -546,10 +546,10 @@ impl<R: data::RequestEncoder> OtlpTransport<R> {
                     .await
                 {
                     Ok(res) => {
-                        span.complete_with(|span| {
+                        span.complete_with(|evt| {
                             emit::debug!(
                                 rt: emit::runtime::internal(),
-                                event: span,
+                                evt,
                                 "OTLP batch of {batch_size} events to {uri}",
                                 batch_size,
                             )
@@ -558,10 +558,10 @@ impl<R: data::RequestEncoder> OtlpTransport<R> {
                         res
                     }
                     Err(err) => {
-                        span.complete_with(|span| {
+                        span.complete_with(|evt| {
                             emit::warn!(
                                 rt: emit::runtime::internal(),
-                                event: span,
+                                evt,
                                 "OTLP batch of {batch_size} events to {uri} failed: {err}",
                                 batch_size,
                                 err,

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -683,9 +683,9 @@ fn add(a: i32, b: i32) -> i32 {
    let r = a + b;
 
    if r == 4 {
-      span.complete_with(|event| {
+      span.complete_with(|evt| {
             emit::error!(
-               event,
+               evt,
                "Compute {a} + {b} failed",
                a,
                b,

--- a/examples/common_patterns/span_manual.rs
+++ b/examples/common_patterns/span_manual.rs
@@ -14,7 +14,7 @@ fn example(i: i32) {
         if r == 4 {
             // Emit a span event on completion
             emit::error!(
-                event: emit::Span::new(
+                evt: emit::Span::new(
                     emit::module!(),
                     timer,
                     "example",
@@ -25,7 +25,7 @@ fn example(i: i32) {
         } else {
             // Emit a span event on completion
             emit::info!(
-                event: emit::Span::new(
+                evt: emit::Span::new(
                     emit::module!(),
                     timer,
                     "example",

--- a/examples/common_patterns/span_manual_completion.rs
+++ b/examples/common_patterns/span_manual_completion.rs
@@ -10,12 +10,12 @@ fn example(i: i32) {
     let r = i + 1;
 
     if r == 4 {
-        span.complete_with(|event| {
-            emit::error!(event, "Running an example failed with {r}");
+        span.complete_with(|evt| {
+            emit::error!(evt, "Running an example failed with {r}");
         });
     } else {
-        span.complete_with(|event| {
-            emit::info!(event, "Running an example produced {r}");
+        span.complete_with(|evt| {
+            emit::info!(evt, "Running an example produced {r}");
         });
     }
 }

--- a/examples/common_patterns/span_trace_propagation.rs
+++ b/examples/common_patterns/span_trace_propagation.rs
@@ -48,8 +48,8 @@ fn routes(method: &str, path: &str) {
     match path {
         "/api/route-1" => api_route_1(),
         _ => {
-            span.complete_with(|event| {
-                emit::error!(event, "HTTP {method} {path} matched no route");
+            span.complete_with(|evt| {
+                emit::error!(evt, "HTTP {method} {path} matched no route");
             });
         }
     }

--- a/macros/src/event.rs
+++ b/macros/src/event.rs
@@ -59,7 +59,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
     let template =
         template.ok_or_else(|| syn::Error::new(span, "missing template string literal"))?;
 
-    push_event_props(&mut props, opts.level)?;
+    push_evt_props(&mut props, opts.level)?;
 
     let extent_tokens = args.extent;
     let base_props_tokens = args.props;
@@ -72,7 +72,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
     )
 }
 
-pub fn push_event_props(props: &mut Props, level: Option<TokenStream>) -> Result<(), syn::Error> {
+pub fn push_evt_props(props: &mut Props, level: Option<TokenStream>) -> Result<(), syn::Error> {
     // Add the level as a property
     if let Some(level_value) = level {
         let level_ident = Ident::new(emit_core::well_known::KEY_LVL, Span::call_site());

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -522,7 +522,7 @@ where
 This macro accepts the following optional control parameters:
 
 - `rt: impl emit::runtime::Runtime`: The runtime to emit the event through.
-- `event: impl emit::event::ToEvent`: A base event to emit. Any properties captured by the macro will be appended to the base event. If this control parameter is specified then `module`, `props`, and `extent` cannot also be set.
+- `evt: impl emit::event::ToEvent`: A base event to emit. Any properties captured by the macro will be appended to the base event. If this control parameter is specified then `module`, `props`, and `extent` cannot also be set.
 - `module: impl Into<emit::Path>`: The module the event belongs to. If unspecified the current module path is used.
 - `props: impl emit::Props`: A base set of properties to add to the event.
 - `extent: impl emit::ToExtent`: The extent to use on the event. If it resolves to `None` then the clock on the runtime will be used to assign a point extent.

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -6,7 +6,7 @@ use syn::{
 
 use crate::{
     args::{self, Arg},
-    event::push_event_props,
+    event::push_evt_props,
     module::module_tokens,
     props::Props,
     template::{self, Template},
@@ -88,7 +88,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
         template.ok_or_else(|| syn::Error::new(span, "missing template string literal"))?;
 
     let mut evt_props = Props::new();
-    push_event_props(&mut evt_props, opts.level)?;
+    push_evt_props(&mut evt_props, opts.level)?;
 
     let span_guard = args
         .guard

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -14,7 +14,7 @@ use emit::{well_known::METRIC_AGG_COUNT, Clock};
 let sample = sample_bytes_written();
 
 emit::emit!(
-    event: emit::Metric::new(
+    evt: emit::Metric::new(
         emit::module!(),
         emit::Empty,
         "bytes_written",
@@ -88,7 +88,7 @@ The following metric reports the current number of bytes written as 591:
 use emit::{Clock, well_known::METRIC_AGG_COUNT};
 
 emit::emit!(
-    event: emit::Metric::new(
+    evt: emit::Metric::new(
         emit::module!(),
         emit::Empty,
         "bytes_written",
@@ -131,7 +131,7 @@ let now = emit::clock().now();
 let last_sample = now.map(|now| now - std::time::Duration::from_secs(30));
 
 emit::emit!(
-    event: emit::Metric::new(
+    evt: emit::Metric::new(
         emit::module!(),
         last_sample..now,
         "bytes_written",
@@ -174,7 +174,7 @@ let now = emit::clock().now();
 let last_sample = now.map(|now| now - std::time::Duration::from_secs(15));
 
 emit::emit!(
-    event: emit::Metric::new(
+    evt: emit::Metric::new(
         emit::module!(),
         last_sample..now,
         "bytes_written",

--- a/src/span.rs
+++ b/src/span.rs
@@ -80,7 +80,7 @@ emit::SpanCtxt::current(emit::ctxt())
         // This is especially important for futures, otherwise the span may
         // complete before the future does
         emit::emit!(
-            event: emit::Span::new(
+            evt: emit::Span::new(
                 emit::module!(),
                 timer,
                 "wait a bit",
@@ -389,7 +389,7 @@ fn wait_a_bit(sleep_ms: u64) {
     if sleep_ms > 500 {
         span.complete_with(|span| {
             emit::warn!(
-                event: span,
+                evt: span,
                 when: emit::filter::always(),
                 "wait a bit took too long",
             );


### PR DESCRIPTION
This cleans up the default template formatting so it looks like a valid `format_args!` by default. I've also renamed the `event` control parameter to `evt`, to better fit the compact naming scheme of other parameters.