### PR TITLE
Prepare for 0.11.0-alpha.14 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [package]
 name = "emit"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -42,11 +42,11 @@ implicit_rt = ["emit_core/implicit_rt", "emit_macros/implicit_rt"]
 implicit_internal_rt = ["emit_core/implicit_internal_rt"]
 
 [dependencies.emit_macros]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "macros"
 
 [dependencies.emit_core]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "core"
 default-features = false
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![all](https://github.com/emit-rs/emit/actions/workflows/all.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/all.yml)
 
-[Current docs](https://docs.rs/emit/0.11.0-alpha.13/emit/index.html)
+[Current docs](https://docs.rs/emit/0.11.0-alpha.14/emit/index.html)
 
 ## Developer-first diagnostics
 
@@ -18,10 +18,10 @@
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 
 [dependencies.emit_term]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 ```rust
@@ -56,13 +56,13 @@ This is alpha-level software. It implements a complete framework but has almost 
 
 ## Getting started
 
-See the `examples` directory and [`emit` documentation](https://docs.rs/emit/0.11.0-alpha.13/emit/index.html) to get started with `emit`.
+See the `examples` directory and [`emit` documentation](https://docs.rs/emit/0.11.0-alpha.14/emit/index.html) to get started with `emit`.
 
 ## Where can I send my diagnostics?
 
 Diagnostics produced by `emit` are sent to an _emitter_. This repository currently implements the following emitters:
 
-- [`emit_term`](https://docs.rs/emit_term/0.11.0-alpha.13/emit_term/index.html) for writing human-readable output to the console.
-- [`emit_file`](https://docs.rs/emit_file/0.11.0-alpha.13/emit_file/index.html) for writing JSON or another machine-readable format to rolling files.
-- [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.13/emit_otlp/index.html) for sending diagnostics to an OpenTelemetry compatible collector.
-- [`emit_opentelemetry`](https://docs.rs/emit_opentelemetry/0.11.0-alpha.13/emit_opentelemetry/index.html) for integrating `emit` into an application using the OpenTelemetry SDK for its diagnostics.
+- [`emit_term`](https://docs.rs/emit_term/0.11.0-alpha.14/emit_term/index.html) for writing human-readable output to the console.
+- [`emit_file`](https://docs.rs/emit_file/0.11.0-alpha.14/emit_file/index.html) for writing JSON or another machine-readable format to rolling files.
+- [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.14/emit_otlp/index.html) for sending diagnostics to an OpenTelemetry compatible collector.
+- [`emit_opentelemetry`](https://docs.rs/emit_opentelemetry/0.11.0-alpha.14/emit_opentelemetry/index.html) for integrating `emit` into an application using the OpenTelemetry SDK for its diagnostics.

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_batcher"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -12,7 +12,7 @@ edition = "2021"
 features = ["tokio"]
 
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../"
 default-features = false
 

--- a/batcher/README.md
+++ b/batcher/README.md
@@ -2,6 +2,6 @@
 
 [![batcher](https://github.com/emit-rs/emit/actions/workflows/batcher.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/batcher.yml)
 
-[Current docs](https://docs.rs/emit_batcher/0.11.0-alpha.13/emit_batcher/index.html)
+[Current docs](https://docs.rs/emit_batcher/0.11.0-alpha.14/emit_batcher/index.html)
 
 Infrastructure for emitting diagnostic events in the background.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_core"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/emitter/file/Cargo.toml
+++ b/emitter/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_file"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -18,7 +18,7 @@ default = ["default_writer"]
 default_writer = ["emit/sval", "sval_json"]
 
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 default-features = false
 features = ["std", "implicit_internal_rt"]
@@ -32,10 +32,10 @@ features = ["std"]
 optional = true
 
 [dependencies.emit_batcher]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../batcher"
 
 [dev-dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["implicit_rt"]

--- a/emitter/file/README.md
+++ b/emitter/file/README.md
@@ -2,6 +2,6 @@
 
 [![file](https://github.com/emit-rs/emit/actions/workflows/file.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/file.yml)
 
-[Current docs](https://docs.rs/emit_file/0.11.0-alpha.13/emit_file/index.html)
+[Current docs](https://docs.rs/emit_file/0.11.0-alpha.14/emit_file/index.html)
 
 Emit diagnostic events to rolling files.

--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -15,10 +15,10 @@ Add `emit` and `emit_file` to your `Cargo.toml`:
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 
 [dependencies.emit_file]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 Initialize `emit` using a rolling file set:

--- a/emitter/opentelemetry/Cargo.toml
+++ b/emitter/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_opentelemetry"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -11,7 +11,7 @@ categories = ["development-tools::debugging"]
 edition = "2021"
 
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["std", "serde", "implicit_internal_rt"]
 default-features = false
@@ -28,7 +28,7 @@ features = ["logs", "trace"]
 version = "1"
 
 [dev-dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["implicit_rt"]
 

--- a/emitter/opentelemetry/README.md
+++ b/emitter/opentelemetry/README.md
@@ -2,7 +2,7 @@
 
 [![opentelemetry](https://github.com/emit-rs/emit/actions/workflows/opentelemetry.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/opentelemetry.yml)
 
-[Current docs](https://docs.rs/emit_opentelemetry/0.11.0-alpha.13/emit_opentelemetry/index.html)
+[Current docs](https://docs.rs/emit_opentelemetry/0.11.0-alpha.14/emit_opentelemetry/index.html)
 
 Integrate `emit` with the OpenTelemetry SDK.
 

--- a/emitter/opentelemetry/src/lib.rs
+++ b/emitter/opentelemetry/src/lib.rs
@@ -1,7 +1,7 @@
 /*!
 Integrate `emit` with the OpenTelemetry SDK.
 
-This library forwards diagnostic events from emit through the OpenTelemetry SDK as log records and spans. This library is for applications that already use the OpenTelemetry SDK. It's also intended for applications that need to unify multiple instrumentation libraries, like `emit`, `log`, and `tracing`, into a shared pipeline. If you'd just like to send `emit` diagnostics via OTLP to the OpenTelemetry Collector or other compatible service, then consider [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.13/emit_otlp/index.html).
+This library forwards diagnostic events from emit through the OpenTelemetry SDK as log records and spans. This library is for applications that already use the OpenTelemetry SDK. It's also intended for applications that need to unify multiple instrumentation libraries, like `emit`, `log`, and `tracing`, into a shared pipeline. If you'd just like to send `emit` diagnostics via OTLP to the OpenTelemetry Collector or other compatible service, then consider [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.14/emit_otlp/index.html).
 
 # Getting started
 
@@ -9,10 +9,10 @@ Configure OpenTelemetry as per its documentation, then add `emit` and `emit_open
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 
 [dependencies.emit_opentelemetry]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 Initialize `emit` to send diagnostics to the OpenTelemetry SDK using [`setup`]:

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_otlp"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -16,13 +16,13 @@ gzip = ["flate2"]
 tls = ["tokio-rustls", "rustls-native-certs"]
 
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["std", "sval", "implicit_internal_rt"]
 default-features = false
 
 [dependencies.emit_batcher]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../batcher"
 features = ["tokio"]
 
@@ -91,6 +91,6 @@ version = "1"
 features = ["full"]
 
 [dev-dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["implicit_rt"]

--- a/emitter/otlp/README.md
+++ b/emitter/otlp/README.md
@@ -2,7 +2,7 @@
 
 [![otlp](https://github.com/emit-rs/emit/actions/workflows/otlp.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/otlp.yml)
 
-[Current docs](https://docs.rs/emit_otlp/0.11.0-alpha.13/emit_otlp/index.html)
+[Current docs](https://docs.rs/emit_otlp/0.11.0-alpha.14/emit_otlp/index.html)
 
 Emit diagnostic events via the OpenTelemetry Protocol (OTLP).
 

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -1,7 +1,7 @@
 /*!
 Emit diagnostic events via the OpenTelemetry Protocol (OTLP).
 
-This library provides [`Otlp`], an [`emit::Emitter`] that sends export requests directly to some remote OTLP receiver. If you need to integrate [`emit`] with the OpenTelemetry SDK, see [`emit-opentelemetry`](https://docs.rs/emit_opentelemetry/0.11.0-alpha.13/emit_opentelemetry/index.html).
+This library provides [`Otlp`], an [`emit::Emitter`] that sends export requests directly to some remote OTLP receiver. If you need to integrate [`emit`] with the OpenTelemetry SDK, see [`emit-opentelemetry`](https://docs.rs/emit_opentelemetry/0.11.0-alpha.14/emit_opentelemetry/index.html).
 
 # How it works
 
@@ -36,10 +36,10 @@ Add `emit` and `emit_otlp` to your `Cargo.toml`:
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 
 [dependencies.emit_otlp]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 Initialize `emit` at the start of your `main.rs` using an OTLP emitter:

--- a/emitter/term/Cargo.toml
+++ b/emitter/term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_term"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -11,7 +11,7 @@ categories = ["development-tools::debugging"]
 edition = "2021"
 
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 default-features = false
 features = ["std", "sval"]
@@ -30,6 +30,6 @@ features = ["local-offset"]
 version = "1"
 
 [dev-dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../../"
 features = ["implicit_rt"]

--- a/emitter/term/README.md
+++ b/emitter/term/README.md
@@ -2,7 +2,7 @@
 
 [![term](https://github.com/emit-rs/emit/actions/workflows/term.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/term.yml)
 
-[Current docs](https://docs.rs/emit_term/0.11.0-alpha.13/emit_term/index.html)
+[Current docs](https://docs.rs/emit_term/0.11.0-alpha.14/emit_term/index.html)
 
 Emit diagnostic events to the console.
 

--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -9,10 +9,10 @@ Add `emit` and `emit_term` to your `Cargo.toml`:
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 
 [dependencies.emit_term]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 Initialize `emit` using `emit_term`:

--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_example_common_patterns"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 edition = "2021"
 publish = false

--- a/examples/opentelemetry/direct_otlp/Cargo.toml
+++ b/examples/opentelemetry/direct_otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_exmaple_opentelemetry_direct_otlp"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 edition = "2021"
 publish = false

--- a/examples/opentelemetry/via_sdk/Cargo.toml
+++ b/examples/opentelemetry/via_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_example_opentelemetry_via_sdk"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 edition = "2021"
 publish = false

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_macros"
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -34,7 +34,7 @@ version = "2"
 features = ["full", "extra-traits", "visit-mut"]
 
 [dependencies.emit_core]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 path = "../core"
 
 [dependencies.fv-template]

--- a/macros/README.md
+++ b/macros/README.md
@@ -2,7 +2,7 @@
 
 [![macros](https://github.com/emit-rs/emit/actions/workflows/macros.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/macros.yml)
 
-[Current docs](https://docs.rs/emit_macros/0.11.0-alpha.13/emit_macros/index.html)
+[Current docs](https://docs.rs/emit_macros/0.11.0-alpha.14/emit_macros/index.html)
 
 Implementation details for `emit!` macros.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ To get started, add `emit` to your `Cargo.toml`:
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 ```
 
 ## Configuring an emitter
@@ -34,9 +34,9 @@ fn main() {
 
 In real applications, you'll want to use a more sophisticated emitter, such as:
 
-- [`emit_term`](https://docs.rs/emit_term/0.11.0-alpha.13/emit_term/index.html): Emit diagnostics to the console.
-- [`emit_file`](https://docs.rs/emit_file/0.11.0-alpha.13/emit_file/index.html): Emit diagnostics to a set of rolling files.
-- [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.13/emit_otlp/index.html): Emit diagnostics to a remote collector via OpenTelemetry Protocol.
+- [`emit_term`](https://docs.rs/emit_term/0.11.0-alpha.14/emit_term/index.html): Emit diagnostics to the console.
+- [`emit_file`](https://docs.rs/emit_file/0.11.0-alpha.14/emit_file/index.html): Emit diagnostics to a set of rolling files.
+- [`emit_otlp`](https://docs.rs/emit_otlp/0.11.0-alpha.14/emit_otlp/index.html): Emit diagnostics to a remote collector via OpenTelemetry Protocol.
 
 For more advanced setup options, see the [`mod@setup`] module.
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,7 +7,7 @@ You can implement your own runtime, providing your own implementations of the am
 
 ```toml
 [dependencies.emit]
-version = "0.11.0-alpha.13"
+version = "0.11.0-alpha.14"
 default-features = false
 features = ["std"]
 ```


### PR DESCRIPTION
## Major changes

- `emit_file` and `emit_otlp` emitter spawning is now infallible. If spawning fails then they'll produce metrics and emit diagnostics to the internal logger.

## What's Changed
* Add some more compile fail tests by @KodrAus in https://github.com/emit-rs/emit/pull/92
* Update openetelemetry crates to 0.24 by @KodrAus in https://github.com/emit-rs/emit/pull/93
* Add tests for emit_file by @KodrAus in https://github.com/emit-rs/emit/pull/95
* Bump dependencies by @KodrAus in https://github.com/emit-rs/emit/pull/100
* Add some tests for emit_term by @KodrAus in https://github.com/emit-rs/emit/pull/101
* Some docs and cleanups by @KodrAus in https://github.com/emit-rs/emit/pull/102
* Test re-opening existing log dirs in integration test by @KodrAus in https://github.com/emit-rs/emit/pull/103
* Tweak the term format a touch to include some module info by @KodrAus in https://github.com/emit-rs/emit/pull/104