### PR TITLE
Add a test project for OTLP emitter throughput

### DIFF
--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Install otelcol
         run: sudo dpkg -i ./otelcol.deb
 
-      - name: Test
+      - name: Integration Test
         working-directory: ./emitter/otlp/test/integration
         run: cargo run
+
+      - name: Throughput Test
+        working-directory: ./emitter/otlp/test/throughput
+        run: cargo run --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "emitter/otlp",
     "emitter/otlp/gen",
     "emitter/otlp/test/integration",
+    "emitter/otlp/test/throughput",
     "emitter/opentelemetry",
     "macros",
     "examples/common_patterns",

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -184,7 +184,7 @@ impl OtlpBuilder {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
 
-                let (sender, receiver) = emit_batcher::bounded(1024);
+                let (sender, receiver) = emit_batcher::bounded(10_000);
 
                 (Some((encoder, sender)), Some((transport, receiver)))
             }
@@ -196,7 +196,7 @@ impl OtlpBuilder {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
 
-                let (sender, receiver) = emit_batcher::bounded(1024);
+                let (sender, receiver) = emit_batcher::bounded(10_000);
 
                 (Some((encoder, sender)), Some((transport, receiver)))
             }
@@ -208,7 +208,7 @@ impl OtlpBuilder {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
 
-                let (sender, receiver) = emit_batcher::bounded(1024);
+                let (sender, receiver) = emit_batcher::bounded(10_000);
 
                 (Some((encoder, sender)), Some((transport, receiver)))
             }

--- a/emitter/otlp/test/throughput/Cargo.toml
+++ b/emitter/otlp/test/throughput/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "emit_otlp_test_throughput"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[dependencies.emit]
+path = "../../../../"
+
+[dependencies.emit_otlp]
+path = "../../"
+
+[dependencies.emit_term]
+path = "../../../term"

--- a/emitter/otlp/test/throughput/config.yaml
+++ b/emitter/otlp/test/throughput/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:44319"
+
+exporters:
+  debug:
+    verbosity: basic
+    sampling_initial: 1
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/emitter/otlp/test/throughput/src/main.rs
+++ b/emitter/otlp/test/throughput/src/main.rs
@@ -1,0 +1,79 @@
+/*!
+A throughput test for emitting events via OTLP.
+
+This project doesn't prove much except what the on-thread cost of event serialization is like.
+*/
+
+use emit::Emitter;
+
+use std::{
+    process::{Child, Command},
+    time::Duration,
+};
+
+fn main() {
+    let mut reporter = emit::metric::Reporter::new();
+
+    // Set up `emit_otlp`
+    let rt = emit::setup()
+        .emit_to({
+            let emitter = emit_otlp::new()
+                .logs(emit_otlp::logs_grpc_proto("http://localhost:44319"))
+                .spawn()
+                .unwrap();
+
+            reporter.add_source(emitter.metric_source());
+
+            emitter
+        })
+        .init();
+
+    // Spawn a collector
+    let otelcol = OtelCol::spawn();
+
+    // Emit our events
+    let count = 10_000;
+    let start = emit::now!().unwrap();
+
+    for i in 0..count {
+        emit::info!("test event {i}");
+    }
+
+    rt.blocking_flush(Duration::from_secs(30));
+
+    let end = emit::now!().unwrap();
+
+    // Write the results
+    let per_event = (end - start).as_nanos() as f64 / count as f64;
+
+    let stdout = emit_term::stdout();
+
+    stdout.emit(&emit::evt!(
+        extent: start..end,
+        "emitted {count} events ({per_event}ns per event)",
+        evt_kind: "span",
+    ));
+
+    reporter.emit_metrics(&stdout);
+
+    drop(otelcol);
+}
+
+struct OtelCol(Child);
+
+impl Drop for OtelCol {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+impl OtelCol {
+    fn spawn() -> Self {
+        OtelCol(
+            Command::new("otelcol")
+                .args(["--config", "./config.yaml"])
+                .spawn()
+                .unwrap(),
+        )
+    }
+}

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -930,19 +930,33 @@ mod alloc_support {
 
             self
         }
-    }
 
-    impl Source for Reporter {
-        fn sample_metrics<S: sampler::Sampler>(&self, sampler: S) {
+        /**
+        Produce a current sample for all metrics.
+        */
+        pub fn sample_metrics<S: sampler::Sampler>(&self, sampler: S) {
             for source in &self.0 {
                 source.sample_metrics(&sampler);
             }
         }
 
-        fn emit_metrics<E: Emitter>(&self, emitter: E) {
+        /**
+        Produce a current sample for all metrics, emitting them as diagnostic events to the given [`Emitter`].
+        */
+        pub fn emit_metrics<E: Emitter>(&self, emitter: E) {
             for source in &self.0 {
                 source.emit_metrics(&emitter);
             }
+        }
+    }
+
+    impl Source for Reporter {
+        fn sample_metrics<S: sampler::Sampler>(&self, sampler: S) {
+            self.sample_metrics(sampler)
+        }
+
+        fn emit_metrics<E: Emitter>(&self, emitter: E) {
+            self.emit_metrics(emitter)
         }
     }
 


### PR DESCRIPTION
This PR adds another integration-like test for the OTLP emitter. This one writes 10,000 events as quickly as possible through the collector and emits some stats about how it went. It should give us a reasonable basis to investigate optimization opportunities from in the future.