### PR TITLE
Tweak the term format a touch to include some module info

### DIFF
--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -724,3 +724,11 @@ pub mod sync;
 
 #[cfg(feature = "tokio")]
 pub mod tokio;
+
+// Re-export an appropriate implementation of blocking functions based on crate features
+
+#[cfg(feature = "tokio")]
+pub use tokio::{blocking_flush, blocking_send};
+
+#[cfg(not(feature = "tokio"))]
+pub use sync::{blocking_flush, blocking_send};

--- a/core/src/emitter.rs
+++ b/core/src/emitter.rs
@@ -221,7 +221,7 @@ impl<E: Emitter, W: wrapping::Wrapping> Emitter for Wrap<E, W> {
 }
 
 /**
-Wrap the [`Emitter`] in a [`Wrapping`], transforming or filtering [`Event`]s before it receives them.
+Wrap an [`Emitter`] in a [`Wrapping`], transforming or filtering [`Event`]s before it receives them.
 
 Flushing defers to the wrapped emitter.
 */
@@ -232,6 +232,8 @@ pub fn wrap<E: Emitter, W: wrapping::Wrapping>(emitter: E, wrapping: W) -> Wrap<
 pub mod wrapping {
     /*!
     The [`Wrapping`] type.
+
+    This module defines a middleware API for [`Emitter`]s. An [`Emitter`] can be wrapped through [`Emitter::wrap_emitter`] in a [`Wrapping`] that can manipulate an [`Event`] before forwarding it to the wrapped emitter.
     */
 
     use super::*;

--- a/core/src/timestamp.rs
+++ b/core/src/timestamp.rs
@@ -119,7 +119,7 @@ impl Timestamp {
     /**
     Try parse a timestamp from an RFC3339 formatted representation.
     */
-    pub fn from_str(ts: &str) -> Result<Self, ParseTimestampError> {
+    pub fn try_from_str(ts: &str) -> Result<Self, ParseTimestampError> {
         ts.parse()
     }
 

--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -503,7 +503,7 @@ impl emit::Emitter for FileSetInner {
     }
 
     fn blocking_flush(&self, timeout: std::time::Duration) -> bool {
-        emit_batcher::sync::blocking_flush(&self.sender, timeout)
+        emit_batcher::blocking_flush(&self.sender, timeout)
     }
 }
 

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -636,22 +636,19 @@ impl emit::Emitter for OtlpInner {
         let start = Instant::now();
 
         if let Some((_, ref sender)) = self.otlp_logs {
-            if !emit_batcher::tokio::blocking_flush(sender, timeout.saturating_sub(start.elapsed()))
-            {
+            if !emit_batcher::blocking_flush(sender, timeout.saturating_sub(start.elapsed())) {
                 return false;
             }
         }
 
         if let Some((_, ref sender)) = self.otlp_traces {
-            if !emit_batcher::tokio::blocking_flush(sender, timeout.saturating_sub(start.elapsed()))
-            {
+            if !emit_batcher::blocking_flush(sender, timeout.saturating_sub(start.elapsed())) {
                 return false;
             }
         }
 
         if let Some((_, ref sender)) = self.otlp_metrics {
-            if !emit_batcher::tokio::blocking_flush(sender, timeout.saturating_sub(start.elapsed()))
-            {
+            if !emit_batcher::blocking_flush(sender, timeout.saturating_sub(start.elapsed())) {
                 return false;
             }
         }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -55,6 +55,15 @@ pub enum Kind {
     Metric,
 }
 
+impl Kind {
+    /**
+    Try parse a kind from a formatted representation.
+    */
+    pub fn try_from_str(s: &str) -> Result<Self, ParseKindError> {
+        s.parse()
+    }
+}
+
 impl fmt::Debug for Kind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"{}\"", self)

--- a/src/level.rs
+++ b/src/level.rs
@@ -70,6 +70,15 @@ pub enum Level {
     Error,
 }
 
+impl Level {
+    /**
+    Try parse a level from a formatted representation.
+    */
+    pub fn try_from_str(s: &str) -> Result<Self, ParseLevelError> {
+        s.parse()
+    }
+}
+
 impl Default for Level {
     fn default() -> Self {
         Level::Info


### PR DESCRIPTION
This PR includes some module info in the terminal output to make it a bit easier to tell what components are generating what logs.