### PR TITLE
Ensure we check no-test configurations in CI

### DIFF
--- a/.github/workflows/batcher.yml
+++ b/.github/workflows/batcher.yml
@@ -22,7 +22,15 @@ jobs:
         working-directory: ./batcher
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./batcher
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./batcher
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./batcher
         run: cargo hack test --feature-powerset --lib
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -22,7 +22,15 @@ jobs:
         working-directory: ./core
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./core
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./core
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./core
         run: cargo hack test --feature-powerset --lib
 

--- a/.github/workflows/emit.yml
+++ b/.github/workflows/emit.yml
@@ -21,7 +21,13 @@ jobs:
       - name: All
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         run: cargo hack test --feature-powerset --lib
 
       - name: Minimal versions

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -29,7 +29,15 @@ jobs:
         working-directory: ./emitter/file
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./emitter/file
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./emitter/file
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./emitter/file
         run: cargo hack test --feature-powerset --lib
 

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -22,7 +22,15 @@ jobs:
         working-directory: ./emitter/opentelemetry
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./emitter/opentelemetry
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./emitter/opentelemetry
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./emitter/opentelemetry
         run: cargo hack test --feature-powerset --lib
 

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -22,7 +22,15 @@ jobs:
         working-directory: ./emitter/otlp
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./emitter/otlp
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./emitter/otlp
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./emitter/otlp
         run: cargo hack test --feature-powerset --lib
 

--- a/.github/workflows/term.yml
+++ b/.github/workflows/term.yml
@@ -22,7 +22,15 @@ jobs:
         working-directory: ./emitter/term
         run: cargo test --all-features
 
-      - name: Powerset
+      - name: Docs
+        working-directory: ./emitter/term
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./emitter/term
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
         working-directory: ./emitter/term
         run: cargo hack test --feature-powerset --lib
 

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -76,7 +76,7 @@ async fn tls_handshake(
             metrics.transport_conn_tls_failed.increment();
 
             for err in certs.errors {
-                emit::warn!("failed to load native certificate: {err}");
+                emit::warn!(rt: emit::runtime::internal(), "failed to load native certificate: {err}");
             }
         }
 


### PR DESCRIPTION
There's been a gap in our CI testing where dev dependencies are triggering features that ensure crate builds work, but regular builds are failing.