### PR TITLE
Allow consuming Option<&T> instead of mapping as &Option<T>

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -705,7 +705,21 @@ Specify that a property value of `None` should not be captured, instead of being
 
 # Syntax
 
-This macro doesn't accept any arguments.
+```text
+(control_param),*
+```
+
+where
+
+- `control_param`: A Rust field-value with a pre-determined identifier (see below).
+
+# Control parameters
+
+This macro accepts the following optional control parameters:
+
+| name     | type                          | description                                                                                             |
+| -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `is_ref` | `bool` | Whether the value is an `Option<&T>`. If `true`, the value will not be wrapped in an extra `&` before converting into a value. |
 
 # Applicable to
 

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -1,12 +1,29 @@
-use crate::hook;
+use crate::{
+    args::{self, Arg},
+    hook,
+};
 use proc_macro2::TokenStream;
-use syn::{parse::Parse, punctuated::Punctuated, token::Comma, Expr, Ident};
+use syn::{parse::Parse, punctuated::Punctuated, token::Comma, Expr, FieldValue, Ident};
 
-pub struct Args;
+pub struct Args {
+    /*
+    NOTE: Also update docs in _Control Parameters_ for this macro when adding new args
+    */
+    is_ref: bool,
+}
 
 impl Parse for Args {
-    fn parse(_: syn::parse::ParseStream) -> syn::Result<Self> {
-        Ok(Args)
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut is_ref = Arg::bool("is_ref");
+
+        args::set_from_field_values(
+            input.parse_terminated(FieldValue::parse, Token![,])?.iter(),
+            [&mut is_ref],
+        )?;
+
+        Ok(Args {
+            is_ref: is_ref.take_or_default(),
+        })
     }
 }
 
@@ -24,12 +41,22 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         predicate: |ident: &str| {
             ident.starts_with("__private_optional") || ident.starts_with("__private_captured")
         },
-        to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
+        to: move |Args { is_ref }: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident.to_string().starts_with("__private_captured") {
                 return None;
             }
 
-            let ident = Ident::new(&ident.to_string().replace("some", "option"), ident.span());
+            let ident = Ident::new(
+                &ident.to_string().replace(
+                    "some",
+                    if *is_ref {
+                        "option_by_value"
+                    } else {
+                        "option_by_ref"
+                    },
+                ),
+                ident.span(),
+            );
 
             Some((quote!(#ident), quote!(#args)))
         },

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -426,7 +426,9 @@ impl<T: CaptureLevel> CaptureLevel for Option<T> {
 pub trait __PrivateOptionalCaptureHook {
     fn __private_optional_capture_some(&self) -> Option<&Self>;
 
-    fn __private_optional_capture_option(&self) -> &Self;
+    fn __private_optional_capture_option_by_value(&self) -> &Self;
+
+    fn __private_optional_capture_option_by_ref(&self) -> &Self;
 }
 
 impl<T: ?Sized> __PrivateOptionalCaptureHook for T {
@@ -434,7 +436,11 @@ impl<T: ?Sized> __PrivateOptionalCaptureHook for T {
         Some(self)
     }
 
-    fn __private_optional_capture_option(&self) -> &Self {
+    fn __private_optional_capture_option_by_value(&self) -> &Self {
+        self
+    }
+
+    fn __private_optional_capture_option_by_ref(&self) -> &Self {
         self
     }
 }
@@ -442,7 +448,12 @@ impl<T: ?Sized> __PrivateOptionalCaptureHook for T {
 pub trait __PrivateOptionalMapHook<T> {
     fn __private_optional_map_some<F: FnOnce(T) -> Option<U>, U>(self, map: F) -> Option<U>;
 
-    fn __private_optional_map_option<'a, F: FnOnce(&'a T) -> Option<U>, U: 'a>(
+    fn __private_optional_map_option_by_value<F: FnOnce(T) -> Option<U>, U>(
+        self,
+        map: F,
+    ) -> Option<U>;
+
+    fn __private_optional_map_option_by_ref<'a, F: FnOnce(&'a T) -> Option<U>, U: 'a>(
         &'a self,
         map: F,
     ) -> Option<U>
@@ -455,7 +466,14 @@ impl<T> __PrivateOptionalMapHook<T> for Option<T> {
         self.and_then(map)
     }
 
-    fn __private_optional_map_option<'a, F: FnOnce(&'a T) -> Option<U>, U: 'a>(
+    fn __private_optional_map_option_by_value<F: FnOnce(T) -> Option<U>, U>(
+        self,
+        map: F,
+    ) -> Option<U> {
+        self.and_then(map)
+    }
+
+    fn __private_optional_map_option_by_ref<'a, F: FnOnce(&'a T) -> Option<U>, U: 'a>(
         &'a self,
         map: F,
     ) -> Option<U> {

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -324,6 +324,21 @@ fn props_optional() {
 }
 
 #[test]
+fn props_optional_ref() {
+    let s = String::from("short lived");
+
+    let some: Option<&str> = Some(&s);
+
+    match emit::props! {
+        #[emit::optional(is_ref: true)] some,
+    } {
+        props => {
+            assert_eq!("short lived", props.pull::<&str, _>("some").unwrap());
+        }
+    }
+}
+
+#[test]
 fn props_as_debug() {
     #[derive(Debug)]
     struct Data;


### PR DESCRIPTION
This PR allows using `#[emit::optional]` on values that are `Option<&T>` instead of just `Option<T>`. I haven't found a good way to handle the case of mapping `Option<T>` and `Option<&T>` in a non-consuming way without needing a hint in the attribute for it. We might be able to avoid it in the future.