### PR TITLE
Rework span completion to support adding props

### DIFF
--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -754,7 +754,7 @@ impl Worker {
 
         if file.is_none() {
             if let Err(err) = self.fs.create_dir_all(Path::new(&self.dir)) {
-                span.complete_with(|span| {
+                span.complete_with(emit::span::completion::from_fn(|span| {
                     emit::warn!(
                         rt: emit::runtime::internal(),
                         extent: span.extent(),
@@ -764,7 +764,7 @@ impl Worker {
                         path: &self.dir,
                         err,
                     )
-                });
+                }));
 
                 return Err(emit_batcher::BatchError::retry(err, batch));
             }
@@ -869,7 +869,7 @@ impl Worker {
             if let Err(err) = file.write_event(buf, self.separator) {
                 self.metrics.file_write_failed.increment();
 
-                span.complete_with(|span| {
+                span.complete_with(emit::span::completion::from_fn(|span| {
                     emit::warn!(
                         rt: emit::runtime::internal(),
                         extent: span.extent(),
@@ -879,7 +879,7 @@ impl Worker {
                         path: file.file_path,
                         err,
                     )
-                });
+                }));
 
                 return Err(emit_batcher::BatchError::retry(err, batch));
             }
@@ -894,7 +894,7 @@ impl Worker {
             .sync_all()
             .map_err(|e| emit_batcher::BatchError::no_retry(e))?;
 
-        span.complete_with(|span| {
+        span.complete_with(emit::span::completion::from_fn(|span| {
             emit::debug!(
                 rt: emit::runtime::internal(),
                 extent: span.extent(),
@@ -904,7 +904,7 @@ impl Worker {
                 #[emit::as_debug]
                 path: file.file_path,
             )
-        });
+        }));
 
         // Set the active file so the next batch can attempt to use it
         // At this point the file is expected to be valid

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -565,19 +565,19 @@ impl<R: data::RequestEncoder> OtlpTransport<R> {
                     .await
                 {
                     Ok(res) => {
-                        span.complete_with(|evt| {
+                        span.complete_with(emit::span::completion::from_fn(|evt| {
                             emit::debug!(
                                 rt: emit::runtime::internal(),
                                 evt,
                                 "OTLP batch of {batch_size} events to {uri}",
                                 batch_size,
                             )
-                        });
+                        }));
 
                         res
                     }
                     Err(err) => {
-                        span.complete_with(|evt| {
+                        span.complete_with(emit::span::completion::from_fn(|evt| {
                             emit::warn!(
                                 rt: emit::runtime::internal(),
                                 evt,
@@ -585,7 +585,7 @@ impl<R: data::RequestEncoder> OtlpTransport<R> {
                                 batch_size,
                                 err,
                             )
-                        });
+                        }));
 
                         return Err(BatchError::retry(err, batch));
                     }

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -634,7 +634,7 @@ fn add(a: i32, b: i32) -> i32 {
    let r = a + b;
 
    if r == 4 {
-      span.complete_with(|evt| {
+      span.complete_with(emit::span::completion::from_fn(|evt| {
             emit::error!(
                evt,
                "Compute {a} + {b} failed",
@@ -643,7 +643,7 @@ fn add(a: i32, b: i32) -> i32 {
                r,
                err: "Invalid result",
             );
-      });
+      }));
    }
 
    r

--- a/examples/common_patterns/emit_debug_values.rs
+++ b/examples/common_patterns/emit_debug_values.rs
@@ -4,13 +4,13 @@ This example demonstrates how to emit complex values using `std::fmt`.
 
 use std::time::Duration;
 
-fn example() {
-    #[derive(Debug)]
-    pub struct User<'a> {
-        id: usize,
-        name: &'a str,
-    }
+#[derive(Debug)]
+pub struct User<'a> {
+    pub id: usize,
+    pub name: &'a str,
+}
 
+fn example() {
     // The `emit::as_debug` attribute captures a property
     // using its `fmt::Debug` implementation
     emit::info!(

--- a/examples/common_patterns/span_manual_completion.rs
+++ b/examples/common_patterns/span_manual_completion.rs
@@ -16,13 +16,13 @@ fn example(i: i32) {
     let r = i + 1;
 
     if r == 4 {
-        span.complete_with(|evt| {
+        span.complete_with(emit::span::completion::from_fn(|evt| {
             emit::error!(evt, "Running an example failed with {r}");
-        });
+        }));
     } else {
-        span.complete_with(|evt| {
+        span.complete_with(emit::span::completion::from_fn(|evt| {
             emit::info!(evt, "Running an example produced {r}");
-        });
+        }));
     }
 }
 

--- a/examples/common_patterns/span_trace_propagation.rs
+++ b/examples/common_patterns/span_trace_propagation.rs
@@ -71,9 +71,9 @@ fn routes(method: &str, path: &str) {
     match path {
         "/api/route-1" => api_route_1(),
         _ => {
-            span.complete_with(|evt| {
+            span.complete_with(emit::span::completion::from_fn(|evt| {
                 emit::error!(evt, "HTTP {method} {path} matched no route");
-            });
+            }));
         }
     }
 }

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -300,7 +300,13 @@ fn inject_sync(
 
         let #span_guard = &mut __span_guard;
 
-        #body_tokens
+        let __r = #body_tokens;
+
+        #[allow(unreachable_code)]
+        {
+            __span_guard.complete();
+            __r
+        }
     }))
 }
 
@@ -374,7 +380,13 @@ fn inject_async(
         __ctxt.in_future(async move {
             let #span_guard = &mut __span_guard;
 
-            #body_tokens
+            let __r = #body_tokens;
+
+            #[allow(unreachable_code)]
+            {
+                __span_guard.complete();
+                __r
+            }
         }).await
     }))
 }

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -862,9 +862,18 @@ pub fn __private_begin_span<
 }
 
 #[track_caller]
-pub fn __private_complete_span<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rng>(
+pub fn __private_complete_span<
+    'a,
+    'b,
+    E: Emitter,
+    F: Filter,
+    C: Ctxt,
+    T: Clock,
+    R: Rng,
+    P: Props,
+>(
     rt: &'a Runtime<E, F, C, T, R>,
-    span: Span<'static, Empty>,
+    span: Span<'b, P>,
     tpl: &'b (impl TplControlParam + ?Sized),
     lvl: Option<&'b (impl CaptureLevel + ?Sized)>,
     panic_lvl: Option<&'b (impl CaptureLevel + ?Sized)>,
@@ -934,9 +943,18 @@ fn is_panicking() -> bool {
 }
 
 #[track_caller]
-pub fn __private_complete_span_ok<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rng>(
+pub fn __private_complete_span_ok<
+    'a,
+    'b,
+    E: Emitter,
+    F: Filter,
+    C: Ctxt,
+    T: Clock,
+    R: Rng,
+    P: Props,
+>(
     rt: &'a Runtime<E, F, C, T, R>,
-    span: Span<'static, Empty>,
+    span: Span<'b, P>,
     tpl: &'b (impl TplControlParam + ?Sized),
     lvl: Option<&'b (impl CaptureLevel + ?Sized)>,
 ) {
@@ -954,9 +972,18 @@ pub fn __private_complete_span_ok<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clo
 }
 
 #[track_caller]
-pub fn __private_complete_span_err<'a, 'b, E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rng>(
+pub fn __private_complete_span_err<
+    'a,
+    'b,
+    E: Emitter,
+    F: Filter,
+    C: Ctxt,
+    T: Clock,
+    R: Rng,
+    P: Props,
+>(
     rt: &'a Runtime<E, F, C, T, R>,
-    span: Span<'static, Empty>,
+    span: Span<'b, P>,
     tpl: &'b (impl TplControlParam + ?Sized),
     lvl: &'b (impl CaptureLevel + ?Sized),
     err: &'b (impl CaptureAsError + ?Sized),

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -28,7 +28,7 @@ use crate::{frame::Frame, span::Span};
 use std::error::Error;
 
 use crate::{
-    span::{SpanCtxt, SpanGuard, SpanId, TraceId},
+    span::{Completion, SpanCtxt, SpanGuard, SpanId, TraceId},
     Level, Timer,
 };
 
@@ -816,7 +816,7 @@ pub fn __private_begin_span<
     C: Ctxt,
     T: Clock,
     R: Rng,
-    S: FnOnce(Span<'static, Empty>),
+    S: Completion,
 >(
     rt: &'a Runtime<E, F, C, T, R>,
     mdl: impl Into<Path<'static>>,

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -955,12 +955,12 @@ pub mod sampler {
 
     This type can be created directly, or via [`from_fn`].
     */
-    pub struct FromFn<F = fn(&Metric<&dyn ErasedProps>)>(F);
+    pub struct FromFn<F = fn(Metric<&dyn ErasedProps>)>(F);
 
     /**
     Create a [`Sampler`] from a function.
     */
-    pub const fn from_fn<F: Fn(&Metric<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
+    pub const fn from_fn<F: Fn(Metric<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
         FromFn(f)
     }
 
@@ -973,9 +973,9 @@ pub mod sampler {
         }
     }
 
-    impl<F: Fn(&Metric<&dyn ErasedProps>)> Sampler for FromFn<F> {
+    impl<F: Fn(Metric<&dyn ErasedProps>)> Sampler for FromFn<F> {
         fn metric<P: Props>(&self, metric: Metric<P>) {
-            (self.0)(&metric.erase())
+            (self.0)(metric.erase())
         }
     }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -919,12 +919,12 @@ pub mod completion {
 
     This type can be created directly, or via [`from_fn`].
     */
-    pub struct FromFn<F = fn(&Span<&dyn ErasedProps>)>(F);
+    pub struct FromFn<F = fn(Span<&dyn ErasedProps>)>(F);
 
     /**
     Create a [`Completion`] from a function.
     */
-    pub const fn from_fn<F: Fn(&Span<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
+    pub const fn from_fn<F: Fn(Span<&dyn ErasedProps>)>(f: F) -> FromFn<F> {
         FromFn(f)
     }
 
@@ -937,9 +937,9 @@ pub mod completion {
         }
     }
 
-    impl<F: Fn(&Span<&dyn ErasedProps>)> Completion for FromFn<F> {
+    impl<F: Fn(Span<&dyn ErasedProps>)> Completion for FromFn<F> {
         fn complete<P: Props>(&self, span: Span<P>) {
-            (self.0)(&span.erase())
+            (self.0)(span.erase())
         }
     }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -729,7 +729,7 @@ An active span in a distributed trace.
 
 This type is created by the [`macro@crate::span!`] macro with the `guard` control parameter. See the [`mod@crate::span`] module for details on creating spans.
 
-Call [`SpanGuard::complete_with`], or just drop the guard to complete it, emitting a [`Span`] for its execution.
+Call [`SpanGuard::complete_with`], or just drop the guard to complete it, passing the resulting [`Span`] to a [`Completion`].
 */
 pub struct SpanGuard<'a, C: Clock, P: Props, F: Completion> {
     // `state` is `None` if the span is completed

--- a/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
@@ -2,7 +2,7 @@ error[E0277]: capturing requires `NotDisplay` implements `Display + Any` by defa
  --> src/compile_fail/std/emit_props_non_display_interpolated.rs:4:28
   |
 4 |     emit::emit!("template {x}");
-  |                            ^ the trait `std::fmt::Display` is not implemented for `NotDisplay`, which is required by `NotDisplay: CaptureWithDefault`
+  |                            ^ the trait `std::fmt::Display` is not implemented for `NotDisplay`
   |
   = help: the trait `CaptureWithDefault` is implemented for `str`
   = note: required for `NotDisplay` to implement `CaptureWithDefault`

--- a/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
@@ -2,7 +2,7 @@ error[E0277]: capturing requires `NotDisplay` implements `Display + Any` by defa
  --> src/compile_fail/std/emit_props_non_display_interpolated.rs:4:28
   |
 4 |     emit::emit!("template {x}");
-  |                            ^ the trait `std::fmt::Display` is not implemented for `NotDisplay`
+  |                            ^ the trait `std::fmt::Display` is not implemented for `NotDisplay`, which is required by `NotDisplay: CaptureWithDefault`
   |
   = help: the trait `CaptureWithDefault` is implemented for `str`
   = note: required for `NotDisplay` to implement `CaptureWithDefault`

--- a/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
@@ -4,7 +4,8 @@ error[E0277]: capturing an optional value requires `Option<&T>`. Try calling `.a
 2 |     emit::emit!("template", #[emit::optional] some: Some(1));
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Optional<'_>` is not implemented for `Option<{integer}>`
   |
-  = help: the trait `Optional<'_>` is implemented for `Option<&_>`
+  = help: the trait `Optional<'_>` is not implemented for `Option<{integer}>`
+          but it is implemented for `Option<&_>`
   = help: for that trait implementation, expected `&_`, found `{integer}`
 
 error[E0282]: type annotations needed for `&_`

--- a/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
@@ -4,8 +4,7 @@ error[E0277]: capturing an optional value requires `Option<&T>`. Try calling `.a
 2 |     emit::emit!("template", #[emit::optional] some: Some(1));
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Optional<'_>` is not implemented for `Option<{integer}>`
   |
-  = help: the trait `Optional<'_>` is not implemented for `Option<{integer}>`
-          but it is implemented for `Option<&_>`
+  = help: the trait `Optional<'_>` is implemented for `Option<&_>`
   = help: for that trait implementation, expected `&_`, found `{integer}`
 
 error[E0282]: type annotations needed for `&_`

--- a/test/ui/src/compile_fail/std/span_guard_err.rs
+++ b/test/ui/src/compile_fail/std/span_guard_err.rs
@@ -1,0 +1,16 @@
+use std::io;
+
+#[emit::span(rt: RT, guard: span, err: (|err| err), "test")]
+pub fn exec(fail: bool) -> Result<bool, io::Error> {
+    if fail {
+        return Err(io::Error::new(io::ErrorKind::Other, "failed"));
+    }
+
+    span.complete();
+
+    Ok(true)
+}
+
+fn main() {
+
+}

--- a/test/ui/src/compile_fail/std/span_guard_err.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_err.stderr
@@ -1,0 +1,13 @@
+error: the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
+ --> src/compile_fail/std/span_guard_err.rs:3:29
+  |
+3 | #[emit::span(rt: RT, guard: span, err: (|err| err), "test")]
+  |                             ^^^^
+
+warning: unused import: `std::io`
+ --> src/compile_fail/std/span_guard_err.rs:1:5
+  |
+1 | use std::io;
+  |     ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/test/ui/src/compile_fail/std/span_guard_err_lvl.rs
+++ b/test/ui/src/compile_fail/std/span_guard_err_lvl.rs
@@ -1,0 +1,16 @@
+use std::io;
+
+#[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
+pub fn exec(fail: bool) -> Result<bool, io::Error> {
+    if fail {
+        return Err(io::Error::new(io::ErrorKind::Other, "failed"));
+    }
+
+    span.complete();
+
+    Ok(true)
+}
+
+fn main() {
+
+}

--- a/test/ui/src/compile_fail/std/span_guard_err_lvl.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_err_lvl.stderr
@@ -1,0 +1,13 @@
+error: the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
+ --> src/compile_fail/std/span_guard_err_lvl.rs:3:29
+  |
+3 | #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
+  |                             ^^^^
+
+warning: unused import: `std::io`
+ --> src/compile_fail/std/span_guard_err_lvl.rs:1:5
+  |
+1 | use std::io;
+  |     ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/test/ui/src/compile_fail/std/span_guard_ok_lvl.rs
+++ b/test/ui/src/compile_fail/std/span_guard_ok_lvl.rs
@@ -1,0 +1,16 @@
+use std::io;
+
+#[emit::span(rt: RT, guard: span, ok_lvl: emit::Level::Info, "test")]
+pub fn exec(fail: bool) -> Result<bool, io::Error> {
+    if fail {
+        return Err(io::Error::new(io::ErrorKind::Other, "failed"));
+    }
+
+    span.complete();
+
+    Ok(true)
+}
+
+fn main() {
+
+}

--- a/test/ui/src/compile_fail/std/span_guard_ok_lvl.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_ok_lvl.stderr
@@ -1,0 +1,13 @@
+error: the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
+ --> src/compile_fail/std/span_guard_ok_lvl.rs:3:29
+  |
+3 | #[emit::span(rt: RT, guard: span, ok_lvl: emit::Level::Info, "test")]
+  |                             ^^^^
+
+warning: unused import: `std::io`
+ --> src/compile_fail/std/span_guard_ok_lvl.rs:1:5
+  |
+1 | use std::io;
+  |     ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -387,6 +387,45 @@ fn span_explicit_ids() {
     assert!(CALLED.was_called());
 }
 
+#[tokio::test]
+async fn async_span_explicit_ids() {
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(emit::TraceId::from_u128(1), evt.props().pull("trace_id"));
+            assert_eq!(emit::SpanId::from_u64(2), evt.props().pull("span_parent"));
+            assert_eq!(emit::SpanId::from_u64(3), evt.props().pull("span_id"));
+
+            CALLED.record();
+        },
+        |evt| {
+            assert_eq!(emit::TraceId::from_u128(1), evt.props().pull("trace_id"));
+            assert_eq!(emit::SpanId::from_u64(2), evt.props().pull("span_parent"));
+            assert_eq!(emit::SpanId::from_u64(3), evt.props().pull("span_id"));
+
+            true
+        },
+    );
+
+    #[emit::span(rt: RT, "test", trace_id, span_parent, span_id)]
+    async fn exec(trace_id: &str, span_parent: &str, span_id: &str) {
+        let ctxt = emit::SpanCtxt::current(RT.ctxt());
+
+        assert_eq!(emit::TraceId::from_u128(1), ctxt.trace_id().copied());
+        assert_eq!(emit::SpanId::from_u64(2), ctxt.span_parent().copied());
+        assert_eq!(emit::SpanId::from_u64(3), ctxt.span_id().copied());
+    }
+
+    exec(
+        "00000000000000000000000000000001",
+        "0000000000000002",
+        "0000000000000003",
+    )
+    .await;
+
+    assert!(CALLED.was_called());
+}
+
 #[test]
 fn span_explicit_ids_ctxt() {
     static CALLED: StaticCalled = StaticCalled::new();

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -281,7 +281,7 @@ fn span_guard() {
 
     #[emit::span(rt: RT, guard: span, "test")]
     fn exec() {
-        let span: &mut emit::span::SpanGuard<_, _, _> = span;
+        let span: emit::span::SpanGuard<_, _, _> = span;
         span.complete();
     }
 
@@ -685,48 +685,6 @@ async fn span_err_lvl_impl_return_async() {
         if fail {
             return Err(io::Error::new(io::ErrorKind::Other, "failed"));
         }
-
-        Ok(true)
-    }
-
-    exec(true).await.unwrap_err();
-}
-
-#[test]
-#[cfg(feature = "std")]
-fn span_err_lvl_guard() {
-    use std::io;
-
-    static RT: StaticRuntime = static_runtime(|_| {}, |_| true);
-
-    #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
-    fn exec(fail: bool) -> Result<bool, io::Error> {
-        if fail {
-            return Err(io::Error::new(io::ErrorKind::Other, "failed"));
-        }
-
-        span.complete();
-
-        Ok(true)
-    }
-
-    exec(true).unwrap_err();
-}
-
-#[tokio::test]
-#[cfg(feature = "std")]
-async fn span_err_lvl_guard_async() {
-    use std::io;
-
-    static RT: StaticRuntime = static_runtime(|_| {}, |_| true);
-
-    #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
-    async fn exec(fail: bool) -> Result<bool, io::Error> {
-        if fail {
-            return Err(io::Error::new(io::ErrorKind::Other, "failed"));
-        }
-
-        span.complete();
 
         Ok(true)
     }

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -658,10 +658,7 @@ async fn span_err_lvl_impl_return_async() {
 fn span_err_lvl_guard() {
     use std::io;
 
-    static RT: StaticRuntime = static_runtime(
-        |_| { },
-        |_| true,
-    );
+    static RT: StaticRuntime = static_runtime(|_| {}, |_| true);
 
     #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
     fn exec(fail: bool) -> Result<bool, io::Error> {
@@ -682,10 +679,7 @@ fn span_err_lvl_guard() {
 async fn span_err_lvl_guard_async() {
     use std::io;
 
-    static RT: StaticRuntime = static_runtime(
-        |_| { },
-        |_| true,
-    );
+    static RT: StaticRuntime = static_runtime(|_| {}, |_| true);
 
     #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
     async fn exec(fail: bool) -> Result<bool, io::Error> {

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -281,7 +281,7 @@ fn span_guard() {
 
     #[emit::span(rt: RT, guard: span, "test")]
     fn exec() {
-        let span: emit::span::SpanGuard<_, _, _> = span;
+        let span: &mut emit::span::SpanGuard<_, _, _> = span;
         span.complete();
     }
 
@@ -646,6 +646,54 @@ async fn span_err_lvl_impl_return_async() {
         if fail {
             return Err(io::Error::new(io::ErrorKind::Other, "failed"));
         }
+
+        Ok(true)
+    }
+
+    exec(true).await.unwrap_err();
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn span_err_lvl_guard() {
+    use std::io;
+
+    static RT: StaticRuntime = static_runtime(
+        |_| { },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
+    fn exec(fail: bool) -> Result<bool, io::Error> {
+        if fail {
+            return Err(io::Error::new(io::ErrorKind::Other, "failed"));
+        }
+
+        span.complete();
+
+        Ok(true)
+    }
+
+    exec(true).unwrap_err();
+}
+
+#[tokio::test]
+#[cfg(feature = "std")]
+async fn span_err_lvl_guard_async() {
+    use std::io;
+
+    static RT: StaticRuntime = static_runtime(
+        |_| { },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
+    async fn exec(fail: bool) -> Result<bool, io::Error> {
+        if fail {
+            return Err(io::Error::new(io::ErrorKind::Other, "failed"));
+        }
+
+        span.complete();
 
         Ok(true)
     }


### PR DESCRIPTION
Closes #166 
Closes #167 

This PR reworks the `SpanGuard` type to not rely on the props type `P` on its resulting span. This means we can change `P` while the span executes, such as by pushing properties to it, without needing to rewrite its completion function.

I've also made span completion take `&mut self`, so you can use guards and do manual completion as well as automatic result completion without them conflicting.