### PR TITLE
Add docs and helpers for initializing outside main

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,6 +35,7 @@
     - [Via OTLP](./emitting-events/otlp.md)
 - [Advanced apps](./advanced-apps.md)
     - [Integrating with OpenTelemetry](./advanced-apps/integrating-with-open-telemetry.md)
+    - [Setup outside of `main`](./advanced-apps/non-main-setup.md)
 - [For developers](./for-developers.md)
     - [Writing an emitter](./for-developers/writing-an-emitter.md)
 - [Troubleshooting](./troubleshooting.md)

--- a/book/src/advanced-apps/non-main-setup.md
+++ b/book/src/advanced-apps/non-main-setup.md
@@ -1,0 +1,21 @@
+# Setup outside of `main`
+
+`emit` is typically configured in your `main` function, but that might not be feasible for some applications. In these cases, you can run `emit`'s setup in a function and flush it deliberately at some later point:
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+fn diagnostics_init() {
+    let _ = emit::setup()
+        .emit_to(emit_term::stdout())
+        .try_init();
+}
+
+fn diagnostics_flush() {
+    emit::blocking_flush(std::time::Duration::from_secs(5));
+}
+```
+
+Calling [`try_init()`](https://docs.rs/emit/0.11.0-alpha.19/emit/setup/struct.Setup.html#method.try_init) ensures you don't panic even if setup is called multiple times.
+
+`emit` doesn't automatically flush or de-initialize its runtime when [`Init`](https://docs.rs/emit/0.11.0-alpha.19/emit/setup/struct.Init.html) goes out of scope so it's safe to let it drop before your application exits. 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,18 @@ pub fn rng() -> runtime::AmbientRng<'static> {
     *runtime::shared().rng()
 }
 
+/**
+Flush the runtime, ensuring all diagnostic events are fully processed.
+
+This method will use [`runtime::shared()`].
+
+This method forwards to [`Emitter::blocking_flush`], which has details on how the timeout is handled.
+*/
+#[cfg(feature = "implicit_rt")]
+pub fn blocking_flush(timeout: std::time::Duration) -> bool {
+    runtime::shared().blocking_flush(timeout)
+}
+
 #[doc(hidden)]
 pub mod __private {
     pub extern crate core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ This method will use [`runtime::shared()`].
 This method forwards to [`Emitter::blocking_flush`], which has details on how the timeout is handled.
 */
 #[cfg(feature = "implicit_rt")]
-pub fn blocking_flush(timeout: std::time::Duration) -> bool {
+pub fn blocking_flush(timeout: core::time::Duration) -> bool {
     runtime::shared().blocking_flush(timeout)
 }
 


### PR DESCRIPTION
This PR introduces a `try_init` method to setup and a top-level `emit::blocking_flush()` function to help applications that don't initialize diagnostics in their `main` function.