### PR TITLE
Add async variants of blocking tokio functions

### DIFF
--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -20,3 +20,7 @@ default-features = false
 version = "1"
 features = ["rt-multi-thread", "sync", "time"]
 optional = true
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["full"]

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -2,13 +2,9 @@
 Run channels in a `tokio` runtime.
 */
 
-use std::{
-    cmp,
-    future::Future,
-    time::{Duration, Instant},
-};
+use std::{future::Future, time::Duration};
 
-use crate::{BatchError, Channel, Receiver, Sender};
+use crate::{sync, BatchError, Channel, Receiver, Sender};
 
 /**
 Spawn a worker to run the [`Receiver`] on a `tokio` runtime.
@@ -55,15 +51,27 @@ Wait for a channel potentially running on a `tokio` thread to process all items 
 If the current thread is a `tokio` thread then this call will be executed using [`tokio::task::block_in_place`] to avoid starving other work.
 */
 pub fn blocking_flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
-    tokio::task::block_in_place(|| {
-        let (notifier, notified) = tokio::sync::oneshot::channel();
+    match tokio::runtime::Handle::try_current() {
+        // If we're on a `tokio` thread then await
+        Ok(handle) => handle.block_on(flush(sender, timeout)),
+        // If we're not on a `tokio` thread then run a regular blocking variant
+        Err(_) => sync::blocking_flush(sender, timeout),
+    }
+}
 
-        sender.when_flushed(move || {
-            let _ = notifier.send(());
-        });
+/**
+Wait for a channel potentially running on a `tokio` thread to process all items active at the point this call was made.
 
-        wait(notified, timeout)
-    })
+This function is an asynchronous variant of [`blocking_send`].
+*/
+pub async fn flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
+    let (notifier, notified) = tokio::sync::oneshot::channel();
+
+    sender.when_flushed(move || {
+        let _ = notifier.send(());
+    });
+
+    wait(notified, timeout).await
 }
 
 /**
@@ -74,20 +82,38 @@ pub fn blocking_send<T: Channel>(
     msg: T::Item,
     timeout: Duration,
 ) -> Result<(), BatchError<T::Item>> {
-    crate::blocking_send(sender, timeout, msg, |timeout| {
-        tokio::task::block_in_place(|| {
+    match tokio::runtime::Handle::try_current() {
+        // If we're on a `tokio` thread then await
+        Ok(handle) => handle.block_on(send(sender, msg, timeout)),
+        // If we're not on a `tokio` thread then run a regular blocking variant
+        Err(_) => sync::blocking_send(sender, msg, timeout),
+    }
+}
+
+/**
+Wait for a channel to send a message, blocking if the channel is at capacity.
+
+This function is an asynchronous variant of [`blocking_send`].
+*/
+pub async fn send<T: Channel>(
+    sender: &Sender<T>,
+    msg: T::Item,
+    timeout: Duration,
+) -> Result<(), BatchError<T::Item>> {
+    sender
+        .send_or_wait(msg, timeout, |sender, timeout| async move {
             let (notifier, notified) = tokio::sync::oneshot::channel();
 
             sender.when_empty(move || {
                 let _ = notifier.send(());
             });
 
-            wait(notified, timeout);
-        });
-    })
+            wait(notified, timeout).await;
+        })
+        .await
 }
 
-fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duration) -> bool {
+async fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duration) -> bool {
     // If the trigger has already fired then return immediately
     if notified.try_recv().is_ok() {
         return true;
@@ -99,39 +125,12 @@ fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duration) -> 
         return false;
     }
 
-    match tokio::runtime::Handle::try_current() {
-        // If we're on a `tokio` thread then await the receiver
-        Ok(handle) => handle.block_on(async {
-            match tokio::time::timeout(timeout, notified).await {
-                // The notifier was triggered
-                Ok(Ok(())) => true,
-                // Unexpected hangup; this should mean the channel was closed
-                Ok(Err(_)) => true,
-                // The timeout was reached instead
-                Err(_) => false,
-            }
-        }),
-        // If we're not on a `tokio` thread then wait for
-        // a notification
-        Err(_) => {
-            let now = Instant::now();
-            let mut wait = Duration::from_micros(1);
-            let max_wait_step = cmp::max(timeout / 3, Duration::from_micros(1));
-
-            while now.elapsed() < timeout {
-                if notified.try_recv().is_ok() {
-                    return true;
-                }
-
-                // Apply some exponential backoff to avoid spinning
-                // Chances are if we're not called immediately that
-                // it'll be waiting on some network or file IO and could
-                // be a while
-                std::thread::sleep(wait);
-                wait += cmp::min(wait * 2, max_wait_step);
-            }
-
-            false
-        }
+    match tokio::time::timeout(timeout, notified).await {
+        // The notifier was triggered
+        Ok(Ok(())) => true,
+        // Unexpected hangup; this should mean the channel was closed
+        Ok(Err(_)) => true,
+        // The timeout was reached instead
+        Err(_) => false,
     }
 }


### PR DESCRIPTION
This PR continues to clean up `emit_batcher`, by making `tokio` versions async, with blocking variants using those, or the blocking variants in `sync`.