### PR TITLE
Write error source chain to exception.stacktrace if present

### DIFF
--- a/emitter/otlp/src/data/resource.rs
+++ b/emitter/otlp/src/data/resource.rs
@@ -29,7 +29,11 @@ impl<P: emit::props::Props> sval::Value for PropsResourceAttributes<P> {
             &mut *stream,
             &RESOURCE_ATTRIBUTES_LABEL,
             &RESOURCE_ATTRIBUTES_INDEX,
-            |stream| stream_attributes(stream, &self.0, |k, v| Some((k, v))),
+            |stream| {
+                stream_attributes(stream, &self.0, |mut stream, k, v| {
+                    stream.stream_attribute(k, v)
+                })
+            },
         )?;
 
         stream.record_tuple_end(None, None, None)


### PR DESCRIPTION
Closes #158 

This PR writes the cause chain of an emitted error in the well-known `err` property into the `exception.stacktrace` attribute on the log record, or on the _exception_ span event in `emit_otlp`.

The value of the `exception.stacktrace` will include one line per cause, like:

```
caused by: there was a problem
caused by: IO error
```