### PR TITLE
Add a setup control parameter to `#[emit::span]`

### DIFF
--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -87,3 +87,7 @@ path = "span_trace_sampling.rs"
 [[example]]
 name = "span_trace_filtering"
 path = "span_trace_filtering.rs"
+
+[[example]]
+name = "testing"
+path = "testing.rs"

--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -1,0 +1,40 @@
+/*!
+This example demonstrates how to use `emit` in unit tests.
+
+Using the `setup` control parameter, you can ensure `emit` is initialized before tests run,
+and that any emitted events are flushed when the test completes.
+*/
+
+// This is the piece of code we're going to test
+pub fn add(a: i32, b: i32) -> i32 {
+    let r = a + b;
+
+    emit::debug!("{r} = {a} + {b}");
+
+    r
+}
+
+// This function is invoked by `#[emit::span]`s because they use it
+// as the `setup` control parameter. It's bound to a value that's dropped
+// at the end of the annotated function
+#[cfg(test)]
+fn setup() -> Option<impl Drop> {
+    emit::setup()
+        .emit_to(emit_term::stdout())
+        .try_init()
+        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)))
+}
+
+#[test]
+#[emit::span(setup, "add_1_1")]
+fn add_1_1() {
+    assert_eq!(2, add(1, 1));
+}
+
+#[test]
+#[emit::span(setup, "add_1_0")]
+fn add_1_0() {
+    assert_eq!(1, add(1, 0));
+}
+
+fn main() {}

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -108,27 +108,6 @@ impl<T> Arg<T> {
     pub fn take(self) -> Option<T> {
         self.value
     }
-
-    pub fn take_if_std(self) -> Result<Option<T>, syn::Error> {
-        #[cfg(feature = "std")]
-        {
-            Ok(self.take())
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            if self.value.is_some() {
-                Err(syn::Error::new(
-                    self.span.unwrap_or_else(Span::call_site),
-                    format!(
-                        "capturing `{}` is only possible when the `std` Cargo feature is enabled",
-                        self.key
-                    ),
-                ))
-            } else {
-                Ok(None)
-            }
-        }
-    }
 }
 
 impl<T: Default> Arg<T> {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -372,7 +372,8 @@ This macro accepts the following optional control parameters:
 | `guard`   | -                             | An identifier to bind an `emit::Span` to in the body of the span for manual completion.                                                                        |
 | `ok_lvl`  | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.                                                    |
 | `err_lvl` | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.        |
-| `err`     | `impl Fn(&E) -> U`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `U` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static` |
+| `err`     | `impl Fn(&E) -> T`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `U` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static` |
+| `setup`   | `impl Fn() -> T`              | Invoke the expression before creating the span, binding the result to a value that's dropped at the end of the annotated function.                             |
 
 # Template
 


### PR DESCRIPTION
For #141 

This PR adds a new `setup` control parameter to `#[emit::span]` that can be used to invoke a function before running any `emit` code in the annotated function. It can be helpful for unit tests to reduce boilerplate when including diagnostics from them:

```rust
pub fn add(a: i32, b: i32) -> i32 {
    let r = a + b;

    emit::debug!("{r} = {a} + {b}");

    r
}

#[cfg(test)]
fn setup() -> Option<impl Drop> {
    emit::setup()
        .emit_to(emit_term::stdout())
        .try_init()
        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)))
}

#[test]
#[emit::span(setup, "add_1_1")]
fn add_1_1() {
    assert_eq!(2, add(1, 1));
}
```