### PR TITLE
Add tests for background teardown

### DIFF
--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -1817,7 +1817,12 @@ mod tests {
 
     #[test]
     fn file_closes_bg_thread_on_drop() {
-        let mut files = set("./target/logs/file_closes_bg_thread_on_drop/logs.txt").spawn();
+        let mut files = set_with_writer(
+            "./target/logs/file_closes_bg_thread_on_drop/logs.txt",
+            |_, _| Ok(()),
+            b"\0",
+        )
+        .spawn();
 
         let handle = {
             let inner = files.inner.take().unwrap();

--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -1814,4 +1814,20 @@ mod tests {
                 .contents()
         );
     }
+
+    #[test]
+    fn file_closes_bg_thread_on_drop() {
+        let mut files = set("./target/logs/file_closes_bg_thread_on_drop/logs.txt").spawn();
+
+        let handle = {
+            let inner = files.inner.take().unwrap();
+
+            inner._handle
+        };
+
+        drop(files);
+
+        // Ensure the background thread is torn down
+        handle.join().unwrap();
+    }
 }


### PR DESCRIPTION
Closes #143 

We do tear down the background thread when `emit_file` or `emit_otlp` types are dropped. This PR just adds some test cases to verify it.