### PR TITLE
Allow capturing trace and span ids as integers

### DIFF
--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -320,7 +320,9 @@ impl CaptureAsError for str {
     }
 }
 
-#[diagnostic::on_unimplemented(message = "capturing a span id requires a `str` or `SpanId`.")]
+#[diagnostic::on_unimplemented(
+    message = "capturing a span id requires a `str`, `u64`, or `SpanId`."
+)]
 pub trait CaptureSpanId {
     fn capture(&self) -> Option<Value>;
 }
@@ -343,13 +345,21 @@ impl CaptureSpanId for str {
     }
 }
 
+impl CaptureSpanId for u64 {
+    fn capture(&self) -> Option<Value> {
+        Some(self.to_value())
+    }
+}
+
 impl<T: CaptureSpanId> CaptureSpanId for Option<T> {
     fn capture(&self) -> Option<Value> {
         self.as_ref().and_then(|v| v.capture())
     }
 }
 
-#[diagnostic::on_unimplemented(message = "capturing a trace id requires a `str` or `TraceId`.")]
+#[diagnostic::on_unimplemented(
+    message = "capturing a trace id requires a `str`, `u128`, or `TraceId`."
+)]
 pub trait CaptureTraceId {
     fn capture(&self) -> Option<Value>;
 }
@@ -367,6 +377,12 @@ impl CaptureTraceId for TraceId {
 }
 
 impl CaptureTraceId for str {
+    fn capture(&self) -> Option<Value> {
+        Some(self.to_value())
+    }
+}
+
+impl CaptureTraceId for u128 {
     fn capture(&self) -> Option<Value> {
         Some(self.to_value())
     }

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -183,6 +183,20 @@ fn props_capture_trace_id_string() {
 }
 
 #[test]
+fn props_capture_trace_id_u128() {
+    match emit::props! {
+        trace_id: 0x00000000000000000000000000000001u128,
+    } {
+        props => {
+            assert_eq!(
+                emit::TraceId::from_u128(1).unwrap(),
+                props.pull::<emit::TraceId, _>("trace_id").unwrap()
+            );
+        }
+    }
+}
+
+#[test]
 fn props_capture_trace_id_as_non_trace_id() {
     match emit::props! {
         #[emit::as_display(inspect: true)] trace_id: true,
@@ -211,6 +225,20 @@ fn props_capture_span_id() {
 fn props_capture_span_id_string() {
     match emit::props! {
         span_id: "0000000000000001",
+    } {
+        props => {
+            assert_eq!(
+                emit::SpanId::from_u64(1).unwrap(),
+                props.pull::<emit::SpanId, _>("span_id").unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn props_capture_span_id_u64() {
+    match emit::props! {
+        span_id: 0x0000000000000001u64,
     } {
         props => {
             assert_eq!(

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -414,13 +414,11 @@ fn span_explicit_ids_ctxt() {
         assert_eq!(ctxt, current);
     }
 
-    exec(
-        emit::SpanCtxt::new(
-            emit::TraceId::from_u128(1),
-            emit::SpanId::from_u64(2),
-            emit::SpanId::from_u64(3),
-        ),
-    );
+    exec(emit::SpanCtxt::new(
+        emit::TraceId::from_u128(1),
+        emit::SpanId::from_u64(2),
+        emit::SpanId::from_u64(3),
+    ));
 
     assert!(CALLED.was_called());
 }


### PR DESCRIPTION
Since trace and span ids can be represented as integers, we should be able to capture them in properties as integers too. This PR optimizes the conversion from raw values back into trace or span ids by trying to cast them to an integer before attempting to parse them from text.