### PR TITLE
Emitter wrapping

### DIFF
--- a/core/src/filter.rs
+++ b/core/src/filter.rs
@@ -51,16 +51,6 @@ pub trait Filter {
     {
         Or::new(self, other)
     }
-
-    /**
-    Wrap an [`Emitter`], only emitting events if they pass the filter.
-    */
-    fn wrap_emitter<E>(self, emitter: E) -> FilteredEmitter<Self, E>
-    where
-        Self: Sized,
-    {
-        FilteredEmitter::new(self, emitter)
-    }
 }
 
 impl<'a, F: Filter + ?Sized> Filter for &'a F {
@@ -162,15 +152,6 @@ impl<F: Filter, E: Emitter> Emitter for FilteredEmitter<F, E> {
     fn blocking_flush(&self, timeout: Duration) -> bool {
         self.emitter.blocking_flush(timeout)
     }
-}
-
-/**
-Wrap an [`Emitter`] in a [`Filter`].
-
-Only events that pass [`Filter::matches`] will be emitted through [`Emitter::emit`].
-*/
-pub fn wrap<F: Filter, E: Emitter>(filter: F, emitter: E) -> FilteredEmitter<F, E> {
-    filter.wrap_emitter(emitter)
 }
 
 impl<T: Filter, U: Filter> Filter for And<T, U> {

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -284,12 +284,15 @@ pub(crate) fn stream_field<'sval, S: sval::Stream<'sval> + ?Sized>(
 pub(crate) fn stream_attributes<'sval>(
     stream: &mut (impl sval::Stream<'sval> + ?Sized),
     props: &'sval impl emit::props::Props,
-    mut for_each: impl FnMut(&emit::str::Str, &emit::value::Value) -> bool,
+    mut for_each: impl FnMut(
+        emit::str::Str<'sval>,
+        emit::value::Value<'sval>,
+    ) -> Option<(emit::str::Str<'sval>, emit::value::Value<'sval>)>,
 ) -> sval::Result {
     stream.seq_begin(None)?;
 
     props.dedup().for_each(|k, v| {
-        if !for_each(&k, &v) {
+        if let Some((k, v)) = for_each(k, v) {
             stream
                 .seq_value_begin()
                 .map(|_| ControlFlow::Continue(()))

--- a/emitter/otlp/src/data/logs/log_record.rs
+++ b/emitter/otlp/src/data/logs/log_record.rs
@@ -98,23 +98,24 @@ impl<
                 stream_attributes(stream, &self.0, |k, v| match k.get() {
                     emit::well_known::KEY_LVL => {
                         level = v.by_ref().cast::<emit::Level>().unwrap_or_default();
-                        true
+                        None
                     }
                     emit::well_known::KEY_SPAN_ID => {
                         span_id = v
                             .by_ref()
                             .cast::<emit::span::SpanId>()
                             .map(|span_id| SP::from(span_id));
-                        true
+                        None
                     }
                     emit::well_known::KEY_TRACE_ID => {
                         trace_id = v
                             .by_ref()
                             .cast::<emit::span::TraceId>()
                             .map(|trace_id| TR::from(trace_id));
-                        true
+                        None
                     }
-                    _ => false,
+                    emit::well_known::KEY_ERR => Some((emit::Str::new("exception.message"), v)),
+                    _ => Some((k, v)),
                 })
             },
         )?;

--- a/emitter/otlp/src/data/resource.rs
+++ b/emitter/otlp/src/data/resource.rs
@@ -29,7 +29,7 @@ impl<P: emit::props::Props> sval::Value for PropsResourceAttributes<P> {
             &mut *stream,
             &RESOURCE_ATTRIBUTES_LABEL,
             &RESOURCE_ATTRIBUTES_INDEX,
-            |stream| stream_attributes(stream, &self.0, |_, _| false),
+            |stream| stream_attributes(stream, &self.0, |k, v| Some((k, v))),
         )?;
 
         stream.record_tuple_end(None, None, None)

--- a/emitter/otlp/src/data/traces/span.rs
+++ b/emitter/otlp/src/data/traces/span.rs
@@ -120,38 +120,38 @@ impl<
             &SPAN_ATTRIBUTES_INDEX,
             |stream| {
                 stream_attributes(stream, &self.props, |k, v| match k.get() {
-                    emit::well_known::KEY_EVT_KIND => true,
-                    emit::well_known::KEY_SPAN_NAME => true,
+                    emit::well_known::KEY_EVT_KIND => None,
+                    emit::well_known::KEY_SPAN_NAME => None,
                     emit::well_known::KEY_LVL => {
                         level = v.by_ref().cast().unwrap_or_default();
-                        true
+                        None
                     }
                     emit::well_known::KEY_SPAN_ID => {
                         span_id = v
                             .by_ref()
                             .cast::<emit::span::SpanId>()
                             .map(|span_id| SP::from(span_id));
-                        true
+                        None
                     }
                     emit::well_known::KEY_SPAN_PARENT => {
                         parent_span_id = v
                             .by_ref()
                             .cast::<emit::span::SpanId>()
                             .map(|parent_span_id| SP::from(parent_span_id));
-                        true
+                        None
                     }
                     emit::well_known::KEY_TRACE_ID => {
                         trace_id = v
                             .by_ref()
                             .cast::<emit::span::TraceId>()
                             .map(|trace_id| TR::from(trace_id));
-                        true
+                        None
                     }
                     emit::well_known::KEY_ERR => {
                         has_err = true;
-                        true
+                        None
                     }
-                    _ => false,
+                    _ => Some((k, v)),
                 })
             },
         )?;
@@ -286,7 +286,7 @@ impl<P: emit::props::Props> sval::Value for PropsEventAttributes<P> {
             &mut *stream,
             &EVENT_ATTRIBUTES_LABEL,
             &EVENT_ATTRIBUTES_INDEX,
-            |stream| stream_attributes(stream, &self.0, |_, _| false),
+            |stream| stream_attributes(stream, &self.0, |k, v| Some((k, v))),
         )?;
 
         stream.record_tuple_end(None, None, None)

--- a/examples/common_patterns/filter_per_emitter.rs
+++ b/examples/common_patterns/filter_per_emitter.rs
@@ -7,9 +7,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This is different from the global filter you set in `setup.emit_when`,
     // which is applied to all emitted events, but can be bypassed.
     let rt = emit::setup()
-        .emit_to(emit::filter::wrap(
-            emit::level::min_filter(emit::Level::Warn),
+        .emit_to(emit::emitter::wrap(
             emit_term::stdout(),
+            emit::emitter::wrapping::from_filter(emit::level::min_filter(emit::Level::Warn)),
         ))
         .and_emit_to(emit_file::set("./target/logs/filter_per_emitter.log").spawn()?)
         .init();


### PR DESCRIPTION
This PR generalizes the pattern we were using for wrapping emitters in filters with a new wrapping API. It lets you wrap emitters in middleware that can transform and filter along the way.