### PR TITLE
Add support for setting a panic level

### DIFF
--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -3,6 +3,9 @@ This example demonstrates how to use `emit` in unit tests.
 
 Using the `setup` control parameter, you can ensure `emit` is initialized before tests run,
 and that any emitted events are flushed when the test completes.
+
+Tests typically panic when they fail. You can use the `panic_lvl` control parameter to mark
+spans as failed if a panic occurs.
 */
 
 // This is the piece of code we're going to test
@@ -26,15 +29,15 @@ fn setup() -> Option<impl Drop> {
 }
 
 #[test]
-#[emit::span(setup, "add_1_1")]
+#[emit::span(setup, panic_lvl: "error", "add_1_1")]
 fn add_1_1() {
     assert_eq!(2, add(1, 1));
 }
 
 #[test]
-#[emit::span(setup, "add_1_0")]
+#[emit::span(setup, panic_lvl: "error", "add_1_0")]
 fn add_1_0() {
-    assert_eq!(1, add(1, 0));
+    assert_eq!(2, add(1, 0));
 }
 
 fn main() {}

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -108,6 +108,27 @@ impl<T> Arg<T> {
     pub fn take(self) -> Option<T> {
         self.value
     }
+
+    pub fn take_if_std(self) -> Result<Option<T>, syn::Error> {
+        #[cfg(feature = "std")]
+        {
+            Ok(self.take())
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            if self.value.is_some() {
+                Err(syn::Error::new(
+                    self.span.unwrap_or_else(Span::call_site),
+                    format!(
+                        "capturing `{}` is only possible when the `std` Cargo feature is enabled",
+                        self.key
+                    ),
+                ))
+            } else {
+                Ok(None)
+            }
+        }
+    }
 }
 
 impl<T: Default> Arg<T> {

--- a/macros/src/emit.rs
+++ b/macros/src/emit.rs
@@ -14,6 +14,9 @@ pub struct ExpandTokens {
 }
 
 struct Args {
+    /*
+    NOTE: Also update docs in _Control Parameters_ for this macro when adding new args
+    */
     rt: args::RtArg,
     evt: Option<TokenStream>,
     mdl: args::MdlArg,

--- a/macros/src/fmt.rs
+++ b/macros/src/fmt.rs
@@ -42,6 +42,9 @@ pub fn template_hole_with_hook(
 }
 
 pub struct Args {
+    /*
+    NOTE: Also update docs in _Control Parameters_ for this macro when adding new args
+    */
     pub flags: String,
 }
 

--- a/macros/src/key.rs
+++ b/macros/src/key.rs
@@ -21,6 +21,9 @@ pub fn key_with_hook(attrs: &[Attribute], key_expr: &ExprLit) -> TokenStream {
 }
 
 pub struct Args {
+    /*
+    NOTE: Also update docs in _Control Parameters_ for this macro when adding new args
+    */
     pub name: Name,
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -364,16 +364,17 @@ where
 
 This macro accepts the following optional control parameters:
 
-| name      | type                          | description                                                                                                                                                    |
-| --------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rt`      | `impl emit::runtime::Runtime` | The runtime to emit the event through.                                                                                                                         |
-| `mdl`     | `impl Into<emit::Path>`       | The module the event belongs to. If unspecified the current module path is used.                                                                               |
-| `when`    | `impl emit::Filter`           | A filter to use instead of the one configured on the runtime.                                                                                                  |
-| `guard`   | -                             | An identifier to bind an `emit::Span` to in the body of the span for manual completion.                                                                        |
-| `ok_lvl`  | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.                                                    |
-| `err_lvl` | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.        |
-| `err`     | `impl Fn(&E) -> T`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `U` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static` |
-| `setup`   | `impl Fn() -> T`              | Invoke the expression before creating the span, binding the result to a value that's dropped at the end of the annotated function.                             |
+| name        | type                          | description                                                                                                                                                    |
+| ----------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rt`        | `impl emit::runtime::Runtime` | The runtime to emit the event through.                                                                                                                         |
+| `mdl`       | `impl Into<emit::Path>`       | The module the event belongs to. If unspecified the current module path is used.                                                                               |
+| `when`      | `impl emit::Filter`           | A filter to use instead of the one configured on the runtime.                                                                                                  |
+| `guard`     | -                             | An identifier to bind an `emit::Span` to in the body of the span for manual completion.                                                                        |
+| `ok_lvl`    | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.                                                    |
+| `err_lvl`   | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.        |
+| `panic_lvl` | `str` or `emit::Level`        | Detect whether the function panics and use the given level if it does.                                                                                         |
+| `err`       | `impl Fn(&E) -> T`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `U` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static` |
+| `setup`     | `impl Fn() -> T`              | Invoke the expression before creating the span, binding the result to a value that's dropped at the end of the annotated function.                             |
 
 # Template
 


### PR DESCRIPTION
Closes #111

This PR cleans up the way we thread parameters around the internals of spans, and makes it possible to mark a span as failing if it panics. It might be good to be able to catch panics and attach them at some point in the future, but this PR doesn't go that far because catching panics, especially in async code, is not entirely trivial. I think this is only really useful for testing, generally Rust code shouldn't expect to panic, but in those cases getting the panic payload would be useful.