### PR TITLE
Update openetelemetry crates to 0.24

### DIFF
--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -40,7 +40,7 @@ jobs:
         run: rustup default nightly
 
       - name: Install certutil
-        run: apt-get update && apt-get install -y libnss3-tools
+        run: sudo apt-get update && sudo apt-get install -y libnss3-tools
 
       - name: Get otelcol
         run: wget -O otelcol.deb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.107.0/otelcol_0.107.0_linux_amd64.deb

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default nightly
 
+      - name: Install certutil
+        run: apt-get update && apt-get install -y libnss3-tools
+
       - name: Get otelcol
         run: wget -O otelcol.deb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.107.0/otelcol_0.107.0_linux_amd64.deb
 

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Configure mkcert
         working-directory: ./emitter/otlp/test/integration
-        run: ./mkcert -install && ./mkcert 127.0.0.1 localhost && ls
+        run: ./mkcert -install && ./mkcert 127.0.0.1 localhost
 
       - name: Integration Test
         working-directory: ./emitter/otlp/test/integration

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install otelcol
         run: sudo dpkg -i ./otelcol.deb
 
+      - name: Get mkcert
+        working-directory: ./emitter/otlp/test/integration
+        run: wget -O mkcert https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 && chmod +x mkcert
+
+      - name: Configure mkcert
+        working-directory: ./emitter/otlp/test/integration
+        run: mkcert -install && mkcert 127.0.0.1 localhost && ls
+
       - name: Integration Test
         working-directory: ./emitter/otlp/test/integration
         run: cargo run

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Configure mkcert
         working-directory: ./emitter/otlp/test/integration
-        run: mkcert -install && mkcert 127.0.0.1 localhost && ls
+        run: ./mkcert -install && ./mkcert 127.0.0.1 localhost && ls
 
       - name: Integration Test
         working-directory: ./emitter/otlp/test/integration

--- a/emitter/opentelemetry/Cargo.toml
+++ b/emitter/opentelemetry/Cargo.toml
@@ -32,6 +32,10 @@ version = "0.11.0-alpha.13"
 path = "../../"
 features = ["implicit_rt"]
 
+[dev-dependencies.opentelemetry_sdk]
+version = "0.24"
+features = ["logs", "trace", "testing"]
+
 [dev-dependencies.opentelemetry-stdout]
 version = "0.5"
 features = ["logs", "trace"]

--- a/emitter/opentelemetry/Cargo.toml
+++ b/emitter/opentelemetry/Cargo.toml
@@ -31,3 +31,7 @@ version = "1"
 version = "0.11.0-alpha.13"
 path = "../../"
 features = ["implicit_rt"]
+
+[dev-dependencies.opentelemetry-stdout]
+version = "0.5"
+features = ["logs", "trace"]

--- a/emitter/opentelemetry/Cargo.toml
+++ b/emitter/opentelemetry/Cargo.toml
@@ -17,11 +17,11 @@ features = ["std", "serde", "implicit_internal_rt"]
 default-features = false
 
 [dependencies.opentelemetry_sdk]
-version = "0.22"
+version = "0.24"
 features = ["logs", "trace"]
 
 [dependencies.opentelemetry]
-version = "0.22"
+version = "0.24"
 features = ["logs", "trace"]
 
 [dependencies.serde]

--- a/emitter/opentelemetry/src/lib.rs
+++ b/emitter/opentelemetry/src/lib.rs
@@ -1206,3 +1206,48 @@ mod any_value {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_log() {
+        todo!()
+    }
+
+    #[test]
+    fn emit_span() {
+        todo!()
+    }
+
+    #[test]
+    fn emit_span_direct() {
+        todo!()
+    }
+
+    #[test]
+    fn otel_span_emit_span() {
+        todo!()
+    }
+
+    #[test]
+    fn emit_span_otel_span() {
+        todo!()
+    }
+
+    #[test]
+    fn otel_span_emit_log() {
+        todo!()
+    }
+
+    #[test]
+    fn emit_span_otel_log() {
+        todo!()
+    }
+
+    #[test]
+    fn emit_value_to_otel_attribute() {
+        todo!()
+    }
+}

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -67,7 +67,7 @@ default-features = false
 features = ["ring"]
 
 [dependencies.rustls-native-certs]
-version = "0.7"
+version = "0.8"
 optional = true
 
 [dependencies.flate2]

--- a/emitter/otlp/test/integration/Cargo.toml
+++ b/emitter/otlp/test/integration/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 [dependencies.emit]
 path = "../../../../"
 
+[dependencies.emit_term]
+path = "../../../term"
+
 [dependencies.emit_otlp]
 path = "../../"
 

--- a/emitter/otlp/test/integration/config.tls.yaml
+++ b/emitter/otlp/test/integration/config.tls.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:44319"
+        tls:
+          cert_file: 127.0.0.1+1.pem
+          key_file: 127.0.0.1+1-key.pem
+      http:
+        endpoint: "localhost:44318"
+        tls:
+          cert_file: 127.0.0.1+1.pem
+          key_file: 127.0.0.1+1-key.pem
+
+exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 1
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -79,9 +79,9 @@ fn main() {
                     #[emit::key("service.name")]
                     service_name: emit::pkg!(),
                 })
-                .logs(emit_otlp::logs_grpc_proto("https://localhost:44319"))
-                .traces(emit_otlp::traces_grpc_proto("https://localhost:44319"))
-                .metrics(emit_otlp::metrics_grpc_proto("https://localhost:44319"))
+                .logs(emit_otlp::logs_grpc_proto("http://localhost:44319"))
+                .traces(emit_otlp::traces_grpc_proto("http://localhost:44319"))
+                .metrics(emit_otlp::metrics_grpc_proto("http://localhost:44319"))
                 .spawn()
                 .unwrap(),
         );
@@ -94,12 +94,12 @@ fn main() {
                     #[emit::key("service.name")]
                     service_name: emit::pkg!(),
                 })
-                .logs(emit_otlp::logs_http_proto("https://localhost:44318/v1/logs"))
+                .logs(emit_otlp::logs_http_proto("http://localhost:44318/v1/logs"))
                 .traces(emit_otlp::traces_http_proto(
-                    "https://localhost:44318/v1/traces",
+                    "http://localhost:44318/v1/traces",
                 ))
                 .metrics(emit_otlp::metrics_http_proto(
-                    "https://localhost:44318/v1/metrics",
+                    "http://localhost:44318/v1/metrics",
                 ))
                 .spawn()
                 .unwrap(),

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -143,7 +143,7 @@ impl OtelCol {
     fn spawn(config: &str) -> Self {
         OtelCol(
             Command::new("otelcol")
-                .args(["--config", "./{config}.yaml"])
+                .args(["--config", &format!("./{config}.yaml")])
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())
                 .spawn()

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -10,6 +10,8 @@ use std::{
 };
 
 fn main() {
+    let _ = emit::setup().emit_to(emit_term::stdout()).init_internal();
+    
     // So ambient methods for generating ids and timestamps will work
     let _ = emit::setup().init();
 

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -79,9 +79,9 @@ fn main() {
                     #[emit::key("service.name")]
                     service_name: emit::pkg!(),
                 })
-                .logs(emit_otlp::logs_grpc_proto("http://localhost:44319"))
-                .traces(emit_otlp::traces_grpc_proto("http://localhost:44319"))
-                .metrics(emit_otlp::metrics_grpc_proto("http://localhost:44319"))
+                .logs(emit_otlp::logs_grpc_proto("https://localhost:44319"))
+                .traces(emit_otlp::traces_grpc_proto("https://localhost:44319"))
+                .metrics(emit_otlp::metrics_grpc_proto("https://localhost:44319"))
                 .spawn()
                 .unwrap(),
         );
@@ -94,18 +94,22 @@ fn main() {
                     #[emit::key("service.name")]
                     service_name: emit::pkg!(),
                 })
-                .logs(emit_otlp::logs_http_proto("http://localhost:44318/v1/logs"))
+                .logs(emit_otlp::logs_http_proto(
+                    "https://localhost:44318/v1/logs",
+                ))
                 .traces(emit_otlp::traces_http_proto(
-                    "http://localhost:44318/v1/traces",
+                    "https://localhost:44318/v1/traces",
                 ))
                 .metrics(emit_otlp::metrics_http_proto(
-                    "http://localhost:44318/v1/metrics",
+                    "https://localhost:44318/v1/metrics",
                 ))
                 .spawn()
                 .unwrap(),
         );
     } else {
-        emit::warn!("not running TLS tests because the local certificate file {cert_path} doesn't exist");
+        emit::warn!(
+            "not running TLS tests because the local certificate file {cert_path} doesn't exist"
+        );
     }
 }
 

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -6,12 +6,13 @@ use emit::Emitter;
 
 use std::{
     io::Read,
+    path::Path,
     process::{Child, Command, Stdio},
 };
 
 fn main() {
     let _ = emit::setup().emit_to(emit_term::stdout()).init_internal();
-    
+
     // So ambient methods for generating ids and timestamps will work
     let _ = emit::setup().init();
 

--- a/examples/opentelemetry/via_sdk/Cargo.toml
+++ b/examples/opentelemetry/via_sdk/Cargo.toml
@@ -12,19 +12,19 @@ path = "../../../"
 path = "../../../emitter/opentelemetry"
 
 [dependencies.opentelemetry_sdk]
-version = "0.22"
+version = "0.24"
 features = ["rt-tokio", "trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.22"
+version = "0.24"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry-otlp]
-version = "0.15"
+version = "0.17"
 features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
 
 [dependencies.tonic]
-version = "0.11"
+version = "0.12"
 
 [dependencies.tokio]
 version = "1"

--- a/examples/opentelemetry/via_sdk/src/main.rs
+++ b/examples/opentelemetry/via_sdk/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
         .await
         .unwrap();
 
-    opentelemetry_otlp::new_pipeline()
+    let tracer_provider = opentelemetry_otlp::new_pipeline()
         .tracing()
         .with_exporter(
             opentelemetry_otlp::new_exporter()
@@ -39,7 +39,7 @@ async fn main() {
         .install_batch(opentelemetry_sdk::runtime::Tokio)
         .unwrap();
 
-    opentelemetry_otlp::new_pipeline()
+    let logger_provider = opentelemetry_otlp::new_pipeline()
         .logging()
         .with_exporter(
             opentelemetry_otlp::new_exporter()
@@ -50,10 +50,10 @@ async fn main() {
         .unwrap();
 
     // Configure `emit` to point to `opentelemetry`
-    let _ = emit_opentelemetry::setup().init();
+    let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
 
     run();
 
-    opentelemetry::global::shutdown_logger_provider();
-    opentelemetry::global::shutdown_tracer_provider();
+    let _ = logger_provider.shutdown();
+    let _ = tracer_provider.shutdown();
 }

--- a/examples/opentelemetry/via_sdk/src/main.rs
+++ b/examples/opentelemetry/via_sdk/src/main.rs
@@ -1,6 +1,6 @@
 // Emit a span
-#[emit::span("Running")]
-fn run() {
+#[emit::span("Running emit")]
+fn run_emit() {
     let mut counter = 1;
 
     for _ in 0..100 {
@@ -19,6 +19,21 @@ fn run() {
         counter,
         emit::Empty,
     ));
+}
+
+fn run_opentelemetry<T: opentelemetry::trace::TracerProvider>(tracer_provider: T)
+where
+    <T::Tracer as opentelemetry::trace::Tracer>::Span: Send + Sync + 'static,
+{
+    use opentelemetry::trace::Tracer;
+
+    tracer_provider
+        .tracer("run_opentelemetry")
+        .in_span("Running OTel", |_| {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+
+            run_emit();
+        })
 }
 
 #[tokio::main]
@@ -52,8 +67,10 @@ async fn main() {
     // Configure `emit` to point to `opentelemetry`
     let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
 
-    run();
+    // Run our example program
+    run_opentelemetry(tracer_provider.clone());
 
+    // Shutdown the SDK
     let _ = logger_provider.shutdown();
     let _ = tracer_provider.shutdown();
 }

--- a/macros/src/emit.rs
+++ b/macros/src/emit.rs
@@ -3,7 +3,7 @@ use syn::{parse::Parse, spanned::Spanned, FieldValue};
 
 use crate::{
     args::{self, Arg},
-    props::{push_evt_props, check_evt_props},
+    props::{check_evt_props, push_evt_props},
     template,
     util::{ToOptionTokens, ToRefTokens},
 };

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -6,7 +6,7 @@ use syn::{
 
 use crate::{
     args::{self, Arg},
-    props::{Props, check_evt_props, push_evt_props},
+    props::{check_evt_props, push_evt_props, Props},
     template::{self, Template},
     util::{ToOptionTokens, ToRefTokens},
 };


### PR DESCRIPTION
This PR updates `emit_openetelemetry` to the current versions of the `opentelemetry` crates. While I'm doing this I'll fill in tests for this side of the project.