### PR TITLE
Re-instate filter::always

### DIFF
--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -344,11 +344,6 @@ impl<T: InternalFilter, U: InternalFilter> InternalFilter for crate::and::And<T,
 
 impl<T: InternalFilter, U: InternalFilter> InternalFilter for crate::or::Or<T, U> {}
 
-impl<T: InternalFilter, U: InternalEmitter> InternalEmitter
-    for crate::filter::FilteredEmitter<T, U>
-{
-}
-
 #[cfg(feature = "alloc")]
 impl<'a, T: ?Sized + InternalFilter> InternalFilter for alloc::boxed::Box<T> {}
 


### PR DESCRIPTION
This type is useful to use when attempting to by-pass normal filtering, and is more obvious as `emit::filter::always()` than as `emit::Empty`:

```rust
emit::info!(when: emit::filter::always(), "..");
```
