### PR TITLE
Test filters on kinds and levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ optional = true
 [dev-dependencies.serde]
 version = "1"
 features = ["derive"]
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["full"]

--- a/core/src/extent.rs
+++ b/core/src/extent.rs
@@ -230,4 +230,16 @@ mod tests {
 
         assert_eq!(Some(Duration::from_secs(0)), ts.len());
     }
+
+    #[test]
+    fn span_backwards() {
+        let ts = Extent::span(Timestamp::MAX..Timestamp::MIN);
+
+        assert!(!ts.is_point());
+        assert!(ts.is_span());
+
+        assert_eq!(&Timestamp::MAX, ts.as_point());
+
+        assert!(ts.len().is_none());
+    }
 }

--- a/core/src/extent.rs
+++ b/core/src/extent.rs
@@ -238,7 +238,7 @@ mod tests {
         assert!(!ts.is_point());
         assert!(ts.is_span());
 
-        assert_eq!(&Timestamp::MAX, ts.as_point());
+        assert_eq!(&Timestamp::MIN, ts.as_point());
 
         assert!(ts.len().is_none());
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -422,7 +422,7 @@ impl ToValue for (dyn std::error::Error + 'static) {
 mod alloc_support {
     use super::*;
 
-    use alloc::{borrow::Cow, vec::Vec};
+    use alloc::{borrow::Cow, string::String, vec::Vec};
 
     impl<'v> Value<'v> {
         /**
@@ -515,6 +515,18 @@ mod alloc_support {
     impl serde::Serialize for OwnedValue {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
             self.0.serialize(serializer)
+        }
+    }
+
+    impl<'a> From<&'a String> for Value<'a> {
+        fn from(value: &'a String) -> Self {
+            Value(value.into())
+        }
+    }
+
+    impl<'a> From<Option<&'a String>> for Value<'a> {
+        fn from(value: Option<&'a String>) -> Self {
+            Value(value_bag::ValueBag::from_option(value))
         }
     }
 

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -123,6 +123,7 @@ A [`Filter`] that matches events with a specific [`Kind`].
 
 The kind to match is pulled from the [`KEY_EVENT_KIND`] well-known property. Events that don't carry any kind are not matched.
 */
+#[derive(Debug)]
 pub struct KindFilter(Kind);
 
 impl KindFilter {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -203,7 +203,7 @@ mod tests {
             assert_eq!(case, value.cast::<Kind>().unwrap());
 
             let formatted = case.to_string();
-            let value = Value::from(&formatted);
+            let value = Value::from(&*formatted);
 
             assert_eq!(case, value.cast::<Kind>().unwrap());
         }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -89,6 +89,8 @@ impl FromStr for Kind {
     type Err = ParseKindError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
         if s.eq_ignore_ascii_case(EVENT_KIND_SPAN) {
             return Ok(Kind::Span);
         }
@@ -153,5 +155,82 @@ pub fn is_metric_filter() -> KindFilter {
 impl Filter for KindFilter {
     fn matches<E: ToEvent>(&self, evt: E) -> bool {
         evt.to_event().props().pull::<Kind, _>(KEY_EVENT_KIND) == Some(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        for (case, expected) in [
+            ("span", Ok::<Kind, ParseKindError>(Kind::Span)),
+            ("metric", Ok(Kind::Metric)),
+            ("spanx", Err(ParseKindError {})),
+            ("sp", Err(ParseKindError {})),
+            ("met", Err(ParseKindError {})),
+            ("", Err(ParseKindError {})),
+            ("span span", Err(ParseKindError {})),
+        ] {
+            match expected {
+                Ok(expected) => {
+                    assert_eq!(expected, Kind::from_str(case).unwrap());
+                    assert_eq!(expected, Kind::from_str(&case.to_uppercase()).unwrap());
+                    assert_eq!(expected, Kind::from_str(&format!(" {case} ")).unwrap());
+                }
+                Err(expected) => assert_eq!(
+                    expected.to_string(),
+                    Kind::from_str(case).unwrap_err().to_string()
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        for case in [Kind::Span, Kind::Metric] {
+            assert_eq!(case, Kind::from_str(&case.to_string()).unwrap());
+        }
+    }
+
+    #[test]
+    fn to_from_value() {
+        for case in [Kind::Span, Kind::Metric] {
+            let value = case.to_value();
+
+            assert_eq!(case, value.cast::<Kind>().unwrap());
+
+            let formatted = case.to_string();
+            let value = Value::from(&formatted);
+
+            assert_eq!(case, value.cast::<Kind>().unwrap());
+        }
+    }
+
+    #[test]
+    fn kind_filter() {
+        let filter = KindFilter::new(Kind::Span);
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_EVENT_KIND, EVENT_KIND_SPAN),
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_EVENT_KIND, EVENT_KIND_METRIC),
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            crate::Empty,
+        )));
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -97,6 +97,8 @@ impl FromStr for Level {
     type Err = ParseLevelError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
         let lvl = s.as_bytes();
 
         match lvl.get(0) {
@@ -231,8 +233,8 @@ mod alloc_support {
     use super::*;
 
     use alloc::vec::Vec;
-
     use emit_core::path::Path;
+    use emit_core::str::Str;
 
     /**
     Construct a set of [`MinLevelFilter`]s that are applied based on the module of an event.
@@ -251,8 +253,12 @@ mod alloc_support {
     Event modules are matched based on [`Path::is_child_of`]. If an event's module is a child of one in the map then its [`MinLevelFilter`] will be checked against it. If an event's module doesn't match any in the map then it will pass the filter.
     */
     pub struct MinLevelPathMap {
-        // TODO: Ensure more specific paths apply ahead of less specific ones
-        paths: Vec<(Path<'static>, MinLevelFilter)>,
+        root: PathNode,
+    }
+
+    struct PathNode {
+        min_level: Option<MinLevelFilter>,
+        children: Vec<(Str<'static>, PathNode)>,
     }
 
     impl MinLevelPathMap {
@@ -260,7 +266,12 @@ mod alloc_support {
         Create an empty map.
         */
         pub const fn new() -> Self {
-            MinLevelPathMap { paths: Vec::new() }
+            MinLevelPathMap {
+                root: PathNode {
+                    min_level: None,
+                    children: Vec::new(),
+                },
+            }
         }
 
         /**
@@ -273,14 +284,31 @@ mod alloc_support {
         ) {
             let path = path.into();
 
-            match self.paths.binary_search_by_key(&&path, |(path, _)| path) {
-                Ok(index) => {
-                    self.paths[index] = (path, min_level.into());
-                }
-                Err(index) => {
-                    self.paths.insert(index, (path, min_level.into()));
-                }
+            let mut node = &mut self.root;
+            for segment in path.segments() {
+                node = match node
+                    .children
+                    .binary_search_by_key(&segment, |(key, _)| key.by_ref())
+                {
+                    Ok(idx) => &mut node.children[idx].1,
+                    Err(idx) => {
+                        node.children.insert(
+                            idx,
+                            (
+                                segment.to_owned(),
+                                PathNode {
+                                    min_level: None,
+                                    children: Vec::new(),
+                                },
+                            ),
+                        );
+
+                        &mut node.children[idx].1
+                    }
+                };
             }
+
+            node.min_level = Some(min_level.into());
         }
     }
 
@@ -288,17 +316,23 @@ mod alloc_support {
         fn matches<E: ToEvent>(&self, evt: E) -> bool {
             let evt = evt.to_event();
 
-            let evt_path = evt.module();
+            let path = evt.module();
 
-            if let Ok(index) = self.paths.binary_search_by_key(&evt_path, |(path, _)| path) {
-                self.paths[index].1.matches(evt)
+            let mut node = &self.root;
+            for segment in path.segments() {
+                let Ok(idx) = node
+                    .children
+                    .binary_search_by_key(&segment, |(key, _)| key.by_ref())
+                else {
+                    break;
+                };
+
+                node = &node.children[idx].1;
+            }
+
+            if let Some(ref filter) = node.min_level {
+                filter.matches(evt)
             } else {
-                for (path, min_level) in &self.paths {
-                    if evt_path.is_child_of(path) {
-                        return min_level.matches(evt);
-                    }
-                }
-
                 true
             }
         }
@@ -317,6 +351,58 @@ mod alloc_support {
             map
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn min_level_specificity() {
+            let mut filter = MinLevelPathMap::new();
+
+            filter.min_level(Path::new_unchecked("a"), Level::Error);
+            filter.min_level(Path::new_unchecked("a::b"), Level::Warn);
+
+            // Unspecified path
+            assert!(filter.matches(crate::Event::new(
+                Path::new_unchecked("b"),
+                crate::Empty,
+                crate::Template::literal("test"),
+                (KEY_LVL, Level::Debug),
+            )));
+
+            // Exact path
+            assert!(!filter.matches(crate::Event::new(
+                Path::new_unchecked("a"),
+                crate::Empty,
+                crate::Template::literal("test"),
+                (KEY_LVL, Level::Warn),
+            )));
+
+            assert!(filter.matches(crate::Event::new(
+                Path::new_unchecked("a"),
+                crate::Empty,
+                crate::Template::literal("test"),
+                (KEY_LVL, Level::Error),
+            )));
+
+            // Child path
+            assert!(!filter.matches(crate::Event::new(
+                Path::new_unchecked("a::c"),
+                crate::Empty,
+                crate::Template::literal("test"),
+                (KEY_LVL, Level::Warn),
+            )));
+
+            // Child path (override)
+            assert!(filter.matches(crate::Event::new(
+                Path::new_unchecked("a::b"),
+                crate::Empty,
+                crate::Template::literal("test"),
+                (KEY_LVL, Level::Warn),
+            )));
+        }
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -327,7 +413,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn level_roundtrip() {
+    fn parse() {
+        for (case, expected) in [
+            ("d", Ok(Level::Debug)),
+            ("dbg", Ok(Level::Debug)),
+            ("debug", Ok::<Level, ParseLevelError>(Level::Debug)),
+            ("i", Ok(Level::Info)),
+            ("inf", Ok(Level::Info)),
+            ("info", Ok(Level::Info)),
+            ("information", Ok(Level::Info)),
+            ("w", Ok(Level::Warn)),
+            ("wrn", Ok(Level::Warn)),
+            ("warn", Ok(Level::Warn)),
+            ("warning", Ok(Level::Warn)),
+            ("e", Ok(Level::Error)),
+            ("err", Ok(Level::Error)),
+            ("error", Ok(Level::Error)),
+            ("", Err(ParseLevelError {})),
+            ("ifo", Err(ParseLevelError {})),
+            ("trace", Err(ParseLevelError {})),
+            ("erroneous", Err(ParseLevelError {})),
+            ("info info", Err(ParseLevelError {})),
+        ] {
+            match expected {
+                Ok(expected) => {
+                    assert_eq!(expected, Level::from_str(case).unwrap());
+                    assert_eq!(expected, Level::from_str(&case.to_uppercase()).unwrap());
+                    assert_eq!(expected, Level::from_str(&format!(" {case} ")).unwrap());
+                }
+                Err(expected) => assert_eq!(
+                    expected.to_string(),
+                    Level::from_str(case).unwrap_err().to_string()
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
         for lvl in [Level::Info, Level::Debug, Level::Warn, Level::Error] {
             let fmt = lvl.to_string();
 
@@ -335,5 +458,99 @@ mod tests {
 
             assert_eq!(lvl, parsed, "{}", fmt);
         }
+    }
+
+    #[test]
+    fn to_from_value() {
+        for case in [Level::Debug, Level::Info, Level::Warn, Level::Error] {
+            let value = case.to_value();
+
+            assert_eq!(case, value.cast::<Level>().unwrap());
+
+            let formatted = case.to_string();
+            let value = Value::from(&formatted);
+
+            assert_eq!(case, value.cast::<Level>().unwrap());
+        }
+    }
+
+    #[test]
+    fn min_level_filter() {
+        let filter = MinLevelFilter::new(Level::Warn);
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_ERROR),
+        )));
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_WARN),
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            crate::Empty,
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_DEBUG),
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_INFO),
+        )));
+    }
+
+    #[test]
+    fn min_level_filter_with_default() {
+        let filter = MinLevelFilter::new(Level::Info).treat_unleveled_as(Level::Info);
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_ERROR),
+        )));
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_WARN),
+        )));
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_INFO),
+        )));
+
+        assert!(filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            crate::Empty,
+        )));
+
+        assert!(!filter.matches(crate::Event::new(
+            crate::Path::new_unchecked("test"),
+            crate::Empty,
+            crate::Template::literal("test"),
+            (KEY_LVL, LVL_DEBUG),
+        )));
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -536,7 +536,7 @@ mod tests {
             assert_eq!(case, value.cast::<Level>().unwrap());
 
             let formatted = case.to_string();
-            let value = Value::from(&formatted);
+            let value = Value::from(&*formatted);
 
             assert_eq!(case, value.cast::<Level>().unwrap());
         }

--- a/src/span.rs
+++ b/src/span.rs
@@ -1247,7 +1247,10 @@ impl<'a, C: Clock, P: Props, F: FnOnce(Span<'a, P>)> SpanGuard<'a, C, P, F> {
 mod tests {
     use super::*;
 
-    use std::{cell::Cell, time::Duration};
+    use std::time::Duration;
+
+    #[cfg(all(feature = "std", feature = "rand"))]
+    use std::cell::Cell;
 
     use crate::Timestamp;
 
@@ -1528,8 +1531,10 @@ mod tests {
         }
     }
 
+    #[cfg(all(feature = "std", feature = "rand"))]
     struct MyClock(Cell<u64>);
 
+    #[cfg(all(feature = "std", feature = "rand"))]
     impl Clock for MyClock {
         fn now(&self) -> Option<crate::Timestamp> {
             let ts = crate::Timestamp::from_unix(Duration::from_secs(self.0.get()));


### PR DESCRIPTION
This PR continues adding tests for functionality, this time around the `Kind` and `Level` types and their various filters. I found some issues with the existing `MinLevelPathMap` type so have reworked it.