### PR TITLE
Support timestamp normalization on Reporter

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -260,7 +260,7 @@ mod tests {
         drop(frame);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", not(miri)))]
     #[tokio::test]
     async fn frame_in_future() {
         let ctxt = crate::platform::thread_local_ctxt::ThreadLocalCtxt::new();

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -802,7 +802,7 @@ mod alloc_support {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use std::{cell::Cell, time::Duration};
+        use std::time::Duration;
 
         #[test]
         fn reporter_is_send_sync() {
@@ -812,7 +812,10 @@ mod alloc_support {
         }
 
         #[test]
+        #[cfg(not(miri))]
         fn reporter_sample() {
+            use std::cell::Cell;
+
             let mut reporter = Reporter::new();
 
             reporter
@@ -855,7 +858,7 @@ mod alloc_support {
         }
 
         #[test]
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(miri)))]
         fn reporter_normalize_std() {
             let mut reporter = Reporter::new();
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -640,8 +640,15 @@ mod alloc_support {
 
     # Normalization
 
-    The reporter will attempt to normalize the extents of any metrics sampled from its sources. When the `std` Cargo feature is enabled this will be done automatically.
-    In other cases, normalization won't happen unless it's configured by [`Reporter::normalize_with_clock`].
+    The reporter will attempt to normalize the extents of any metrics sampled from its sources. Normalization will:
+
+    1. Take the current timestamp, `now`, when sampling metrics.
+    2. If the metric sample has no extent, or has a point extent, it will be replaced with `now`.
+    3. If the metric sample has a range extent, the end will be set to `now` and the start will be `now` minus the original length. If this would produce an invlaid range then the original is kept.
+
+    When the `std` Cargo feature is enabled this will be done automatically. In other cases, normalization won't happen unless it's configured by [`Reporter::normalize_with_clock`].
+
+    Normalization can be disabled by calling [`Reporter::without_normalization`].
     */
     pub struct Reporter {
         sources: Vec<Box<dyn ErasedSource + Send + Sync>>,


### PR DESCRIPTION
Closes #119

This PR adds timestamp normalization support to `Reporter`. By default when the `std` feature is enabled, timestamps of sampled metrics will be normalized to a single value taken at the start of the call. Points will be assigned to this value and ranges will be shifted so the end is equal to it.