### PR TITLE
Allow batcher to block on a full queue instead of truncating

### DIFF
--- a/batcher/src/internal_metrics.rs
+++ b/batcher/src/internal_metrics.rs
@@ -47,7 +47,8 @@ impl Counter {
 }
 
 metrics!(InternalMetrics {
-    queue_overflow: Counter,
+    queue_full_truncated: Counter,
+    queue_full_blocked: Counter,
     queue_batch_processed: Counter,
     queue_batch_failed: Counter,
     queue_batch_panicked: Counter,

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -3,11 +3,60 @@ Run channels on regular OS threads.
 */
 
 use std::{
-    sync::{Arc, Condvar, Mutex},
+    future::{self, Future},
+    pin::pin,
+    sync::{Arc, Condvar, Mutex, OnceLock},
+    task, thread,
     time::{Duration, Instant},
 };
 
-use crate::{BatchError, Channel, Sender};
+use crate::{BatchError, Channel, Receiver, Sender};
+
+/**
+Run the receiver synchronously.
+
+This method spawns a background thread and runs [`Receiver::exec`] on it. The handle will join when the [`Sender`] is dropped.
+*/
+pub fn spawn<T: Channel + Send + 'static>(
+    receiver: Receiver<T>,
+    mut on_batch: impl FnMut(T) -> Result<(), BatchError<T>> + Send + 'static,
+) -> thread::JoinHandle<()>
+where
+    T::Item: Send + 'static,
+{
+    static WAKER: OnceLock<Arc<NeverWake>> = OnceLock::new();
+
+    // A waker that does nothing; the tasks it runs are fully
+    // synchronous so there's never any notifications to issue
+    struct NeverWake;
+
+    impl task::Wake for NeverWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    thread::spawn(move || {
+        // The future is polled to completion here, so we can pin
+        // it directly on the stack
+        let mut fut = pin!(receiver.exec(
+            |delay| future::ready(thread::sleep(delay)),
+            move |batch| future::ready(on_batch(batch)),
+        ));
+
+        // Get a context for our synchronous task
+        let waker = WAKER.get_or_init(|| Arc::new(NeverWake)).clone().into();
+        let mut cx = task::Context::from_waker(&waker);
+
+        // Drive the task to completion; it should complete in one go,
+        // but may eagerly return as soon as it hits an await point, so
+        // just to be sure we continuously poll it
+        loop {
+            match fut.as_mut().poll(&mut cx) {
+                task::Poll::Ready(r) => return r,
+                task::Poll::Pending => continue,
+            }
+        }
+    })
+}
 
 /**
 Wait for a channel running on a regular OS thread to process all items active at the point this call was made.
@@ -31,8 +80,8 @@ Wait for a channel to send a message, blocking if the channel is at capacity.
 */
 pub fn blocking_send<T: Channel>(
     sender: &Sender<T>,
-    timeout: Duration,
     msg: T::Item,
+    timeout: Duration,
 ) -> Result<(), BatchError<T::Item>> {
     crate::blocking_send(sender, timeout, msg, |timeout| {
         let notifier = Trigger::new();
@@ -100,5 +149,112 @@ impl Trigger {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Receiver;
+
+    use std::{sync::mpsc, thread};
+
+    enum SenderCommand<T> {
+        Send(T),
+        BlockingSend(T, Duration),
+        BlockingFlush(Duration),
+        Stop,
+    }
+
+    enum ReciverCommand<T> {
+        ProcessBatch(Box<dyn FnOnce(Vec<T>) -> Result<(), BatchError<Vec<T>>> + Send>),
+    }
+
+    fn spawn_sender<T: Send + 'static>(
+        sender: Sender<Vec<T>>,
+    ) -> (mpsc::Sender<SenderCommand<T>>, thread::JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel();
+
+        let handle = thread::spawn(move || loop {
+            match rx.recv().unwrap() {
+                SenderCommand::Send(msg) => {
+                    sender.send(msg);
+                }
+                SenderCommand::BlockingSend(msg, timeout) => {
+                    blocking_send(&sender, msg, timeout);
+                }
+                SenderCommand::BlockingFlush(timeout) => {
+                    todo!()
+                }
+                SenderCommand::Stop => return,
+            }
+        });
+
+        (tx, handle)
+    }
+
+    fn spawn_receiver<T: Send + 'static>(
+        receiver: Receiver<Vec<T>>,
+    ) -> mpsc::Sender<ReciverCommand<T>> {
+        let (tx, rx) = mpsc::channel();
+
+        spawn(receiver, move |batch| match rx.recv().unwrap() {
+            ReciverCommand::ProcessBatch(p) => p(batch),
+        });
+
+        tx
+    }
+
+    #[test]
+    fn send_recv() {
+        todo!()
+    }
+
+    #[test]
+    fn recv_panic() {
+        todo!()
+    }
+
+    #[test]
+    fn send_full_capacity() {
+        todo!()
+    }
+
+    #[test]
+    fn blocking_send_recv() {
+        todo!()
+    }
+
+    #[test]
+    fn blocking_send_full_capacity() {
+        todo!()
+    }
+
+    #[test]
+    fn blocking_send_full_capacity_timeout() {
+        todo!()
+    }
+
+    #[test]
+    fn flush_empty() {
+        todo!()
+    }
+
+    #[test]
+    fn flush_active_batch_non_empty_next() {
+        // Flush while a batch is active; should wait for the next batch too
+        todo!()
+    }
+
+    #[test]
+    fn flush_active_batch_empty_next() {
+        // Flush while a batch is active; should not wait for the next batch too
+        todo!()
+    }
+
+    #[test]
+    fn flush_timeout() {
+        todo!()
     }
 }

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -418,17 +418,18 @@ mod tests {
             let handle = s.spawn(|| blocking_flush(&sender, Duration::from_secs(1)));
 
             // Process both batches
-            receiver
-                .send(ReceiverCommand::process_batch(|_| Ok(())))
-                .unwrap();
-            receiver
-                .send(ReceiverCommand::process_batch(|_| Ok(())))
-                .unwrap();
+            for _ in 0..2 {
+                receiver
+                    .send(ReceiverCommand::process_batch(|_| Ok(())))
+                    .unwrap();
+                receiver
+                    .send(ReceiverCommand::process_batch(|_| Ok(())))
+                    .unwrap();
+            }
 
             // Wait for the flush to complete
             handle.join().unwrap();
 
-            assert!(!sender.shared.state.lock().unwrap().is_in_batch);
             assert_eq!(
                 0,
                 sender.shared.state.lock().unwrap().next_batch.channel.len()

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -57,51 +57,82 @@ If the current thread is a `tokio` thread then this call will be executed using 
 */
 pub fn blocking_flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
     tokio::task::block_in_place(|| {
-        let (notifier, mut notified) = tokio::sync::oneshot::channel();
+        let (notifier, notified) = tokio::sync::oneshot::channel();
 
-        sender.on_next_flush(move || {
+        sender.when_flushed(move || {
             let _ = notifier.send(());
         });
 
-        // If there's nothing to flush then return immediately
-        if notified.try_recv().is_ok() {
-            return true;
-        }
-
-        match tokio::runtime::Handle::try_current() {
-            // If we're on a `tokio` thread then await the receiver
-            Ok(handle) => handle.block_on(async {
-                match tokio::time::timeout(timeout, notified).await {
-                    // The notifier was triggered
-                    Ok(Ok(())) => true,
-                    // Unexpected hangup; this should mean the channel was closed
-                    Ok(Err(_)) => true,
-                    // The timeout was reached instead
-                    Err(_) => false,
-                }
-            }),
-            // If we're not on a `tokio` thread then wait for
-            // a notification
-            Err(_) => {
-                let now = Instant::now();
-                let mut wait = Duration::from_micros(1);
-                let max_wait_step = cmp::max(timeout / 3, Duration::from_micros(1));
-
-                while now.elapsed() < timeout {
-                    if notified.try_recv().is_ok() {
-                        return true;
-                    }
-
-                    // Apply some exponential backoff to avoid spinning
-                    // Chances are if data isn't flushed immediately that
-                    // it'll be waiting on some network or file IO and could
-                    // be a while
-                    std::thread::sleep(wait);
-                    wait += cmp::min(wait * 2, max_wait_step);
-                }
-
-                false
-            }
-        }
+        wait(notified, timeout)
     })
+}
+
+/**
+Wait for a channel to send a message, blocking if the channel is at capacity.
+*/
+pub fn blocking_send<T: Channel>(
+    sender: &Sender<T>,
+    timeout: Duration,
+    msg: T::Item,
+) -> Result<(), BatchError<T::Item>> {
+    crate::blocking_send(sender, timeout, msg, |timeout| {
+        tokio::task::block_in_place(|| {
+            let (notifier, notified) = tokio::sync::oneshot::channel();
+
+            sender.when_empty(move || {
+                let _ = notifier.send(());
+            });
+
+            wait(notified, timeout);
+        });
+    })
+}
+
+fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duration) -> bool {
+    // If the trigger has already fired then return immediately
+    if notified.try_recv().is_ok() {
+        return true;
+    }
+
+    // If the timeout is 0 then return immediately
+    // The trigger hasn't already fired so there's no point waiting for it
+    if timeout == Duration::ZERO {
+        return false;
+    }
+
+    match tokio::runtime::Handle::try_current() {
+        // If we're on a `tokio` thread then await the receiver
+        Ok(handle) => handle.block_on(async {
+            match tokio::time::timeout(timeout, notified).await {
+                // The notifier was triggered
+                Ok(Ok(())) => true,
+                // Unexpected hangup; this should mean the channel was closed
+                Ok(Err(_)) => true,
+                // The timeout was reached instead
+                Err(_) => false,
+            }
+        }),
+        // If we're not on a `tokio` thread then wait for
+        // a notification
+        Err(_) => {
+            let now = Instant::now();
+            let mut wait = Duration::from_micros(1);
+            let max_wait_step = cmp::max(timeout / 3, Duration::from_micros(1));
+
+            while now.elapsed() < timeout {
+                if notified.try_recv().is_ok() {
+                    return true;
+                }
+
+                // Apply some exponential backoff to avoid spinning
+                // Chances are if we're not called immediately that
+                // it'll be waiting on some network or file IO and could
+                // be a while
+                std::thread::sleep(wait);
+                wait += cmp::min(wait * 2, max_wait_step);
+            }
+
+            false
+        }
+    }
 }

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -43,8 +43,7 @@ pub fn spawn<
                     .enable_all()
                     .build()
                     .unwrap()
-                    .block_on(receive)
-                    .unwrap();
+                    .block_on(receive);
             });
         }
     }
@@ -72,8 +71,8 @@ Wait for a channel to send a message, blocking if the channel is at capacity.
 */
 pub fn blocking_send<T: Channel>(
     sender: &Sender<T>,
-    timeout: Duration,
     msg: T::Item,
+    timeout: Duration,
 ) -> Result<(), BatchError<T::Item>> {
     crate::blocking_send(sender, timeout, msg, |timeout| {
         tokio::task::block_in_place(|| {

--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -403,9 +403,7 @@ impl FileSetBuilder {
 
         let (sender, receiver) = emit_batcher::bounded(10_000);
 
-        let handle = thread::spawn(move || {
-            let _ = receiver.blocking_exec(|batch| worker.on_batch(batch));
-        });
+        let handle = emit_batcher::sync::spawn(receiver, move |batch| worker.on_batch(batch));
 
         Ok(FileSet {
             sender,

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -216,15 +216,8 @@ impl OtlpBuilder {
         };
 
         let receive = async move {
-            let processors = FuturesUnordered::<
-                Pin<
-                    Box<
-                        dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>>
-                            + Send
-                            + 'static,
-                    >,
-                >,
-            >::new();
+            let processors =
+                FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
 
             if let Some((transport, receiver)) = process_otlp_logs {
                 let transport = Arc::new(transport);

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -75,50 +75,7 @@ Once the builder is configured, call [`OtlpBuilder::spawn`] and pass the resulti
 
 # Where the background worker is spawned
 
-The [`Otlp`] emitter doesn't do any work directly. That's all handled by a background worker created through [`OtlpBuilder::spawn`]. Where [`OtlpBuilder::spawn`] actually spawns that background worker depends on where it's called.
-
-If [`OtlpBuilder::spawn`] is called within a `tokio` runtime, then the worker will spawn into that runtime:
-
-```
-// This will spawn in the active tokio runtime because of #[tokio::main]
-
-#[tokio::main]
-async fn main() {
-    let rt = emit::setup()
-        .emit_to(emit_otlp::new()
-            .resource(emit::props! {
-                #[emit::key("service.name")]
-                service_name: emit::pkg!(),
-            })
-            .logs(emit_otlp::logs_grpc_proto("http://localhost:4319"))
-            .spawn()
-            .unwrap())
-        .init();
-
-    rt.blocking_flush(std::time::Duration::from_secs(30));
-}
-```
-
-If [`OtlpBuilder::spawn`] is called outside a `tokio` runtime, then the worker will spawn on a background thread with a single-threaded executor on it:
-
-```
-// This will spawn on a background thread because there's no active tokio runtime
-
-fn main() {
-    let rt = emit::setup()
-        .emit_to(emit_otlp::new()
-            .resource(emit::props! {
-                #[emit::key("service.name")]
-                service_name: emit::pkg!(),
-            })
-            .logs(emit_otlp::logs_grpc_proto("http://localhost:4319"))
-            .spawn()
-            .unwrap())
-        .init();
-
-    rt.blocking_flush(std::time::Duration::from_secs(30));
-}
-```
+The [`Otlp`] emitter doesn't do any work directly. That's all handled by a background worker created through [`OtlpBuilder::spawn`]. The worker will spawn on a background thread with a single-threaded `tokio` executor on it.
 
 ## Configuring for gRPC+protobuf
 


### PR DESCRIPTION
Closes #68 

The default background batching implementation will truncate all unprocessed events if it fills up. This is to prevent logging from blocking up the works, and based on the assumption that newer events are more important than older ones.

This isn't suitable for using the batcher for auditing or proxying use-cases so this PR introduces a function that emitters can use to block waiting for the current batch to be flushed if it's full instead of truncating. If this times out instead of adding the event then it's returned to the caller, who can then discard it or issue a destructive non-blocking send instead.