### PR TITLE
Support parsing W3C traceparent headers with sampling

### DIFF
--- a/.github/workflows/traceparent.yml
+++ b/.github/workflows/traceparent.yml
@@ -1,0 +1,39 @@
+name: traceparent
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: rustup default nightly
+
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
+      - name: All
+        working-directory: ./traceparent
+        run: cargo test --all-features
+
+      - name: Docs
+        working-directory: ./traceparent
+        run: cargo doc --all-features
+
+      - name: Build powerset
+        working-directory: ./traceparent
+        run: cargo hack build --feature-powerset --lib
+
+      - name: Test powerset
+        working-directory: ./traceparent
+        run: cargo hack test --feature-powerset --lib
+
+      - name: Minimal versions
+        working-directory: ./traceparent
+        run: cargo hack test --feature-powerset --lib -Z minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "core",
     "batcher",
+    "traceparent",
     "emitter/term",
     "emitter/file",
     "emitter/file/test/integration",
@@ -14,7 +15,7 @@ members = [
     "examples/common_patterns",
     "examples/opentelemetry/direct_otlp",
     "examples/opentelemetry/via_sdk",
-    "test/ui",
+    "test/ui", "traceparent",
 ]
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "examples/common_patterns",
     "examples/opentelemetry/direct_otlp",
     "examples/opentelemetry/via_sdk",
-    "test/ui", "traceparent",
+    "test/ui",
 ]
 
 [package]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,3 @@ fn greet(user: &str) {
 ```
 
 ![The output of running the above program](https://github.com/emit-rs/emit/blob/main/asset/emit_term.png?raw=true)
-
-## Current status
-
-This is alpha-level software. It implements a complete framework but has almost no tests and needs a lot more documentation. 

--- a/book/src/producing-events/tracing/propagating-across-services.md
+++ b/book/src/producing-events/tracing/propagating-across-services.md
@@ -13,7 +13,7 @@ When an incoming request arrives, you can push the incoming traceparent onto the
 # extern crate emit_traceparent;
 // 1. Pull the incoming traceparent
 //    If the request doesn't specify one then use an empty sampled context
-let traceparent = emit_traceparent::Traceparent::try_from_str("00-12b2fde225aebfa6758ede9cac81bf4d-23995f85b4610391-01")
+let traceparent = emit_traceparent::Traceparent::try_from_str("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
     .unwrap_or_else(|_| emit_traceparent::Traceparent::current());
 
 // 2. Push the traceparent onto the context and execute your handler within it
@@ -36,8 +36,8 @@ Event {
         "evt_kind": span,
         "span_name": "incoming request",
         "trace_id": 4bf92f3577b34da6a3ce929d0e0e4736,
-        "span_id": 1b46015559cb7b57,
-        "span_parent": 2d7fab81f9e2ed5b,
+        "span_id": d6ae3ee046c529d9,
+        "span_parent": 00f067aa0ba902b7,
     },
 }
 ```

--- a/book/src/producing-events/tracing/sampling.md
+++ b/book/src/producing-events/tracing/sampling.md
@@ -2,6 +2,87 @@
 
 Sampling is a tool to help limit the volume of ingested trace data. It's typically applied when a trace begins by making an upfront decision about whether to produce and/or emit the trace. This is usually called "head sampling" and is limited to probablistic methods. Tail sampling, or deciding whether to ingest a trace after it's completed is much harder to implement, because there's no absolute way to know when a particular trace is finished, or how long it will take.
 
-`emit` doesn't bake in any sampling concept directly, but the [`#[span]`](https://docs.rs/emit/0.11.0-alpha.18/emit/attr.span.html) macro does apply filtering before creating any span context. This can be used to implement sampling. If you're using the OpenTelemetry SDK, [`emit_opentelemetry`](https://docs.rs/emit_opentelemetry/latest/emit_opentelemetry/) will respect its sampling.
+Sampling and [propagation](./propagating-across-services.md) are tied together. If a service decides not to sample a given trace then it _must_ propagate that decision to downstream services. Otherwise you'll end up with a broken trace.
 
-When filtering spans, remember that once a span is created it _must_ be completed and emitted. Otherwise you'll end up with a broken trace where span subtrees are missing.
+## Using `emit_traceparent` for sampling
+
+[`emit_traceparent`](https://docs.rs/emit_traceparent/latest/emit_traceparent/) is a library that implements trace sampling and propagation. Using `setup_with_sampler`, you can configure `emit` with a function that's run at the start of each trace to determine whether to emit it or not. Any other diagnostics produced within an unsampled trace will be discarded along with it.
+
+This example is a simple sampler that includes one in every 10 traces:
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+# extern crate emit_traceparent;
+# use std::sync::atomic::{AtomicUsize, Ordering};
+fn main() {
+    let rt = emit_traceparent::setup_with_sampler({
+        let counter = AtomicUsize::new(0);
+
+        move |_| {
+            // Sample 1 in every 10 traces
+            counter.fetch_add(1, Ordering::Relaxed) % 10 == 0
+        }
+    })
+    .emit_to(emit_term::stdout())
+    .init();
+
+    // Your code goes here
+
+    rt.blocking_flush(std::time::Duration::from_secs(5));
+}
+```
+
+## Using the OpenTelemetry SDK for sampling
+
+If you're using the OpenTelemetry SDK, [`emit_opentelemetry`](https://docs.rs/emit_opentelemetry/latest/emit_opentelemetry/) will respect its sampling.
+
+## Manual sampling
+
+You can use `emit`'s [filters](../../filtering-events.md) to implement sampling. This example excludes all diagnostics produced outside of sampled traces, and only includes one in every 10 traces:
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+# use std::sync::atomic::{AtomicUsize, Ordering};
+use emit::{Filter, Props};
+
+fn main() {
+    let rt = emit::setup()
+        .emit_when({
+            // Only include events in sampled traces
+            let is_in_sampled_trace = emit::filter::from_fn(|evt| {
+                evt.props().get("trace_id").is_some() && evt.props().get("span_id").is_some()
+            });
+
+            // Only keep 1 in every n traces
+            let one_in_n_traces = emit::filter::from_fn({
+                let counter = AtomicUsize::new(0);
+
+                move |evt| {
+                    // If the event is not a span then include it
+                    let Some(emit::Kind::Span) = evt.props().pull::<emit::Kind, _>("evt_kind")
+                    else {
+                        return true;
+                    };
+
+                    // If the span is not the root of a new trace then include it
+                    if evt.props().get("span_parent").is_some() {
+                        return true;
+                    };
+
+                    // Keep 1 in every 10 traces
+                    counter.fetch_add(1, Ordering::Relaxed) % 10 == 0
+                }
+            });
+
+            is_in_sampled_trace.and_when(one_in_n_traces)
+        })
+        .emit_to(emit_term::stdout())
+        .init();
+
+    // Your code goes here
+
+    rt.blocking_flush(std::time::Duration::from_secs(5));
+}
+```

--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -41,6 +41,17 @@ pub trait Ctxt {
     }
 
     /**
+    Create a disabled frame.
+
+    The properties in `P` will not be made live when the frame is entered but may still be tracked by the underlying context using the returned frame. This method can be used to inform a context about properties that would have been used under some other conditions.
+    */
+    fn open_disabled<P: Props>(&self, props: P) -> Self::Frame {
+        let _ = props;
+
+        self.open_push(Empty)
+    }
+
+    /**
     Make the properties in a frame active.
 
     Once a frame is entered, it must be exited by a call to [`Ctxt::exit`] on the same thread.

--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -45,7 +45,7 @@ pub trait Ctxt {
 
     Once a frame is entered, it must be exited by a call to [`Ctxt::exit`] on the same thread.
     */
-    fn enter(&self, local: &mut Self::Frame);
+    fn enter(&self, frame: &mut Self::Frame);
 
     /**
     Access the current context.
@@ -61,7 +61,7 @@ pub trait Ctxt {
 
     Once a frame is exited, it can be entered again with a new call to [`Ctxt::enter`], potentially on another thread if [`Ctxt::Frame`] allows it.
     */
-    fn exit(&self, local: &mut Self::Frame);
+    fn exit(&self, frame: &mut Self::Frame);
 
     /**
     Close a frame, performing any shared cleanup.

--- a/core/src/emitter.rs
+++ b/core/src/emitter.rs
@@ -158,7 +158,7 @@ Create an [`Emitter`] from a function.
 
 The input function is assumed not to perform any background work that needs flushing.
 */
-pub fn from_fn<F: Fn(&Event<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
+pub const fn from_fn<F: Fn(&Event<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
     FromFn::new(f)
 }
 
@@ -281,7 +281,7 @@ pub mod wrapping {
     /**
     Create a [`Wrapping`] from a function.
     */
-    pub fn from_fn<F: Fn(&dyn ErasedEmitter, Event<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
+    pub const fn from_fn<F: Fn(&dyn ErasedEmitter, Event<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
         FromFn::new(f)
     }
 

--- a/core/src/filter.rs
+++ b/core/src/filter.rs
@@ -119,7 +119,7 @@ impl<F: Fn(&Event<&dyn ErasedProps>) -> bool> Filter for FromFn<F> {
 /**
 Create a [`Filter`] from a function.
 */
-pub fn from_fn<F: Fn(&Event<&dyn ErasedProps>) -> bool>(f: F) -> FromFn<F> {
+pub const fn from_fn<F: Fn(&Event<&dyn ErasedProps>) -> bool>(f: F) -> FromFn<F> {
     FromFn(f)
 }
 

--- a/emitter/opentelemetry/src/lib.rs
+++ b/emitter/opentelemetry/src/lib.rs
@@ -1509,10 +1509,8 @@ mod tests {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (logs, spans, _, tracer_provider) = build(&SLOT);
 
-        #[emit::span(rt: SLOT.get(), guard: span, "emit {attr}", attr: "span")]
+        #[emit::span(rt: SLOT.get(), "emit {attr}", attr: "span")]
         fn emit_span() {
-            assert!(!span.is_enabled());
-
             emit::emit!(rt: SLOT.get(), "emit event");
         }
 

--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -15,6 +15,9 @@ path = "../../emitter/term"
 [dependencies.emit_file]
 path = "../../emitter/file"
 
+[dependencies.emit_traceparent]
+path = "../../traceparent"
+
 [dependencies.thiserror]
 version = "1"
 
@@ -69,3 +72,11 @@ path = "span_manual.rs"
 [[example]]
 name = "span_trace_propagation"
 path = "span_trace_propagation.rs"
+
+[[example]]
+name = "span_trace_sampling"
+path = "span_trace_sampling.rs"
+
+[[example]]
+name = "span_trace_filtering"
+path = "span_trace_filtering.rs"

--- a/examples/common_patterns/span_trace_filtering.rs
+++ b/examples/common_patterns/span_trace_filtering.rs
@@ -1,0 +1,63 @@
+/*
+An example of how to perform trace sampling using `emit`'s filtering.
+
+Prefer the approach from `span_trace_sampling` if you need to propagate sampling
+decisions to any downstream services you call.
+*/
+
+use emit::{Filter, Props};
+
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+fn main() {
+    let rt = emit::setup()
+        .emit_when({
+            // Only include events in sampled traces
+            let is_in_sampled_trace = emit::filter::from_fn(|evt| {
+                evt.props().get("trace_id").is_some() && evt.props().get("span_id").is_some()
+            });
+
+            // Only keep 1 in every n traces
+            let one_in_n_traces = emit::filter::from_fn({
+                let counter = AtomicUsize::new(0);
+
+                move |evt| {
+                    // If the event is not a span then include it
+                    let Some(emit::Kind::Span) = evt.props().pull::<emit::Kind, _>("evt_kind")
+                    else {
+                        return true;
+                    };
+
+                    // If the span is not the root of a new trace then include it
+                    if evt.props().get("span_parent").is_some() {
+                        return true;
+                    };
+
+                    // Keep 1 in every 10 traces
+                    counter.fetch_add(1, Ordering::Relaxed) % 10 == 0
+                }
+            });
+
+            is_in_sampled_trace.and_when(one_in_n_traces)
+        })
+        .emit_to(emit_term::stdout())
+        .init();
+
+    for i in 0..30 {
+        run_work(i);
+    }
+
+    rt.blocking_flush(Duration::from_secs(5));
+}
+
+#[emit::span("run work")]
+fn run_work(i: i32) -> i32 {
+    let r = i + 1;
+
+    emit::debug!("computed {r} = {i} + 1");
+
+    r
+}

--- a/examples/common_patterns/span_trace_propagation.rs
+++ b/examples/common_patterns/span_trace_propagation.rs
@@ -13,8 +13,12 @@ Applications using the OpenTelemetry SDK should use its propagation mechanisms i
 use std::{collections::HashMap, time::Duration};
 
 fn main() {
-    let rt = emit::setup().emit_to(emit_term::stdout()).init();
+    // 1. Setup using `emit_traceparent` instead of `emit`
+    let rt = emit_traceparent::setup()
+        .emit_to(emit_term::stdout())
+        .init();
 
+    // A sampled request
     http::incoming(
         http::HttpRequest {
             method: "GET".into(),
@@ -24,6 +28,25 @@ fn main() {
                 map.insert(
                     "traceparent".into(),
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into(),
+                );
+                map
+            },
+        },
+        routes,
+    );
+
+    // An unsampled request
+    http::incoming(
+        http::HttpRequest {
+            method: "GET".into(),
+            path: "/api/route-1".into(),
+            headers: {
+                let mut map = HashMap::new();
+                map.insert(
+                    "traceparent".into(),
+                    // Try changing the last digit to 0
+                    // This will cause the trace to be unsampled
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00".into(),
                 );
                 map
             },
@@ -55,56 +78,7 @@ fn routes(method: &str, path: &str) {
     }
 }
 
-// This is a portable traceparent parser
-// You may want to use it, or if you've got another one handy use it instead
-//
-// We may include this in `emit` itself at some point.
-pub mod traceparent {
-    pub fn parse(
-        traceparent: &str,
-    ) -> Result<(emit::TraceId, emit::SpanId), Box<dyn std::error::Error + Send + Sync>> {
-        let mut parts = traceparent.split('-');
-
-        let version = parts.next().ok_or("missing version")?;
-
-        let "00" = version else {
-            return Err(
-                format!("unexpected version {version:?}. Only version '00' is supported").into(),
-            );
-        };
-
-        let trace_id = parts.next().ok_or("missing trace id")?;
-        let span_id = parts.next().ok_or("missing span id")?;
-        let flags = parts.next().ok_or("missing flags")?;
-
-        let None = parts.next() else {
-            return Err(format!("traceparent {traceparent:?} is in an invalid format").into());
-        };
-
-        let ("00" | "01") = flags else {
-            return Err(format!("unexpected flags {flags:?}").into());
-        };
-
-        let trace_id = trace_id.parse()?;
-        let span_id = span_id.parse()?;
-
-        Ok((trace_id, span_id))
-    }
-
-    pub fn format(
-        trace_id: Option<emit::TraceId>,
-        span_id: Option<emit::SpanId>,
-    ) -> Option<String> {
-        let (Some(trace_id), Some(span_id)) = (trace_id, span_id) else {
-            return None;
-        };
-
-        Some(format!("00-{trace_id}-{span_id}-01"))
-    }
-}
-
 pub mod http {
-    use emit::Props;
     use std::collections::HashMap;
 
     #[derive(serde::Serialize)]
@@ -115,54 +89,32 @@ pub mod http {
     }
 
     pub fn incoming(request: HttpRequest, route: impl Fn(&str, &str)) {
-        // Pulling the traceparent from a HTTP request into the current context
-
         emit::debug!("Inbound {#[emit::as_serde] request}");
 
-        // 1. Pull the trace and span ids from the incoming traceparent
-        let mut trace_id = None;
-        let mut span_id = None;
-
-        if let Some((parsed_trace_id, parsed_span_id)) = request
+        // 1. Pull the incoming traceparent
+        //    If the request doesn't specify one then use an empty sampled context
+        let traceparent = request
             .headers
             .get("traceparent")
-            .and_then(|traceparent| crate::traceparent::parse(traceparent).ok())
-        {
-            trace_id = Some(parsed_trace_id);
-            span_id = Some(parsed_span_id);
-        }
+            .and_then(|traceparent| emit_traceparent::Traceparent::try_from_str(traceparent).ok())
+            .unwrap_or_else(|| emit_traceparent::Traceparent::current());
 
-        // 2. Push the trace and span ids to the current emit context
-        //    This ensures any spans created in the request use the same
-        //    trace id, and set their parent span ids appropriately
-        emit::Frame::push(
-            emit::ctxt(),
-            emit::props! {
-                trace_id,
-                span_id,
-            },
-        )
-        .call(|| {
+        // 2. Push the traceparent onto the context
+        traceparent.push().call(move || {
             // 3. Handle your request within the frame
             route(&request.method, &request.path)
-        });
+        })
     }
 
     pub fn outgoing(mut request: HttpRequest) {
-        // Adding the traceparent from the current context onto a HTTP request
+        // 1. Get the current traceparent
+        let traceparent = emit_traceparent::Traceparent::current();
 
-        // 1. Pull the trace and span ids from the current context
-        let (trace_id, span_id) = emit::Frame::current(emit::ctxt()).with(|current| {
-            (
-                current.pull(emit::well_known::KEY_TRACE_ID),
-                current.pull(emit::well_known::KEY_SPAN_ID),
-            )
-        });
-
-        // 2. Format them as a traceparent header
-        if let Some(traceparent) = crate::traceparent::format(trace_id, span_id) {
-            // 3. Add the traceparent to the outgoing request
-            request.headers.insert("traceparent".into(), traceparent);
+        if traceparent.is_valid() {
+            // 2. Add the traceparent to the outgoing request
+            request
+                .headers
+                .insert("traceparent".into(), traceparent.to_string());
         }
 
         emit::debug!("Outbound {#[emit::as_serde] request}");

--- a/examples/common_patterns/span_trace_sampling.rs
+++ b/examples/common_patterns/span_trace_sampling.rs
@@ -1,0 +1,40 @@
+/*
+An example of how to perform trace sampling using `emit_traceparent`.
+
+This example differs from `span_trace_filtering` by letting you propagate the sampling decision
+to downstream services.
+*/
+
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+fn main() {
+    // Setup using `emit_traceparent` instead of `emit`
+    let rt = emit_traceparent::setup_with_sampler({
+        let counter = AtomicUsize::new(0);
+
+        move |_| {
+            // Sample 1 in every 10 traces
+            counter.fetch_add(1, Ordering::Relaxed) % 10 == 0
+        }
+    })
+    .emit_to(emit_term::stdout())
+    .init();
+
+    for i in 0..30 {
+        run_work(i);
+    }
+
+    rt.blocking_flush(Duration::from_secs(5));
+}
+
+#[emit::span("run work")]
+fn run_work(i: i32) -> i32 {
+    let r = i + 1;
+
+    emit::debug!("computed {r} = {i} + 1");
+
+    r
+}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -56,6 +56,19 @@ impl<C: Ctxt> Frame<C> {
     }
 
     /**
+    Get a disabled frame.
+
+    The properties in `props` will not be visible when the frame is entered. This method should be used when `props` could have been pushed, but were filtered out.
+    */
+    #[track_caller]
+    #[must_use = "call `enter`, `call`, or `in_future` to make the properties active"]
+    pub fn disabled(ctxt: C, props: impl Props) -> Self {
+        let scope = mem::ManuallyDrop::new(ctxt.open_disabled(props));
+
+        Frame { ctxt, scope }
+    }
+
+    /**
     Access the properties in this frame.
     */
     #[track_caller]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -102,6 +102,20 @@ impl<C: Ctxt> Frame<C> {
             future,
         }
     }
+
+    /**
+    Get a reference to the underlying context frame.
+    */
+    pub fn inner(&self) -> &C::Frame {
+        &self.scope
+    }
+
+    /**
+    Get an exclusive reference to the underlying context frame.
+    */
+    pub fn inner_mut(&mut self) -> &mut C::Frame {
+        &mut self.scope
+    }
 }
 
 /**

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -774,7 +774,7 @@ pub fn __private_begin_span<
     span_ctxt_props: &'b (impl Props + ?Sized),
     span_evt_props: &'b (impl Props + ?Sized),
     default_complete: S,
-) -> (Frame<Option<&'a C>>, SpanGuard<'static, &'a T, Empty, S>) {
+) -> (Frame<&'a C>, SpanGuard<'static, &'a T, Empty, S>) {
     let mdl = mdl.into();
     let name = name.into();
     let tpl = tpl.tpl_control_param();

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -393,7 +393,7 @@ pub mod source {
     /**
     Create a [`Source`] from a function.
     */
-    pub fn from_fn<F: Fn(&mut dyn ErasedSampler)>(source: F) -> FromFn<F> {
+    pub const fn from_fn<F: Fn(&mut dyn ErasedSampler)>(source: F) -> FromFn<F> {
         FromFn::new(source)
     }
 
@@ -771,7 +771,7 @@ pub mod sampler {
     /**
     Create a [`Sampler`] from a function.
     */
-    pub fn from_fn<F: Fn(&Metric<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
+    pub const fn from_fn<F: Fn(&Metric<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
         FromFn(f)
     }
 

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -2,10 +2,14 @@
 The [`ThreadLocalCtxt`] type.
 */
 
-use core::mem;
-use std::{cell::RefCell, collections::HashMap, ops::ControlFlow, sync::Mutex};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    mem,
+    ops::ControlFlow,
+    sync::{Arc, Mutex},
+};
 
-use alloc::sync::Arc;
 use emit_core::{
     ctxt::Ctxt,
     props::Props,

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -120,12 +120,12 @@ impl Ctxt for ThreadLocalCtxt {
         span
     }
 
-    fn enter(&self, link: &mut Self::Frame) {
-        swap(self.id, link);
+    fn enter(&self, frame: &mut Self::Frame) {
+        swap(self.id, frame);
     }
 
-    fn exit(&self, link: &mut Self::Frame) {
-        swap(self.id, link);
+    fn exit(&self, frame: &mut Self::Frame) {
+        swap(self.id, frame);
     }
 
     fn close(&self, _: Self::Frame) {}

--- a/src/span.rs
+++ b/src/span.rs
@@ -804,10 +804,7 @@ impl<'a, C: Clock, P: Props, F: FnOnce(Span<'a, P>)> SpanGuard<'a, C, P, F> {
         }
     }
 
-    /**
-    Whether the span will emit an event on completion.
-    */
-    pub fn is_enabled(&self) -> bool {
+    fn is_enabled(&self) -> bool {
         self.state.is_some()
     }
 

--- a/traceparent/Cargo.toml
+++ b/traceparent/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "emit_traceparent"
 version = "0.11.0-alpha.18"
+authors = ["emit contributors"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/emit-rs/emit"
+description = "W3C traceparent support for emit."
+keywords = ["logging", "tracing", "metrics", "observability"]
+categories = ["development-tools::debugging"]
 edition = "2021"
 
 [dependencies.emit]

--- a/traceparent/Cargo.toml
+++ b/traceparent/Cargo.toml
@@ -13,3 +13,7 @@ edition = "2021"
 [dependencies.emit]
 version = "0.11.0-alpha.18"
 path = "../"
+
+[dev-dependencies.emit_term]
+version = "0.11.0-alpha.18"
+path = "../emitter/term"

--- a/traceparent/Cargo.toml
+++ b/traceparent/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "emit_traceparent"
+version = "0.11.0-alpha.18"
+edition = "2021"
+
+[dependencies.emit]
+version = "0.11.0-alpha.18"
+path = "../"

--- a/traceparent/README.md
+++ b/traceparent/README.md
@@ -1,0 +1,7 @@
+# `emit_traceparent`
+
+[![traceparent](https://github.com/emit-rs/emit/actions/workflows/traceparent.yml/badge.svg)](https://github.com/emit-rs/emit/actions/workflows/traceparent.yml)
+
+[Current docs](https://docs.rs/emit_traceparent/0.11.0-alpha.18/emit_traceparent/index.html)
+
+Support trace propagation and sampling via [W3C traceparents](https://www.w3.org/TR/trace-context/).

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -237,7 +237,7 @@ impl TraceFlags {
     }
 
     /**
-    Try parse a slice of ASCII hex bytes into a span id.
+    Try parse a slice of ASCII hex bytes into trace flags.
 
     If `hex` is not a 2 byte array of valid hex characters (`[a-fA-F0-9]`) then this method will fail.
     */

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -534,7 +534,9 @@ mod tests {
             span_ctxt_2.push(&ctxt).call(|| {
                 let traceparent = Traceparent::current();
 
-                let span_ctxt_2 = SpanCtxt::current(&ctxt);
+                let span_ctxt_3 = SpanCtxt::current(&ctxt);
+
+                assert_eq!(span_ctxt_2, span_ctxt_3);
 
                 assert_eq!(
                     span_ctxt_1.trace_id().unwrap(),

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -1,0 +1,153 @@
+/*!
+Distributed trace context for `emit` with support for sampling.
+*/
+
+pub fn set_traceparent(traceparent: Traceparent) {
+    todo!()
+}
+
+pub fn get_traceparent() -> Option<Traceparent> {
+    todo!()
+}
+
+/**
+An error encountered attempting to work with a [`Traceparent`].
+*/
+#[derive(Debug)]
+pub struct Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "the input was not a valid id")
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub struct Traceparent {
+    trace_id: Option<TraceId>,
+    span_id: Option<SpanId>,
+    trace_flags: TraceFlags,
+}
+
+pub struct TraceFlags(u8);
+
+impl TraceFlags {
+    pub const EMPTY: Self = TraceFlags(0);
+    pub const SAMPLED: Self = TraceFlags(1);
+
+    pub fn try_from_str(flags: &str) -> Result<Self, Error> {
+        todo!()
+    }
+
+    pub fn from_u8(raw: u8) -> Self {
+        TraceFlags(raw)
+    }
+
+    pub fn to_u8(&self) -> u8 {
+        self.0
+    }
+
+    pub fn is_sampled(&self) -> bool {
+        self.0 & Self::SAMPLED.0 == 0
+    }
+}
+
+impl FromStr for TraceFlags {
+    type Err = Error;
+
+    fn from_str(flags: &str) -> Result<Self, Error> {
+        Self::try_from_str(flags)
+    }
+}
+
+impl fmt::Display for TraceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Traceparent {
+    pub const fn new(
+        trace_id: Option<TraceId>,
+        span_id: Option<SpanId>,
+        trace_flags: TraceFlags,
+    ) -> Self {
+        Traceparent {
+            trace_id,
+            span_id,
+            trace_flags,
+        }
+    }
+
+    pub fn try_from_str(header: &str) -> Result<Self, Error> {
+        todo!()
+    }
+
+    pub fn from_span_ctxt(span_ctxt: SpanCtxt) -> Self {
+        Traceparent::new(span_ctxt.trace_id, span_ctxt.span_id, TraceFlags::SAMPLED)
+    }
+
+    pub fn to_span_ctxt(&self) -> Option<SpanCtxt> {
+        if self.trace_flags.is_sampled() {
+            Some(SpanCtxt::new(self.trace_id, None, self.span_id))
+        } else {
+            None
+        }
+    }
+
+    pub fn trace_id(&self) -> Option<&TraceId> {
+        self.trace_id.as_ref()
+    }
+
+    pub fn span_id(&self) -> Option<&SpanId> {
+        self.span_id.as_ref()
+    }
+
+    pub fn trace_flags(&self) -> &TraceFlags {
+        &self.trace_flags
+    }
+}
+
+impl FromStr for Traceparent {
+    type Err = Error;
+
+    fn from_str(header: &str) -> Result<Self, Error> {
+        Self::try_from_str(header)
+    }
+}
+
+impl fmt::Display for Traceparent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        todo!()
+    }
+}
+
+// Intercept calls to `open` and look for `trace_id` and `span_id`
+// Push then to the trace context; that means getting the current
+// and using its sampled flag if present
+pub struct TraceparentCtxt<C> {
+    inner: C,
+}
+
+impl<C: Ctxt> Ctxt for TraceparentCtxt<C> {
+    type Current = C::Current;
+    type Frame = C::Frame;
+}
+
+pub struct TraceparentFilter {}
+
+impl Filter for TraceparentFilter {
+    fn matches<E: ToEvent>(&self, _: E) -> bool {
+        let Some(traceparent) = get_traceparent() else {
+            return true;
+        };
+
+        traceparent.trace_flags().is_sampled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -639,4 +639,8 @@ mod tests {
         .join()
         .unwrap();
     }
+
+    // TODO: Even if the filter doesn't pass, we need to stash our traceparent frame
+    // That means the sampler matches the root span, but stores unsampled flags
+    // so that the resulting span is not emitted, but the traceparent is stored
 }

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -2,34 +2,56 @@
 Distributed trace context for `emit` with support for sampling.
 */
 
-pub fn set_traceparent(traceparent: Traceparent) {
-    todo!()
+use std::{cell::RefCell, fmt, mem, str::FromStr};
+
+use emit::{
+    event::ToEvent,
+    span::{SpanCtxt, SpanId, TraceId},
+    well_known::{KEY_SPAN_ID, KEY_TRACE_ID},
+    Ctxt, Filter, Props,
+};
+
+thread_local! {
+    static ACTIVE_TRACEPARENT: RefCell<Option<Traceparent>> = RefCell::new(None);
+}
+
+// TODO: Need a guard that unsets on Drop
+pub fn set_traceparent(traceparent: Option<Traceparent>) -> Option<Traceparent> {
+    ACTIVE_TRACEPARENT.with(|slot| {
+        let mut slot = slot.borrow_mut();
+
+        mem::replace(&mut *slot, traceparent)
+    })
 }
 
 pub fn get_traceparent() -> Option<Traceparent> {
-    todo!()
+    ACTIVE_TRACEPARENT.with(|slot| *slot.borrow())
 }
 
 /**
 An error encountered attempting to work with a [`Traceparent`].
 */
 #[derive(Debug)]
-pub struct Error {}
+pub struct Error {
+    msg: String,
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "the input was not a valid id")
+        fmt::Display::fmt(&self.msg, f)
     }
 }
 
 impl std::error::Error for Error {}
 
+#[derive(Debug, Clone, Copy)]
 pub struct Traceparent {
     trace_id: Option<TraceId>,
     span_id: Option<SpanId>,
     trace_flags: TraceFlags,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct TraceFlags(u8);
 
 impl TraceFlags {
@@ -37,7 +59,13 @@ impl TraceFlags {
     pub const SAMPLED: Self = TraceFlags(1);
 
     pub fn try_from_str(flags: &str) -> Result<Self, Error> {
-        todo!()
+        match flags {
+            "00" => Ok(TraceFlags::EMPTY),
+            "01" => Ok(TraceFlags::SAMPLED),
+            _ => Err(Error {
+                msg: format!("unexpected flags {flags:?}"),
+            }),
+        }
     }
 
     pub fn from_u8(raw: u8) -> Self {
@@ -81,11 +109,47 @@ impl Traceparent {
     }
 
     pub fn try_from_str(header: &str) -> Result<Self, Error> {
-        todo!()
+        let mut parts = header.split('-');
+
+        let version = parts.next().ok_or_else(|| Error {
+            msg: "missing version".into(),
+        })?;
+
+        let "00" = version else {
+            return Err(Error {
+                msg: format!("unexpected version {version:?}. Only version '00' is supported"),
+            });
+        };
+
+        let trace_id = parts.next().ok_or_else(|| Error {
+            msg: "missing trace id".into(),
+        })?;
+        let span_id = parts.next().ok_or_else(|| Error {
+            msg: "missing span id".into(),
+        })?;
+        let trace_flags = parts.next().ok_or_else(|| Error {
+            msg: "missing flags".into(),
+        })?;
+
+        let None = parts.next() else {
+            return Err(Error {
+                msg: format!("traceparent {header:?} is in an invalid format"),
+            });
+        };
+
+        let trace_id = TraceId::try_from_hex(trace_id).map_err(|e| Error { msg: e.to_string() })?;
+        let span_id = SpanId::try_from_hex(span_id).map_err(|e| Error { msg: e.to_string() })?;
+        let trace_flags = TraceFlags::try_from_str(trace_flags)?;
+
+        Ok(Traceparent::new(Some(trace_id), Some(span_id), trace_flags))
     }
 
     pub fn from_span_ctxt(span_ctxt: SpanCtxt) -> Self {
-        Traceparent::new(span_ctxt.trace_id, span_ctxt.span_id, TraceFlags::SAMPLED)
+        Traceparent::new(
+            span_ctxt.trace_id().copied(),
+            span_ctxt.span_id().copied(),
+            TraceFlags::SAMPLED,
+        )
     }
 
     pub fn to_span_ctxt(&self) -> Option<SpanCtxt> {
@@ -130,9 +194,85 @@ pub struct TraceparentCtxt<C> {
     inner: C,
 }
 
+pub struct TraceparentCtxtFrame<F> {
+    inner: F,
+    active: bool,
+    slot: Option<Traceparent>,
+}
+
 impl<C: Ctxt> Ctxt for TraceparentCtxt<C> {
     type Current = C::Current;
-    type Frame = C::Frame;
+    type Frame = TraceparentCtxtFrame<C::Frame>;
+
+    fn with_current<R, F: FnOnce(&Self::Current) -> R>(&self, with: F) -> R {
+        self.inner.with_current(with)
+    }
+
+    fn open_root<P: Props>(&self, props: P) -> Self::Frame {
+        let slot = incoming_traceparent(&props);
+
+        let inner = self.inner.open_root(props);
+
+        TraceparentCtxtFrame {
+            inner,
+            slot,
+            active: slot.is_some(),
+        }
+    }
+
+    fn open_push<P: Props>(&self, props: P) -> Self::Frame {
+        let slot = incoming_traceparent(&props);
+
+        let inner = self.inner.open_push(props);
+
+        TraceparentCtxtFrame {
+            inner,
+            slot,
+            active: slot.is_some(),
+        }
+    }
+
+    fn enter(&self, frame: &mut Self::Frame) {
+        if frame.active {
+            frame.slot = set_traceparent(frame.slot);
+        }
+
+        self.inner.enter(&mut frame.inner)
+    }
+
+    fn exit(&self, frame: &mut Self::Frame) {
+        if frame.active {
+            frame.slot = set_traceparent(frame.slot);
+        }
+
+        self.inner.exit(&mut frame.inner)
+    }
+
+    fn close(&self, frame: Self::Frame) {
+        self.inner.close(frame.inner)
+    }
+}
+
+fn incoming_traceparent(props: impl Props) -> Option<Traceparent> {
+    let trace_id = props.pull::<TraceId, _>(KEY_TRACE_ID);
+    let span_id = props.pull::<SpanId, _>(KEY_SPAN_ID);
+
+    if let Some(span_id) = span_id {
+        let current_traceparent = get_traceparent();
+
+        let traceparent = Traceparent::new(
+            trace_id
+                .or_else(|| current_traceparent.and_then(|current| current.trace_id().copied())),
+            Some(span_id),
+            current_traceparent
+                .map(|current| *current.trace_flags())
+                .unwrap_or(TraceFlags::SAMPLED),
+        );
+
+        Some(traceparent)
+    } else {
+        None
+    }
 }
 
 pub struct TraceparentFilter {}
@@ -150,4 +290,29 @@ impl Filter for TraceparentFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn traceparent_parse_valid() {
+        todo!()
+    }
+
+    #[test]
+    fn traceparent_parse_invalid() {
+        todo!()
+    }
+
+    #[test]
+    fn traceparent_to_span_ctxt() {
+        todo!()
+    }
+
+    #[test]
+    fn traceparent_ctxt() {
+        todo!()
+    }
+
+    #[test]
+    fn traceparent_ctxt_across_threads() {
+        todo!()
+    }
 }

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -380,6 +380,10 @@ impl<C: Ctxt> Ctxt for TraceparentCtxt<C> {
         }
     }
 
+    fn open_disabled<P: Props>(&self, props: P) -> Self::Frame {
+        todo!()
+    }
+
     fn enter(&self, frame: &mut Self::Frame) {
         if frame.active {
             frame.slot = set_active_traceparent(frame.slot);


### PR DESCRIPTION
Closes #120

`emit` is only concerned with sampled context. This keeps its API simple and focused, but distributed apps still need to propagate the fact that a trace they're participating in is unsampled to any downstream callers, otherwise those will likely start a new trace.

This PR introduces a new subcrate `emit_traceparent` that can parse [W3C traceparent headers](https://www.w3.org/TR/trace-context). It also provides a central place to store and retrieve the active traceparent so you can use it for propagation and sampling. I've opted to add this in an external library instead of directly in `emit` to avoid making its own `emit::span` API murkier, and to avoid baking in competing concepts with the OpenTelemetry SDK, which, via `emit_opentelemetry`, is another backend option for apps that participate in distributed traces.