### PR TITLE
Expand macros to code supporting temporaries

### DIFF
--- a/book/src/producing-events/tracing/manual-span-creation.md
+++ b/book/src/producing-events/tracing/manual-span-creation.md
@@ -19,7 +19,7 @@ let (span, frame) = emit::span::ActiveSpan::start(
     emit::rng(),
     // 1. What to do with the span when the guard completes
     //    Typically you'll want to emit it
-    emit::span::completion::from_fn(|evt| emit::emit!(evt)),
+    emit::span::completion::default(emit::emitter(), emit::ctxt()),
     // Any properties to put in the ambient context
     // This doesn't need to include any span or trace ids unless you want to
     // override whatever `ActiveSpan` generates for you

--- a/examples/common_patterns/span_manual_creation.rs
+++ b/examples/common_patterns/span_manual_creation.rs
@@ -15,7 +15,7 @@ fn example(i: i32) {
         emit::clock(),
         emit::rng(),
         // The completion determines what happens to the span when it completes
-        emit::span::completion::from_fn(|evt| emit::emit!(evt, "Running an example")),
+        emit::span::completion::default(emit::emitter(), emit::ctxt()),
         // Any properties to put in ambient context along with trace/span ids
         emit::props! {},
         emit::mdl!(),
@@ -37,7 +37,7 @@ fn example(i: i32) {
         if r == 4 {
             // Emit a span event on completion
             span.complete_with(emit::span::completion::from_fn(|evt| {
-                emit::error!(evt, "Running an example failed with {r}",)
+                emit::error!(evt, "Running an example failed with {r}")
             }));
         } else {
             // The span will complete when it goes out of scope, but it's good

--- a/macros/src/build.rs
+++ b/macros/src/build.rs
@@ -160,9 +160,9 @@ pub fn expand_evt_tokens(opts: ExpandEvtTokens) -> Result<TokenStream, syn::Erro
 
     let extent_tokens = args.extent.to_tokens().to_ref_tokens();
     let base_props_tokens = args.props.to_tokens().to_ref_tokens();
-    let template_tokens = template.template_tokens().to_ref_tokens();
-    let props_tokens = props.props_tokens().to_ref_tokens();
-    let mdl_tokens = args.mdl.to_tokens().to_ref_tokens();
+    let template_tokens = template.template_tokens();
+    let props_tokens = props.props_tokens();
+    let mdl_tokens = args.mdl.to_tokens();
 
     Ok(
         quote!(emit::__private::__private_evt(#mdl_tokens, #template_tokens, #extent_tokens, #base_props_tokens, #props_tokens)),

--- a/macros/src/build.rs
+++ b/macros/src/build.rs
@@ -53,23 +53,6 @@ impl Parse for TplPartsArgs {
 }
 
 /**
-The `tpl_parts!` macro.
-*/
-pub fn expand_tpl_parts_tokens(opts: ExpandTplTokens) -> Result<TokenStream, syn::Error> {
-    let span = opts.input.span();
-
-    let (_, template, props) =
-        template::parse2::<TplPartsArgs>(opts.input, capture::default_fn_name, false)?;
-
-    let template =
-        template.ok_or_else(|| syn::Error::new(span, "missing template string literal"))?;
-
-    validate_props(&props)?;
-
-    Ok(template.template_parts_tokens())
-}
-
-/**
 The `tpl!` macro.
 */
 pub fn expand_tpl_tokens(opts: ExpandTplTokens) -> Result<TokenStream, syn::Error> {

--- a/macros/src/dbg.rs
+++ b/macros/src/dbg.rs
@@ -62,7 +62,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
 
     let props_match_input_tokens = props.match_input_tokens();
     let props_match_binding_tokens = props.match_binding_tokens();
-    let props_tokens = props.match_bound_tokens();
+    let props_tokens = props.match_bound_tokens().to_ref_tokens();
 
     let rt_tokens = args::RtArg::default().to_tokens()?.to_ref_tokens();
     let when_tokens = None::<TokenStream>.to_option_tokens(quote!(&emit::Empty));

--- a/macros/src/emit.rs
+++ b/macros/src/emit.rs
@@ -99,7 +99,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
 
     let props_match_input_tokens = props.match_input_tokens();
     let props_match_binding_tokens = props.match_binding_tokens();
-    let props_tokens = props.match_bound_tokens();
+    let props_tokens = props.match_bound_tokens().to_ref_tokens();
 
     let rt_tokens = args.rt.to_tokens()?.to_ref_tokens();
     let when_tokens = args

--- a/macros/src/format.rs
+++ b/macros/src/format.rs
@@ -30,7 +30,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
     }
     #[cfg(feature = "std")]
     {
-        use crate::template;
+        use crate::{template, util::ToRefTokens};
 
         let span = opts.input.span();
 
@@ -42,7 +42,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
 
         let props_match_input_tokens = props.match_input_tokens();
         let props_match_binding_tokens = props.match_binding_tokens();
-        let props_tokens = props.match_bound_tokens();
+        let props_tokens = props.match_bound_tokens().to_ref_tokens();
 
         let template_tokens = template.template_tokens();
 

--- a/macros/src/key.rs
+++ b/macros/src/key.rs
@@ -15,7 +15,7 @@ pub fn key_with_hook(attrs: &[Attribute], key_expr: &ExprLit) -> TokenStream {
         #[allow(unused_imports)]
         {
             use emit::__private::__PrivateKeyHook as _;
-            emit::Str::new(#key_expr).__private_key_as_default()
+            emit::__private::Key(#key_expr).__private_key_as_default()
         }
     )
 }
@@ -81,7 +81,7 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         predicate: |ident: &str| ident.starts_with("__private_key"),
         to: move |args: &Args, _: &Ident, _: &Punctuated<Expr, Comma>| {
             let (to_ident, to_arg) = match args.name {
-                Name::Str(ref name) => (quote!(__private_key_as_static), quote!(#name)),
+                Name::Str(ref name) => (quote!(__private_key_as), quote!(#name)),
                 Name::Any(ref name) => (quote!(__private_key_as), name.clone()),
             };
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -500,25 +500,6 @@ pub fn tpl(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 /**
-Get the parts of a template.
-
-# Syntax
-
-See the [`macro@tpl`] macro for syntax.
-
-# Returns
-
-An `[emit::template::Part; N]` array.
-*/
-#[proc_macro]
-pub fn tpl_parts(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    build::expand_tpl_parts_tokens(build::ExpandTplTokens {
-        input: TokenStream::from(item),
-    })
-    .unwrap_or_compile_error()
-}
-
-/**
 Emit an event.
 
 # Syntax

--- a/macros/src/props.rs
+++ b/macros/src/props.rs
@@ -84,7 +84,7 @@ impl Props {
     fn sorted_props_tokens<'a>(
         key_values: impl Iterator<Item = &'a TokenStream> + 'a,
     ) -> TokenStream {
-        quote!(emit::__private::__PrivateMacroProps::new_ref(&[#(#key_values),*]))
+        quote!(emit::__private::__PrivateMacroProps::from_array([#(#key_values),*]))
     }
 
     fn next_match_binding_ident(&mut self, span: Span) -> Ident {

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -249,7 +249,7 @@ fn inject_sync(
     err_lvl_tokens: Option<TokenStream>,
     err_tokens: Option<TokenStream>,
 ) -> Result<TokenStream, syn::Error> {
-    let ctxt_props_tokens = ctxt_props.props_tokens();
+    let ctxt_props_tokens = ctxt_props.props_tokens().to_ref_tokens();
     let template_tokens = template.template_tokens().to_ref_tokens();
     let span_name_tokens = template.template_literal_tokens();
 
@@ -328,7 +328,7 @@ fn inject_async(
     err_lvl_tokens: Option<TokenStream>,
     err_tokens: Option<TokenStream>,
 ) -> Result<TokenStream, syn::Error> {
-    let ctxt_props_tokens = ctxt_props.props_tokens();
+    let ctxt_props_tokens = ctxt_props.props_tokens().to_ref_tokens();
     let template_tokens = template.template_tokens().to_ref_tokens();
     let span_name_tokens = template.template_literal_tokens();
 

--- a/macros/src/template.rs
+++ b/macros/src/template.rs
@@ -84,29 +84,19 @@ pub fn parse2<A: Parse>(
         let template_parts = template_visitor.parts?;
         let literal = template_visitor.literal;
 
-        /*
-        Ideally this would be:
+        let parts_tokens = {
+            quote!({
+                const __TPL_PARTS: &[emit::template::Part] = &[
+                    #(#template_parts),*
+                ];
 
-        ```
-        {
-            const __TPL_PARTS: [emit::template::Part; #len] = [
-                #(#template_parts),*
-            ];
+                __TPL_PARTS
+            })
+        };
 
-            &__TPL_PARTS
-        }
-        ```
+        let literal_tokens = quote!(#literal);
 
-        but because of the use of trait bounds it can't be const-evaluated.
-        Once that is stable then we'll be able to use it here and avoid
-        "value doesn't live long enough" errors in `let x = tpl!(..);`.
-        */
-        (
-            quote!([
-                #(#template_parts),*
-            ]),
-            quote!(#literal),
-        )
+        (parts_tokens, literal_tokens)
     };
 
     let template = if template.has_literal() {
@@ -127,10 +117,6 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn template_parts_tokens(&self) -> TokenStream {
-        self.template_parts_tokens.clone()
-    }
-
     pub fn template_literal_tokens(&self) -> TokenStream {
         self.template_literal_tokens.clone()
     }
@@ -138,7 +124,7 @@ impl Template {
     pub fn template_tokens(&self) -> TokenStream {
         let template_parts = &self.template_parts_tokens;
 
-        quote!(emit::Template::new_ref(&#template_parts))
+        quote!(emit::Template::new_ref(#template_parts))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,22 @@ pub mod setup;
 pub use setup::{setup, Setup};
 
 /**
+Get the shared emitter.
+
+This method will use the [`Emitter`] from [`runtime::shared()`].
+
+Calling `emitter::emit()` is different from `runtime::shared().emit()`:
+
+1. `emitter::emit()` won't apply the filter.
+2. `emitter::emit()` won't add a timestamp to events if they don't have one.
+3. `emitter::emit()` won't add ambient properties.
+*/
+#[cfg(feature = "implicit_rt")]
+pub fn emitter() -> runtime::AmbientEmitter<'static> {
+    *runtime::shared().emitter()
+}
+
+/**
 Get the shared filter.
 
 This method will use the [`Filter`] from [`runtime::shared()`].

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -871,7 +871,8 @@ pub fn __private_complete_span<
     lvl: Option<&'b (impl CaptureLevel + ?Sized)>,
     panic_lvl: Option<&'b (impl CaptureLevel + ?Sized)>,
 ) {
-    let mut completion = span::completion::Default::new(rt.emitter(), rt.ctxt());
+    let mut completion =
+        span::completion::Default::new(rt.emitter(), rt.ctxt()).with_tpl(tpl.tpl_control_param());
 
     if let Some(lvl) = lvl.and_then(|lvl| lvl.capture()) {
         completion = completion.with_lvl(lvl);
@@ -881,7 +882,7 @@ pub fn __private_complete_span<
         completion = completion.with_panic_lvl(lvl);
     }
 
-    completion.complete(span.with_tpl(tpl.tpl_control_param()));
+    completion.complete(span);
 }
 
 #[track_caller]

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -208,6 +208,21 @@ impl<'a, P> Metric<'a, P> {
             props,
         }
     }
+
+    /**
+    Map the properties of the metric.
+    */
+    pub fn map_props<U>(self, map: impl FnOnce(P) -> U) -> Metric<'a, U> {
+        Metric {
+            mdl: self.mdl,
+            extent: self.extent,
+            tpl: self.tpl,
+            name: self.name,
+            agg: self.agg,
+            value: self.value,
+            props: map(self.props),
+        }
+    }
 }
 
 impl<'a, P: Props> ToEvent for Metric<'a, P> {

--- a/test/ui/src/event.rs
+++ b/test/ui/src/event.rs
@@ -2,18 +2,52 @@ use emit::Props;
 
 #[test]
 fn event_basic() {
-    match emit::evt!(
+    let evt = emit::evt!(
         "Hello, {user}",
         user: "Rust",
-    ) {
-        evt => {
-            assert_eq!("Hello, Rust", evt.msg().to_string());
-            assert_eq!("Hello, {user}", evt.tpl().to_string());
-            assert_eq!(module_path!(), evt.mdl());
+    );
 
-            assert!(evt.extent().is_none());
+    assert_eq!("Hello, Rust", evt.msg().to_string());
+    assert_eq!("Hello, {user}", evt.tpl().to_string());
+    assert_eq!(module_path!(), evt.mdl());
 
-            assert_eq!("Rust", evt.props().pull::<&str, _>("user").unwrap());
-        }
-    }
+    assert!(evt.extent().is_none());
+
+    assert_eq!("Rust", evt.props().pull::<&str, _>("user").unwrap());
+}
+
+#[test]
+fn event_mdl() {
+    let evt = emit::evt!(
+        mdl: emit::path!("x"),
+        "template",
+    );
+
+    assert_eq!(emit::path!("x"), evt.mdl());
+}
+
+#[test]
+fn event_extent() {
+    let evt = emit::evt!(
+        extent: emit::Timestamp::MIN,
+        "template",
+    );
+
+    assert_eq!(emit::Timestamp::MIN, evt.ts().unwrap());
+}
+
+#[test]
+fn event_base_props() {
+    let props = emit::props! {
+        a: "base",
+    };
+
+    let evt = emit::evt!(
+        props,
+        "template",
+        b: "evt",
+    );
+
+    assert_eq!("base", evt.props().pull::<&str, _>("a").unwrap());
+    assert_eq!("evt", evt.props().pull::<&str, _>("b").unwrap());
 }

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -4,43 +4,48 @@ use emit::Props;
 
 #[test]
 fn props_basic() {
-    match emit::props! {
+    let props = emit::props! {
         b: 1,
         a: true,
         c: 2.0,
         d: "text",
-    } {
-        props => {
-            assert!(props.is_unique());
+    };
 
-            assert_eq!(1, props.pull::<i32, _>("b").unwrap());
-            assert_eq!(true, props.pull::<bool, _>("a").unwrap());
-            assert_eq!(2.0, props.pull::<f64, _>("c").unwrap());
-            assert_eq!("text", props.pull::<&str, _>("d").unwrap());
-        }
-    }
+    assert!(props.is_unique());
+
+    assert_eq!(1, props.pull::<i32, _>("b").unwrap());
+    assert_eq!(true, props.pull::<bool, _>("a").unwrap());
+    assert_eq!(2.0, props.pull::<f64, _>("c").unwrap());
+    assert_eq!("text", props.pull::<&str, _>("d").unwrap());
 }
 
 #[test]
 fn props_uncooked() {
-    match emit::props! {
+    let props = emit::props! {
         r#type: 1,
-    } {
-        props => {
-            assert_eq!(1, props.pull::<i32, _>("type").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(1, props.pull::<i32, _>("type").unwrap());
 }
 
 #[test]
 fn props_external() {
     let x = 42;
 
-    match emit::props! {
+    let props = emit::props! {
         x,
+    };
+
+    assert_eq!(42, props.pull::<i32, _>("x").unwrap());
+}
+
+#[test]
+fn props_ref() {
+    match emit::props! {
+        a: String::from("short lived"),
     } {
         props => {
-            assert_eq!(42, props.pull::<i32, _>("x").unwrap());
+            assert_eq!("short lived", props.pull::<&str, _>("a").unwrap());
         }
     }
 }
@@ -58,17 +63,15 @@ fn props_event_meta() {
 
 #[test]
 fn props_cfg() {
-    match emit::props! {
+    let props = emit::props! {
         #[cfg(not(emit_disabled))]
         enabled: "enabled",
         #[cfg(emit_disabled)]
         disabled: "disabled",
-    } {
-        props => {
-            assert_eq!("enabled", props.pull::<&str, _>("enabled").unwrap());
-            assert!(props.get("disabled").is_none());
-        }
-    }
+    };
+
+    assert_eq!("enabled", props.pull::<&str, _>("enabled").unwrap());
+    assert!(props.get("disabled").is_none());
 }
 
 #[test]
@@ -91,15 +94,13 @@ fn props_capture_err() {
 
 #[test]
 fn props_capture_err_string() {
-    match emit::props! {
+    let props = emit::props! {
         err: "Some error",
-    } {
-        props => {
-            let err = props.pull::<&str, _>("err").unwrap();
+    };
 
-            assert_eq!("Some error", err);
-        }
-    }
+    let err = props.pull::<&str, _>("err").unwrap();
+
+    assert_eq!("Some error", err);
 }
 
 #[test]
@@ -124,223 +125,195 @@ fn props_capture_err_anyhow() {
 
 #[test]
 fn props_capture_err_as_non_err() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display(inspect: true)] err: true,
-    } {
-        props => {
-            let err = props.pull::<bool, _>("err").unwrap();
+    };
 
-            assert_eq!(true, err);
-        }
-    }
+    let err = props.pull::<bool, _>("err").unwrap();
+
+    assert_eq!(true, err);
 }
 
 #[test]
 fn props_capture_lvl() {
-    match emit::props! {
+    let props = emit::props! {
         lvl: emit::Level::Info,
-    } {
-        props => {
-            assert_eq!(
-                emit::Level::Info,
-                props.pull::<emit::Level, _>("lvl").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::Level::Info,
+        props.pull::<emit::Level, _>("lvl").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_lvl_string() {
-    match emit::props! {
+    let props = emit::props! {
         lvl: "info",
-    } {
-        props => {
-            assert_eq!(
-                emit::Level::Info,
-                props.pull::<emit::Level, _>("lvl").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::Level::Info,
+        props.pull::<emit::Level, _>("lvl").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_lvl_as_non_lvl() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display(inspect: true)] lvl: true,
-    } {
-        props => {
-            assert_eq!(true, props.pull::<bool, _>("lvl").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(true, props.pull::<bool, _>("lvl").unwrap());
 }
 
 #[test]
 fn props_capture_trace_id() {
-    match emit::props! {
-        trace_id: emit::TraceId::from_u128(1),
-    } {
-        props => {
-            assert_eq!(
-                emit::TraceId::from_u128(1).unwrap(),
-                props.pull::<emit::TraceId, _>("trace_id").unwrap()
-            );
-        }
-    }
+    let trace_id = emit::TraceId::from_u128(1);
+
+    let props = emit::props! {
+        trace_id,
+    };
+
+    assert_eq!(
+        emit::TraceId::from_u128(1).unwrap(),
+        props.pull::<emit::TraceId, _>("trace_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_trace_id_string() {
-    match emit::props! {
+    let props = emit::props! {
         trace_id: "00000000000000000000000000000001",
-    } {
-        props => {
-            assert_eq!(
-                emit::TraceId::from_u128(1).unwrap(),
-                props.pull::<emit::TraceId, _>("trace_id").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::TraceId::from_u128(1).unwrap(),
+        props.pull::<emit::TraceId, _>("trace_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_trace_id_u128() {
-    match emit::props! {
+    let props = emit::props! {
         trace_id: 0x00000000000000000000000000000001u128,
-    } {
-        props => {
-            assert_eq!(
-                emit::TraceId::from_u128(1).unwrap(),
-                props.pull::<emit::TraceId, _>("trace_id").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::TraceId::from_u128(1).unwrap(),
+        props.pull::<emit::TraceId, _>("trace_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_trace_id_as_non_trace_id() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display(inspect: true)] trace_id: true,
-    } {
-        props => {
-            assert_eq!(true, props.pull::<bool, _>("trace_id").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(true, props.pull::<bool, _>("trace_id").unwrap());
 }
 
 #[test]
 fn props_capture_span_id() {
-    match emit::props! {
-        span_id: emit::SpanId::from_u64(1),
-    } {
-        props => {
-            assert_eq!(
-                emit::SpanId::from_u64(1).unwrap(),
-                props.pull::<emit::SpanId, _>("span_id").unwrap()
-            );
-        }
-    }
+    let span_id = emit::SpanId::from_u64(1);
+
+    let props = emit::props! {
+        span_id,
+    };
+
+    assert_eq!(
+        emit::SpanId::from_u64(1).unwrap(),
+        props.pull::<emit::SpanId, _>("span_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_span_id_string() {
-    match emit::props! {
+    let props = emit::props! {
         span_id: "0000000000000001",
-    } {
-        props => {
-            assert_eq!(
-                emit::SpanId::from_u64(1).unwrap(),
-                props.pull::<emit::SpanId, _>("span_id").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::SpanId::from_u64(1).unwrap(),
+        props.pull::<emit::SpanId, _>("span_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_span_id_u64() {
-    match emit::props! {
+    let props = emit::props! {
         span_id: 0x0000000000000001u64,
-    } {
-        props => {
-            assert_eq!(
-                emit::SpanId::from_u64(1).unwrap(),
-                props.pull::<emit::SpanId, _>("span_id").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::SpanId::from_u64(1).unwrap(),
+        props.pull::<emit::SpanId, _>("span_id").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_span_id_as_non_span_id() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display(inspect: true)] span_id: true,
-    } {
-        props => {
-            assert_eq!(true, props.pull::<bool, _>("span_id").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(true, props.pull::<bool, _>("span_id").unwrap());
 }
 
 #[test]
 fn props_capture_span_parent() {
-    match emit::props! {
-        span_parent: emit::SpanId::from_u64(1),
-    } {
-        props => {
-            assert_eq!(
-                emit::SpanId::from_u64(1).unwrap(),
-                props.pull::<emit::SpanId, _>("span_parent").unwrap()
-            );
-        }
-    }
+    let span_parent = emit::SpanId::from_u64(1);
+
+    let props = emit::props! {
+        span_parent,
+    };
+
+    assert_eq!(
+        emit::SpanId::from_u64(1).unwrap(),
+        props.pull::<emit::SpanId, _>("span_parent").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_span_parent_string() {
-    match emit::props! {
+    let props = emit::props! {
         span_parent: "0000000000000001",
-    } {
-        props => {
-            assert_eq!(
-                emit::SpanId::from_u64(1).unwrap(),
-                props.pull::<emit::SpanId, _>("span_parent").unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        emit::SpanId::from_u64(1).unwrap(),
+        props.pull::<emit::SpanId, _>("span_parent").unwrap()
+    );
 }
 
 #[test]
 fn props_capture_span_parent_as_non_span_id() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display(inspect: true)] span_parent: true,
-    } {
-        props => {
-            assert_eq!(true, props.pull::<bool, _>("span_parent").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(true, props.pull::<bool, _>("span_parent").unwrap());
 }
 
 #[test]
 fn props_key() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::key("not an identifier")] a: 1,
-    } {
-        props => {
-            assert_eq!(1, props.pull::<i32, _>("not an identifier").unwrap());
-        }
-    }
+    };
+
+    assert_eq!(1, props.pull::<i32, _>("not an identifier").unwrap());
 }
 
 #[test]
 fn props_optional() {
-    match emit::props! {
+    let props = emit::props! {
         #[emit::optional] some: Some(&1),
         #[emit::optional] none: None::<&i32>,
-    } {
-        props => {
-            assert_eq!(1, props.pull::<i32, _>("some").unwrap());
-            assert!(props.get("none").is_none());
-        }
-    }
+    };
+
+    assert_eq!(1, props.pull::<i32, _>("some").unwrap());
+    assert!(props.get("none").is_none());
 }
 
 #[test]
@@ -349,13 +322,11 @@ fn props_optional_ref() {
 
     let some: Option<&str> = Some(&s);
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::optional] some,
-    } {
-        props => {
-            assert_eq!("short lived", props.pull::<&str, _>("some").unwrap());
-        }
-    }
+    };
+
+    assert_eq!("short lived", props.pull::<&str, _>("some").unwrap());
 }
 
 #[test]
@@ -363,13 +334,11 @@ fn props_as_debug() {
     #[derive(Debug)]
     struct Data;
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_debug] a: Data,
-    } {
-        props => {
-            assert_eq!(format!("{:?}", Data), props.get("a").unwrap().to_string());
-        }
-    }
+    };
+
+    assert_eq!(format!("{:?}", Data), props.get("a").unwrap().to_string());
 }
 
 #[test]
@@ -382,13 +351,11 @@ fn props_as_display() {
         }
     }
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_display] a: Data,
-    } {
-        props => {
-            assert_eq!(format!("{}", Data), props.get("a").unwrap().to_string());
-        }
-    }
+    };
+
+    assert_eq!(format!("{}", Data), props.get("a").unwrap().to_string());
 }
 
 #[test]
@@ -417,17 +384,15 @@ fn props_as_value() {
         }
     }
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_value] data: Data,
         #[emit::as_value] some: Some(Data),
         #[emit::as_value] none: None::<Data>,
-    } {
-        props => {
-            assert_eq!("Data", props.pull::<&str, _>("data").unwrap());
-            assert_eq!("Data", props.pull::<&str, _>("some").unwrap());
-            assert!(props.get("none").unwrap().is_null());
-        }
-    }
+    };
+
+    assert_eq!("Data", props.pull::<&str, _>("data").unwrap());
+    assert_eq!("Data", props.pull::<&str, _>("some").unwrap());
+    assert!(props.get("none").unwrap().is_null());
 }
 
 #[test]
@@ -438,16 +403,14 @@ fn props_as_sval() {
         a: i32,
     }
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_sval] a: Data { a: 42 },
-    } {
-        props => {
-            assert_eq!(
-                "{\"a\":42}",
-                sval_json::stream_to_string(props.get("a").unwrap()).unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        "{\"a\":42}",
+        sval_json::stream_to_string(props.get("a").unwrap()).unwrap()
+    );
 }
 
 #[test]
@@ -458,14 +421,12 @@ fn props_as_serde() {
         a: i32,
     }
 
-    match emit::props! {
+    let props = emit::props! {
         #[emit::as_serde] a: Data { a: 42 },
-    } {
-        props => {
-            assert_eq!(
-                "{\"a\":42}",
-                serde_json::to_string(&props.get("a").unwrap()).unwrap()
-            );
-        }
-    }
+    };
+
+    assert_eq!(
+        "{\"a\":42}",
+        serde_json::to_string(&props.get("a").unwrap()).unwrap()
+    );
 }

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -40,17 +40,6 @@ fn props_external() {
 }
 
 #[test]
-fn props_ref() {
-    match emit::props! {
-        a: String::from("short lived"),
-    } {
-        props => {
-            assert_eq!("short lived", props.pull::<&str, _>("a").unwrap());
-        }
-    }
-}
-
-#[test]
 fn props_event_meta() {
     let _ = emit::props!(
         ts_start: "2024-01-01T00:00:00.000Z",
@@ -356,6 +345,18 @@ fn props_as_display() {
     };
 
     assert_eq!(format!("{}", Data), props.get("a").unwrap().to_string());
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn props_ref() {
+    match emit::props! {
+        a: String::from("short lived"),
+    } {
+        props => {
+            assert_eq!("short lived", props.pull::<&str, _>("a").unwrap());
+        }
+    }
 }
 
 #[test]

--- a/test/ui/src/tpl.rs
+++ b/test/ui/src/tpl.rs
@@ -1,26 +1,16 @@
 #[test]
 fn tpl_basic() {
-    match emit::tpl!("Hello, {user}") {
-        tpl => {
-            let parts = tpl.parts().collect::<Vec<_>>();
+    let tpl = emit::tpl!("Hello, {user}");
 
-            assert_eq!("Hello, ", parts[0].as_text().unwrap());
-            assert_eq!("user", parts[1].label().unwrap());
-        }
-    }
+    let parts = tpl.parts().collect::<Vec<_>>();
+
+    assert_eq!("Hello, ", parts[0].as_text().unwrap());
+    assert_eq!("user", parts[1].label().unwrap());
 }
 
 #[test]
 fn tpl_event_meta() {
     let _ = emit::tpl!("{ts_start}..{ts} {mdl} {tpl} {msg}");
-}
-
-#[test]
-fn tpl_parts() {
-    let parts = emit::tpl_parts!("Hello, {user}");
-
-    assert_eq!("Hello, ", parts[0].as_text().unwrap());
-    assert_eq!("user", parts[1].label().unwrap());
 }
 
 #[test]
@@ -34,17 +24,15 @@ fn tpl_cfg() {
 
 #[test]
 fn tpl_fmt() {
-    match emit::tpl!(
+    let tpl = emit::tpl!(
         "Hello, {user}",
         #[emit::fmt("?")]
         user
-    ) {
-        tpl => {
-            let parts = tpl.parts().collect::<Vec<_>>();
+    );
 
-            assert_eq!("Hello, ", parts[0].as_text().unwrap());
-            assert_eq!("user", parts[1].label().unwrap());
-            assert!(parts[1].formatter().is_some());
-        }
-    }
+    let parts = tpl.parts().collect::<Vec<_>>();
+
+    assert_eq!("Hello, ", parts[0].as_text().unwrap());
+    assert_eq!("user", parts[1].label().unwrap());
+    assert!(parts[1].formatter().is_some());
 }


### PR DESCRIPTION
This PR fixes up a few papercuts around `tpl!()`, `props!()`, and `evt!()` where they couldn't produce values you could assign to temporaries. Now you can.