### PR TITLE
Allow splitting a Frame into its raw parts

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -161,6 +161,16 @@ impl<C: Ctxt> Frame<C> {
     }
 }
 
+impl<C: Ctxt> Drop for Frame<C> {
+    fn drop(&mut self) {
+        // SAFETY: We're being dropped, so won't access fields again
+        let ctxt = unsafe { mem::ManuallyDrop::take(&mut self.ctxt) };
+        let scope = unsafe { mem::ManuallyDrop::take(&mut self.scope) };
+
+        ctxt.close(scope)
+    }
+}
+
 /**
 The result of calling [`Frame::enter`].
 
@@ -184,16 +194,6 @@ impl<'a, C: Ctxt> EnterGuard<'a, C> {
 impl<'a, C: Ctxt> Drop for EnterGuard<'a, C> {
     fn drop(&mut self) {
         self.scope.ctxt.exit(&mut self.scope.scope);
-    }
-}
-
-impl<C: Ctxt> Drop for Frame<C> {
-    fn drop(&mut self) {
-        // SAFETY: We're being dropped, so won't access `scope` again
-        let ctxt = unsafe { mem::ManuallyDrop::take(&mut self.ctxt) };
-        let scope = unsafe { mem::ManuallyDrop::take(&mut self.scope) };
-
-        ctxt.close(scope)
     }
 }
 


### PR DESCRIPTION
This is an advanced API for working with context frames. If you end up with a `Frame`, you may need to manage it in a way that doesn't cleanly map onto lifetime-scoped guards. The underlying `Ctxt` type allows this, so adding a method that unwraps the frame into its parts so you can manage them yourself is reasonable.