### PR TITLE
Clean up emit_opentelemetry API and add troubleshooting docs

### DIFF
--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -260,8 +260,8 @@ impl<'a> serde::Serialize for Path<'a> {
 
 #[cfg(feature = "alloc")]
 mod alloc_support {
-    use alloc::{borrow::Cow, boxed::Box, string::String};
     use super::*;
+    use alloc::{borrow::Cow, boxed::Box, string::String};
 
     impl Path<'static> {
         /**


### PR DESCRIPTION
The `emit_opentelemetry` docs were mostly just wrong so I've updated them and removed any lingering API artifacts from its old approach.