### PR TITLE
Ensure explicit trace/span ids take precedence in #[emit::span]

### DIFF
--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -783,10 +783,8 @@ pub fn __private_begin_span<
                     |span_props| {
                         span_evt_props
                             .and_props(span_props)
-                            // These props will be pushed onto the context
-                            // if the filter matches, so are only needed explicitly here
-                            .and_props(&span_ctxt)
                             .and_props(&span_ctxt_props)
+                            .and_props(&span_ctxt)
                             .and_props(ctxt_props)
                     },
                 ))
@@ -795,6 +793,8 @@ pub fn __private_begin_span<
         mdl,
         Timer::start(rt.clock()),
         name,
+        // NOTE: We could avoid constructing a context if `span_ctxt_props`
+        // already carries trace/span ids
         SpanCtxt::current(rt.ctxt()).new_child(rt.rng()),
         Empty,
         default_complete,

--- a/src/span.rs
+++ b/src/span.rs
@@ -787,20 +787,12 @@ impl<'a, C: Clock, P: Props, F: FnOnce(Span<'a, P>)> SpanGuard<'a, C, P, F> {
         if self.is_enabled() {
             Frame::push(
                 ctxt,
-                ctxt_props.and_props(
-                self.state
-                    .as_ref()
-                    .expect("span is already complete")
-                    .ctxt),
+                ctxt_props.and_props(self.state.as_ref().expect("span is already complete").ctxt),
             )
         } else {
             Frame::disabled(
                 ctxt,
-                ctxt_props.and_props(
-                self.state
-                    .as_ref()
-                    .expect("span is already complete")
-                    .ctxt),
+                ctxt_props.and_props(self.state.as_ref().expect("span is already complete").ctxt),
             )
         }
     }

--- a/src/span.rs
+++ b/src/span.rs
@@ -787,20 +787,20 @@ impl<'a, C: Clock, P: Props, F: FnOnce(Span<'a, P>)> SpanGuard<'a, C, P, F> {
         if self.is_enabled() {
             Frame::push(
                 ctxt,
+                ctxt_props.and_props(
                 self.state
                     .as_ref()
                     .expect("span is already complete")
-                    .ctxt
-                    .and_props(ctxt_props),
+                    .ctxt),
             )
         } else {
             Frame::disabled(
                 ctxt,
+                ctxt_props.and_props(
                 self.state
                     .as_ref()
                     .expect("span is already complete")
-                    .ctxt
-                    .and_props(ctxt_props),
+                    .ctxt),
             )
         }
     }

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -364,17 +364,13 @@ fn span_explicit_ids() {
             assert_eq!(emit::TraceId::from_u128(1), evt.props().pull("trace_id"));
             assert_eq!(emit::SpanId::from_u64(2), evt.props().pull("span_parent"));
             assert_eq!(emit::SpanId::from_u64(3), evt.props().pull("span_id"));
-            
+
             true
         },
     );
 
     #[emit::span(rt: RT, "test", trace_id, span_parent, span_id)]
-    fn exec(
-        trace_id: &str,
-        span_parent: &str,
-        span_id: &str,
-    ) {
+    fn exec(trace_id: &str, span_parent: &str, span_id: &str) {
         let ctxt = emit::SpanCtxt::current(RT.ctxt());
 
         assert_eq!(emit::TraceId::from_u128(1), ctxt.trace_id().copied());

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -388,6 +388,44 @@ fn span_explicit_ids() {
 }
 
 #[test]
+fn span_explicit_ids_ctxt() {
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(emit::TraceId::from_u128(1), evt.props().pull("trace_id"));
+            assert_eq!(emit::SpanId::from_u64(2), evt.props().pull("span_parent"));
+            assert_eq!(emit::SpanId::from_u64(3), evt.props().pull("span_id"));
+
+            CALLED.record();
+        },
+        |evt| {
+            assert_eq!(emit::TraceId::from_u128(1), evt.props().pull("trace_id"));
+            assert_eq!(emit::SpanId::from_u64(2), evt.props().pull("span_parent"));
+            assert_eq!(emit::SpanId::from_u64(3), evt.props().pull("span_id"));
+
+            true
+        },
+    );
+
+    #[emit::span(rt: RT, "test", trace_id: ctxt.trace_id(), span_parent: ctxt.span_parent(), span_id: ctxt.span_id())]
+    fn exec(ctxt: emit::SpanCtxt) {
+        let current = emit::SpanCtxt::current(RT.ctxt());
+
+        assert_eq!(ctxt, current);
+    }
+
+    exec(
+        emit::SpanCtxt::new(
+            emit::TraceId::from_u128(1),
+            emit::SpanId::from_u64(2),
+            emit::SpanId::from_u64(3),
+        ),
+    );
+
+    assert!(CALLED.was_called());
+}
+
+#[test]
 #[cfg(feature = "std")]
 fn span_ok_lvl() {
     use std::io;


### PR DESCRIPTION
When using `#[emit::span]`, you may still want to control the span context. The natural way to do this is just adding them as properties to the `#[emit::span]` macro. Previously we'd prefer generated context over properties you pass in, but it makes more sense to prefer what the user provides so now this will produce a span that uses `ctxt` instead of generating one:

```rust
#[emit::span("work", trace_id: ctxt.trace_id(), span_parent: ctxt.span_parent(), span_id: ctxt.span_id())]
fn work(ctxt: SpanCtxt, ..) {
    ..
}
```