### PR TITLE
Rename safe _unchecked methods to _raw

### DIFF
--- a/core/src/emitter.rs
+++ b/core/src/emitter.rs
@@ -388,12 +388,7 @@ pub mod wrapping {
 
                 wrapping.wrap(
                     Empty,
-                    Event::new(
-                        Path::new_unchecked("a"),
-                        Template::literal("test"),
-                        Empty,
-                        Empty,
-                    ),
+                    Event::new(Path::new_raw("a"), Template::literal("test"), Empty, Empty),
                 );
             }
 
@@ -410,12 +405,7 @@ pub mod wrapping {
 
             wrapping.wrap(
                 Empty,
-                Event::new(
-                    Path::new_unchecked("a"),
-                    Template::literal("test"),
-                    Empty,
-                    Empty,
-                ),
+                Event::new(Path::new_raw("a"), Template::literal("test"), Empty, Empty),
             );
 
             assert_eq!(1, calls.get());
@@ -535,7 +525,7 @@ mod tests {
             let emitter = &emitter as &dyn ErasedEmitter;
 
             emitter.emit(Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 Template::literal("event 1"),
                 Empty,
                 Empty,
@@ -553,7 +543,7 @@ mod tests {
             (None, vec![]),
         ] {
             emitter.emit(Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 Template::literal("event 1"),
                 Empty,
                 Empty,
@@ -571,13 +561,13 @@ mod tests {
         let count = Cell::new(0);
 
         let emitter = from_fn(|evt| {
-            assert_eq!(Path::new_unchecked("a"), evt.mdl());
+            assert_eq!(Path::new_raw("a"), evt.mdl());
 
             count.set(count.get() + 1);
         });
 
         emitter.emit(Event::new(
-            Path::new_unchecked("a"),
+            Path::new_raw("a"),
             Template::literal("event 1"),
             Empty,
             Empty,
@@ -591,7 +581,7 @@ mod tests {
         let emitter = MyEmitter::new().and_to(MyEmitter::new());
 
         emitter.emit(Event::new(
-            Path::new_unchecked("a"),
+            Path::new_raw("a"),
             Template::literal("event 1"),
             Empty,
             Empty,
@@ -615,7 +605,7 @@ mod tests {
         }));
 
         emitter.emit(Event::new(
-            Path::new_unchecked("a"),
+            Path::new_raw("a"),
             Template::literal("event 1"),
             Empty,
             Empty,

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn event_new() {
         let evt = Event::new(
-            Path::new_unchecked("module"),
+            Path::new_raw("module"),
             Template::literal("An event"),
             Extent::range(Timestamp::MIN..Timestamp::MAX),
             [
@@ -282,7 +282,7 @@ mod tests {
         );
 
         fn assert(evt: &Event<impl Props>) {
-            assert_eq!(Path::new_unchecked("module"), evt.mdl());
+            assert_eq!(Path::new_raw("module"), evt.mdl());
             assert_eq!(
                 Timestamp::MIN..Timestamp::MAX,
                 evt.extent().unwrap().as_range().unwrap().clone()

--- a/core/src/filter.rs
+++ b/core/src/filter.rs
@@ -232,7 +232,7 @@ mod tests {
             assert_eq!(
                 matches,
                 case.matches(Event::new(
-                    Path::new_unchecked("module"),
+                    Path::new_raw("module"),
                     Template::literal("Event"),
                     Empty,
                     Empty,
@@ -251,7 +251,7 @@ mod tests {
                 assert_eq!(
                     a && b,
                     fa.and_when(fb).matches(Event::new(
-                        Path::new_unchecked("module"),
+                        Path::new_raw("module"),
                         Template::literal("Event"),
                         Empty,
                         Empty,
@@ -271,7 +271,7 @@ mod tests {
                 assert_eq!(
                     a || b,
                     fa.or_when(fb).matches(Event::new(
-                        Path::new_unchecked("module"),
+                        Path::new_raw("module"),
                         Template::literal("Event"),
                         Empty,
                         Empty,
@@ -283,17 +283,17 @@ mod tests {
 
     #[test]
     fn from_fn_filter() {
-        let f = from_fn(|evt| evt.mdl() == Path::new_unchecked("module"));
+        let f = from_fn(|evt| evt.mdl() == Path::new_raw("module"));
 
         assert!(f.matches(Event::new(
-            Path::new_unchecked("module"),
+            Path::new_raw("module"),
             Template::literal("Event"),
             Empty,
             Empty,
         )));
 
         assert!(!f.matches(Event::new(
-            Path::new_unchecked("not_module"),
+            Path::new_raw("not_module"),
             Template::literal("Event"),
             Empty,
             Empty,
@@ -305,7 +305,7 @@ mod tests {
         let f = always();
 
         assert!(f.matches(Event::new(
-            Path::new_unchecked("module"),
+            Path::new_raw("module"),
             Template::literal("Event"),
             Empty,
             Empty,
@@ -318,7 +318,7 @@ mod tests {
         let f = &f as &dyn ErasedFilter;
 
         assert!(f.matches(Event::new(
-            Path::new_unchecked("module"),
+            Path::new_raw("module"),
             Template::literal("Event"),
             Empty,
             Empty,
@@ -328,7 +328,7 @@ mod tests {
         let f = &f as &dyn ErasedFilter;
 
         assert!(!f.matches(Event::new(
-            Path::new_unchecked("module"),
+            Path::new_raw("module"),
             Template::literal("Event"),
             Empty,
             Empty,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
             MyCtxt("ctxt_prop", 13),
             MyClock(timestamp::Timestamp::from_unix(Duration::from_secs(77))),
             event::Event::new(
-                path::Path::new_unchecked("test"),
+                path::Path::new_raw("test"),
                 template::Template::literal("text"),
                 empty::Empty,
                 ("evt_prop", true),
@@ -154,7 +154,7 @@ mod tests {
             empty::Empty,
             empty::Empty,
             event::Event::new(
-                path::Path::new_unchecked("test"),
+                path::Path::new_raw("test"),
                 template::Template::literal("text"),
                 empty::Empty,
                 ("evt_prop", true),

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -61,8 +61,8 @@ impl Path<'static> {
 
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
-    pub const fn new_unchecked(path: &'static str) -> Self {
-        Path::new_str_unchecked(Str::new(path))
+    pub const fn new_raw(path: &'static str) -> Self {
+        Path::new_str_raw(Str::new(path))
     }
 }
 
@@ -81,12 +81,12 @@ impl<'a> Path<'a> {
     /**
     Create a path from a raw borrowed value without checking its validity.
 
-    The [`Path::new_unchecked`] method should be preferred where possible.
+    The [`Path::new_raw`] method should be preferred where possible.
 
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
-    pub const fn new_ref_unchecked(path: &'a str) -> Self {
-        Self::new_str_unchecked(Str::new_ref(path))
+    pub const fn new_ref_raw(path: &'a str) -> Self {
+        Self::new_str_raw(Str::new_ref(path))
     }
 
     /**
@@ -107,7 +107,7 @@ impl<'a> Path<'a> {
 
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
-    pub const fn new_str_unchecked(path: Str<'a>) -> Self {
+    pub const fn new_str_raw(path: Str<'a>) -> Self {
         Path(path)
     }
 
@@ -375,8 +375,8 @@ mod alloc_support {
 
         This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
         */
-        pub fn new_owned_unchecked(path: impl Into<Box<str>>) -> Self {
-            Path::new_str_unchecked(Str::new_owned(path))
+        pub fn new_owned_raw(path: impl Into<Box<str>>) -> Self {
+            Path::new_str_raw(Str::new_owned(path))
         }
     }
 
@@ -395,12 +395,12 @@ mod alloc_support {
         /**
         Create a path from a potentially owned raw value without checking its validity.
 
-        If the value is `Cow::Borrowed` then this method will defer to [`Path::new_ref_unchecked`]. If the value is `Cow::Owned` then this method will defer to [`Path::new_owned_unchecked`].
+        If the value is `Cow::Borrowed` then this method will defer to [`Path::new_ref_raw`]. If the value is `Cow::Owned` then this method will defer to [`Path::new_owned_raw`].
 
         This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
         */
-        pub fn new_cow_ref_unchecked(path: Cow<'a, str>) -> Self {
-            Path::new_str_unchecked(Str::new_cow_ref(path))
+        pub fn new_cow_ref_raw(path: Cow<'a, str>) -> Self {
+            Path::new_str_raw(Str::new_cow_ref(path))
         }
 
         /**
@@ -427,7 +427,7 @@ mod alloc_support {
 
             base.push_str("::");
             base.push_str(other.into().0.get());
-            Path::new_owned_unchecked(base)
+            Path::new_owned_raw(base)
         }
     }
 
@@ -437,7 +437,7 @@ mod alloc_support {
 
         #[test]
         fn to_owned() {
-            let path = Path::new_ref_unchecked("module");
+            let path = Path::new_ref_raw("module");
 
             assert_eq!(path, path.to_owned());
         }
@@ -445,11 +445,8 @@ mod alloc_support {
         #[test]
         fn to_cow() {
             for (path, expected) in [
-                (Path::new_unchecked("module"), Cow::Borrowed("module")),
-                (
-                    Path::new_ref_unchecked("module"),
-                    Cow::Owned("module".to_owned()),
-                ),
+                (Path::new_raw("module"), Cow::Borrowed("module")),
+                (Path::new_ref_raw("module"), Cow::Owned("module".to_owned())),
             ] {
                 assert_eq!(expected, path.to_cow());
             }
@@ -462,13 +459,7 @@ mod alloc_support {
                 ("a::b", "c", "a::b::c"),
                 ("a", "b::c", "a::b::c"),
             ] {
-                assert_eq!(
-                    expected,
-                    Path::new_unchecked(a)
-                        .append(Path::new_unchecked(&b))
-                        .0
-                        .get(),
-                );
+                assert_eq!(expected, Path::new_raw(a).append(Path::new_raw(&b)).0.get(),);
             }
         }
     }
@@ -480,7 +471,7 @@ mod tests {
 
     #[test]
     fn by_ref() {
-        let path = Path::new_unchecked("module");
+        let path = Path::new_raw("module");
 
         assert_eq!(path, path.by_ref());
     }
@@ -542,7 +533,7 @@ mod tests {
 
     #[test]
     fn to_from_value() {
-        let path = Path::new_unchecked("module");
+        let path = Path::new_raw("module");
 
         for value in [Value::from_any(&path), Value::from("module")] {
             assert_eq!(path, value.cast::<Path>().unwrap());

--- a/macros/src/build.rs
+++ b/macros/src/build.rs
@@ -110,7 +110,7 @@ pub fn expand_path_tokens(opts: ExpandPathTokens) -> Result<TokenStream, syn::Er
     let path = path.value();
 
     if emit_core::path::is_valid_path(&path) {
-        Ok(quote!(emit::Path::new_unchecked(#path)))
+        Ok(quote!(emit::Path::new_raw(#path)))
     } else {
         Err(syn::Error::new(span, "the value is not a valid path"))
     }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -223,21 +223,21 @@ mod tests {
         let filter = KindFilter::new(Kind::Span);
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_EVT_KIND, EVENT_KIND_SPAN),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_EVT_KIND, EVENT_KIND_METRIC),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             crate::Empty,

--- a/src/level.rs
+++ b/src/level.rs
@@ -411,17 +411,17 @@ mod alloc_support {
         fn min_level() {
             let mut filter = MinLevelPathMap::new();
 
-            filter.min_level(Path::new_unchecked("a"), Level::Error);
+            filter.min_level(Path::new_raw("a"), Level::Error);
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
             )));
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Error),
@@ -435,14 +435,14 @@ mod alloc_support {
             filter.default_min_level(Level::Error);
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
             )));
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Error),
@@ -454,25 +454,25 @@ mod alloc_support {
             let mut filter = MinLevelPathMap::new();
 
             filter
-                .min_level(Path::new_unchecked("a"), Level::Error)
-                .min_level(Path::new_unchecked("a::b::c"), Level::Warn);
+                .min_level(Path::new_raw("a"), Level::Error)
+                .min_level(Path::new_raw("a::b::c"), Level::Warn);
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
             )));
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("a::b"),
+                Path::new_raw("a::b"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
             )));
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("a::b::c"),
+                Path::new_raw("a::b::c"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
@@ -483,10 +483,10 @@ mod alloc_support {
         fn min_level_unmatched() {
             let mut filter = MinLevelPathMap::new();
 
-            filter.min_level(Path::new_unchecked("a"), Level::Error);
+            filter.min_level(Path::new_raw("a"), Level::Error);
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("b"),
+                Path::new_raw("b"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
@@ -499,10 +499,10 @@ mod alloc_support {
 
             filter
                 .default_min_level(Level::Error)
-                .min_level(Path::new_unchecked("a"), Level::Error);
+                .min_level(Path::new_raw("a"), Level::Error);
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("b"),
+                Path::new_raw("b"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, Level::Warn),
@@ -515,31 +515,31 @@ mod alloc_support {
 
             filter
                 .default_min_level(MinLevelFilter::new(3))
-                .min_level(Path::new_unchecked("a"), MinLevelFilter::new(1));
+                .min_level(Path::new_raw("a"), MinLevelFilter::new(1));
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, 2),
             )));
 
             assert!(filter.matches(crate::Event::new(
-                Path::new_unchecked("b"),
+                Path::new_raw("b"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, 6),
             )));
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("a"),
+                Path::new_raw("a"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, 0),
             )));
 
             assert!(!filter.matches(crate::Event::new(
-                Path::new_unchecked("b"),
+                Path::new_raw("b"),
                 crate::Template::literal("test"),
                 crate::Empty,
                 (KEY_LVL, 2),
@@ -625,35 +625,35 @@ mod tests {
         let filter = MinLevelFilter::new(Level::Warn);
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_ERROR),
         )));
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_WARN),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             crate::Empty,
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_DEBUG),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_INFO),
@@ -665,35 +665,35 @@ mod tests {
         let filter = MinLevelFilter::new(Level::Info).treat_unleveled_as(Level::Info);
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_ERROR),
         )));
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_WARN),
         )));
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_INFO),
         )));
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             crate::Empty,
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, LVL_DEBUG),
@@ -705,28 +705,28 @@ mod tests {
         let filter = MinLevelFilter::new(3).treat_unleveled_as(1);
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, 3),
         )));
 
         assert!(filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, 4),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             (KEY_LVL, 2),
         )));
 
         assert!(!filter.matches(crate::Event::new(
-            crate::Path::new_unchecked("test"),
+            crate::Path::new_raw("test"),
             crate::Template::literal("test"),
             crate::Empty,
             crate::Empty,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ This defers uses the standard `module_path` macro.
 #[macro_export]
 macro_rules! mdl {
     () => {
-        $crate::Path::new_unchecked($crate::__private::core::module_path!())
+        $crate::Path::new_raw($crate::__private::core::module_path!())
     };
 }
 
@@ -107,7 +107,7 @@ This macro uses the build-time `CARGO_PKG_NAME` environment variable.
 #[macro_export]
 macro_rules! pkg {
     () => {
-        $crate::Path::new_unchecked($crate::__private::core::env!("CARGO_PKG_NAME"))
+        $crate::Path::new_raw($crate::__private::core::env!("CARGO_PKG_NAME"))
     };
 }
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -426,7 +426,7 @@ pub mod source {
             impl Source for MySource {
                 fn sample_metrics<S: Sampler>(&self, sampler: S) {
                     sampler.metric(Metric::new(
-                        Path::new_unchecked("test"),
+                        Path::new_raw("test"),
                         "metric 1",
                         "count",
                         crate::Empty,
@@ -435,7 +435,7 @@ pub mod source {
                     ));
 
                     sampler.metric(Metric::new(
-                        Path::new_unchecked("test"),
+                        Path::new_raw("test"),
                         "metric 2",
                         "count",
                         crate::Empty,
@@ -460,7 +460,7 @@ pub mod source {
 
             from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     crate::Empty,
@@ -470,7 +470,7 @@ pub mod source {
             })
             .and_sample(from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 2",
                     "count",
                     crate::Empty,
@@ -491,7 +491,7 @@ pub mod source {
 
             from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     crate::Empty,
@@ -500,7 +500,7 @@ pub mod source {
                 ));
 
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 2",
                     "count",
                     crate::Empty,
@@ -519,7 +519,7 @@ pub mod source {
         fn erased_source() {
             let source = from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     crate::Empty,
@@ -528,7 +528,7 @@ pub mod source {
                 ));
 
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 2",
                     "count",
                     crate::Empty,
@@ -746,7 +746,7 @@ mod alloc_support {
             reporter
                 .add_source(source::from_fn(|sampler| {
                     sampler.metric(Metric::new(
-                        Path::new_unchecked("test"),
+                        Path::new_raw("test"),
                         "metric 1",
                         "count",
                         crate::Empty,
@@ -756,7 +756,7 @@ mod alloc_support {
                 }))
                 .add_source(source::from_fn(|sampler| {
                     sampler.metric(Metric::new(
-                        Path::new_unchecked("test"),
+                        Path::new_raw("test"),
                         "metric 2",
                         "count",
                         crate::Empty,
@@ -789,7 +789,7 @@ mod alloc_support {
 
             reporter.add_source(source::from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     crate::Empty,
@@ -811,7 +811,7 @@ mod alloc_support {
 
             reporter.add_source(source::from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     crate::Empty,
@@ -835,7 +835,7 @@ mod alloc_support {
 
             reporter.add_source(source::from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     Timestamp::from_unix(Duration::from_secs(100)).unwrap(),
@@ -862,7 +862,7 @@ mod alloc_support {
 
             reporter.add_source(source::from_fn(|sampler| {
                 sampler.metric(Metric::new(
-                    Path::new_unchecked("test"),
+                    Path::new_raw("test"),
                     "metric 1",
                     "count",
                     Timestamp::from_unix(Duration::from_secs(100)).unwrap()
@@ -1040,7 +1040,7 @@ pub mod sampler {
             });
 
             sampler.metric(Metric::new(
-                Path::new_unchecked("test"),
+                Path::new_raw("test"),
                 "test",
                 "count",
                 Empty,
@@ -1064,7 +1064,7 @@ pub mod sampler {
             let sampler = &sampler as &dyn ErasedSampler;
 
             sampler.metric(Metric::new(
-                Path::new_unchecked("test"),
+                Path::new_raw("test"),
                 "test",
                 "count",
                 Empty,
@@ -1087,7 +1087,7 @@ mod tests {
     #[test]
     fn metric_new() {
         let metric = Metric::new(
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "my metric",
             "count",
             Timestamp::from_unix(Duration::from_secs(1)),
@@ -1109,7 +1109,7 @@ mod tests {
     #[test]
     fn metric_to_event() {
         let metric = Metric::new(
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "my metric",
             "count",
             Timestamp::from_unix(Duration::from_secs(1)),
@@ -1150,7 +1150,7 @@ mod tests {
             (None, None),
         ] {
             let metric = Metric::new(
-                Path::new_unchecked("test"),
+                Path::new_raw("test"),
                 "my metric",
                 "count",
                 case,

--- a/src/span.rs
+++ b/src/span.rs
@@ -1058,7 +1058,7 @@ pub mod completion {
                 called.set(true);
             });
 
-            completion.complete(Span::new(Path::new_unchecked("test"), "test", Empty, Empty));
+            completion.complete(Span::new(Path::new_raw("test"), "test", Empty, Empty));
 
             assert!(called.get());
         }
@@ -1075,7 +1075,7 @@ pub mod completion {
 
             let completion = &completion as &dyn ErasedCompletion;
 
-            completion.complete(Span::new(Path::new_unchecked("test"), "test", Empty, Empty));
+            completion.complete(Span::new(Path::new_raw("test"), "test", Empty, Empty));
 
             assert!(called.get());
         }
@@ -1320,7 +1320,7 @@ mod tests {
     #[test]
     fn span_new() {
         let span = Span::new(
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "my span",
             Timestamp::from_unix(Duration::from_secs(1)),
             ("span_prop", true),
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn span_to_event() {
         let span = Span::new(
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "my span",
             Timestamp::from_unix(Duration::from_secs(1)),
             ("span_prop", true),
@@ -1374,12 +1374,7 @@ mod tests {
             ),
             (None, None),
         ] {
-            let span = Span::new(
-                Path::new_unchecked("test"),
-                "my span",
-                case,
-                ("span_prop", true),
-            );
+            let span = Span::new(Path::new_raw("test"), "my span", case, ("span_prop", true));
 
             let extent = span.to_extent();
 
@@ -1449,7 +1444,7 @@ mod tests {
                 complete_called.set(true);
             }),
             ("ctxt_prop", 2),
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "span",
             ("event_prop", 1),
         );
@@ -1481,7 +1476,7 @@ mod tests {
                 complete_called.set(true);
             }),
             Empty,
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "span",
             Empty,
         );
@@ -1514,7 +1509,7 @@ mod tests {
                 default_complete_called.set(true);
             }),
             Empty,
-            Path::new_unchecked("test"),
+            Path::new_raw("test"),
             "span",
             Empty,
         );

--- a/traceparent/src/lib.rs
+++ b/traceparent/src/lib.rs
@@ -1,7 +1,7 @@
 /*!
 Distributed trace context for `emit`.
 
-This library implements the [W3C trace context](https://www.w3.org/TR/trace-context) standard over `emit`'s tracing functionality. Trace context is propagated as a traceparent in a simple text format. Here's an example of a traceparent:
+This library implements the [W3C trace context](https://www.w3.org/TR/trace-context) standard over `emit`'s tracing functionality. Trace context is propagated as a traceparent and tracestate in a simple text format. Here's an example of a traceparent:
 
 ```text
 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
@@ -13,6 +13,14 @@ It includes:
 - A _trace id_: `4bf92f3577b34da6a3ce929d0e0e4736`.
 - A _span id_: `00f067aa0ba902b7`.
 - A set of _trace flags_: `01` (sampled).
+
+Here's an example of tracestate:
+
+```text
+vendorname1=opaqueValue1,vendorname2=opaqueValue2
+```
+
+It contains a collection of key-value pairs with vendor-specific information.
 
 # Getting started
 


### PR DESCRIPTION
Methods like `Path::new_unchecked` look like they should be unsafe, but aren't. They don't check whether the input value is valid, but there's no memory safety invariants tied to this. It sets off needless red flags when reviewing code to see `_unchecked` so we should just avoid that suffix if there's no use of the `unsafe` keyword to review.