### PR TITLE
Add a flush_on_drop guard to Init

### DIFF
--- a/book/src/emitting-events.md
+++ b/book/src/emitting-events.md
@@ -137,7 +137,6 @@ Also see [Filtering events](./filtering-events.md) for more details on filtering
 Events may be processed asynchronously, so to ensure they're fulling flushed before your `main` returns, you can call [`blocking_flush`](https://docs.rs/emit/0.11.0-alpha.19/emit/setup/struct.Init.html#method.blocking_flush) at the end of your `main` function:
 
 ```rust
-```rust
 # extern crate emit;
 # extern crate emit_term;
 fn main() {

--- a/book/src/emitting-events.md
+++ b/book/src/emitting-events.md
@@ -131,3 +131,42 @@ let emitter = emit::emitter::from_fn(|evt| println!("{evt:?}"))
 ```
 
 Also see [Filtering events](./filtering-events.md) for more details on filtering in `emit`.
+
+## Flushing
+
+Events may be processed asynchronously, so to ensure they're fulling flushed before your `main` returns, you can call [`blocking_flush`](https://docs.rs/emit/0.11.0-alpha.19/emit/setup/struct.Init.html#method.blocking_flush) at the end of your `main` function:
+
+```rust
+```rust
+# extern crate emit;
+# extern crate emit_term;
+fn main() {
+    let rt = emit::setup()
+        .emit_to(emit_term::stdout())
+        .init();
+
+    // Your app code goes here
+
+    // Flush at the end of `main`
+    rt.blocking_flush(std::time::Duration::from_secs(5));
+}
+```
+
+It's a good idea to flush even if your emitter isn't asynchronous. In this case it'll be a no-op, but will ensure flushing does happen if you ever introduce an asynchronous emitter in the future.
+
+Instead of `blocking_flush`, you can call [`flush_on_drop`](https://docs.rs/emit/0.11.0-alpha.19/emit/setup/struct.Init.html#method.flush_on_drop):
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+fn main() {
+    let _rt = emit::setup()
+        .emit_to(emit_term::stdout())
+        .init()
+        .flush_on_drop(std::time::Duration::from_secs(5));
+
+    // Your app code goes here
+}
+```
+
+Once the returned guard goes out of scope it'll call `blocking_flush` for you, even if a panic unwinds through your `main` function. **Make sure you give the guard an identifer like `_rt` and not `_`**, otherwise it will be dropped immediately and not at the end of your `main` function.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -353,6 +353,18 @@ impl<'a, TEmitter: Emitter + ?Sized, TCtxt: Ctxt + ?Sized> Init<'a, TEmitter, TC
     Flush the runtime when the returned guard is dropped, ensuring all diagnostic events are fully processed.
 
     This method forwards to [`Emitter::blocking_flush`], which has details on how the timeout is handled.
+
+    **Important:** Ensure you bind an identifier to this method, otherwise it will be immediately dropped instead of at the end of your `main`:
+
+    ```
+    # use std::time::Duration;
+    fn main() {
+        // Use an ident like `_guard`, not `_`
+        let _guard = emit::setup().init().flush_on_drop(Duration::from_secs(5));
+
+        // Your code goes here
+    }
+    ```
     */
     pub fn flush_on_drop(self, timeout: Duration) -> InitGuard<'a, TEmitter, TCtxt> {
         InitGuard {


### PR DESCRIPTION
Closes #122 

This PR introduces an `Init::flush_on_drop` method as an alternative to `blocking_flush` that will try flush when it goes out of scope:

```rust
fn main() {
    let _guard = emit::setup().emit_to(..).init().flush_on_drop(Duration::from_secs(5));

    ..
}
```

It's important to bind this value to a proper identifier and not just `_`, otherwise it'll be dropped immediately.