### PR TITLE
Rework optional attribute to always require Option<&T>

### DIFF
--- a/examples/common_patterns/emit_optional_values.rs
+++ b/examples/common_patterns/emit_optional_values.rs
@@ -17,6 +17,16 @@ fn example() {
         #[emit::as_serde]
         user: None::<&str>,
     );
+
+    // The `optional` attribute is applicable to `Option<&T>`.
+    // If you have an `Option<T>`, you can call `as_ref()` on it:
+    let some = Some(1);
+
+    emit::info!(
+        "Hello, {user}",
+        #[emit::optional]
+        user: some.as_ref(),
+    );
 }
 
 fn main() {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -705,25 +705,11 @@ Specify that a property value of `None` should not be captured, instead of being
 
 # Syntax
 
-```text
-(control_param),*
-```
-
-where
-
-- `control_param`: A Rust field-value with a pre-determined identifier (see below).
-
-# Control parameters
-
-This macro accepts the following optional control parameters:
-
-| name     | type                          | description                                                                                             |
-| -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `is_ref` | `bool` | Whether the value is an `Option<&T>`. If `true`, the value will not be wrapped in an extra `&` before converting into a value. |
+This macro doesn't accept any arguments.
 
 # Applicable to
 
-This attribute can be applied to properties.
+This attribute can be applied to properties where the type is `Option<&T>`.
 */
 #[proc_macro_attribute]
 pub fn optional(

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -1,29 +1,16 @@
-use crate::{
-    args::{self, Arg},
-    hook,
-};
+use crate::hook;
 use proc_macro2::TokenStream;
-use syn::{parse::Parse, punctuated::Punctuated, token::Comma, Expr, FieldValue, Ident};
+use syn::{parse::Parse, punctuated::Punctuated, token::Comma, Expr, Ident};
 
 pub struct Args {
     /*
     NOTE: Also update docs in _Control Parameters_ for this macro when adding new args
     */
-    is_ref: bool,
 }
 
 impl Parse for Args {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let mut is_ref = Arg::bool("is_ref");
-
-        args::set_from_field_values(
-            input.parse_terminated(FieldValue::parse, Token![,])?.iter(),
-            [&mut is_ref],
-        )?;
-
-        Ok(Args {
-            is_ref: is_ref.take_or_default(),
-        })
+    fn parse(_: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Args {})
     }
 }
 
@@ -41,20 +28,13 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         predicate: |ident: &str| {
             ident.starts_with("__private_optional") || ident.starts_with("__private_captured")
         },
-        to: move |Args { is_ref }: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
+        to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident.to_string().starts_with("__private_captured") {
                 return None;
             }
 
             let ident = Ident::new(
-                &ident.to_string().replace(
-                    "some",
-                    if *is_ref {
-                        "option_by_value"
-                    } else {
-                        "option_by_ref"
-                    },
-                ),
+                &ident.to_string().replace("some", "option_ref"),
                 ident.span(),
             );
 

--- a/test/ui/src/compile_fail/std/emit_props_optional_non_ref.rs
+++ b/test/ui/src/compile_fail/std/emit_props_optional_non_ref.rs
@@ -1,0 +1,3 @@
+fn main() {
+    emit::emit!("template", #[emit::optional] some: Some(1));
+}

--- a/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
@@ -1,0 +1,19 @@
+error[E0277]: capturing an optional value requires `Option<&T>`. Try calling `.as_ref()`.
+ --> src/compile_fail/std/emit_props_optional_non_ref.rs:2:29
+  |
+2 |     emit::emit!("template", #[emit::optional] some: Some(1));
+  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Optional<'_>` is not implemented for `Option<{integer}>`
+  |
+  = help: the trait `Optional<'_>` is implemented for `Option<&_>`
+  = help: for that trait implementation, expected `&_`, found `{integer}`
+
+error[E0282]: type annotations needed for `&_`
+ --> src/compile_fail/std/emit_props_optional_non_ref.rs:2:29
+  |
+2 |     emit::emit!("template", #[emit::optional] some: Some(1));
+  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: consider giving this closure parameter an explicit type, where the placeholders `_` are specified
+  |
+2 |     emit::emit!("template", #[emit::optional] some: Some(1): &_);
+  |                                                            ++++

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -313,8 +313,8 @@ fn props_key() {
 #[test]
 fn props_optional() {
     match emit::props! {
-        #[emit::optional] some: Some(1),
-        #[emit::optional] none: None::<i32>,
+        #[emit::optional] some: Some(&1),
+        #[emit::optional] none: None::<&i32>,
     } {
         props => {
             assert_eq!(1, props.pull::<i32, _>("some").unwrap());
@@ -330,7 +330,7 @@ fn props_optional_ref() {
     let some: Option<&str> = Some(&s);
 
     match emit::props! {
-        #[emit::optional(is_ref: true)] some,
+        #[emit::optional] some,
     } {
         props => {
             assert_eq!("short lived", props.pull::<&str, _>("some").unwrap());


### PR DESCRIPTION
Followup to #151 

I found that the best approach to dealing with `&Option<T>` vs `Option<&T>` is just always require `Option<&T>`, because we can provide nicer compile errors, and calling `as_ref()` on options is a really common thing to do in Rust already.