### PR TITLE
Add a start_span! macro for easy span creation

### DIFF
--- a/examples/common_patterns/span_manual_creation.rs
+++ b/examples/common_patterns/span_manual_creation.rs
@@ -9,22 +9,7 @@ This example differs from `span_manual_creation_full` in still using the same `A
 use std::time::Duration;
 
 fn example(i: i32) {
-    let (span, frame) = emit::span::ActiveSpan::start(
-        emit::filter(),
-        emit::ctxt(),
-        emit::clock(),
-        emit::rng(),
-        // The completion determines what happens to the span when it completes
-        emit::span::completion::default(emit::emitter(), emit::ctxt()),
-        // Any properties to put in ambient context along with trace/span ids
-        emit::props! {},
-        emit::mdl!(),
-        // The name of the span
-        "example",
-        // Any properties to associate with the span itself
-        // These aren't added to the ambient context
-        emit::props! {},
-    );
+    let (span, frame) = emit::start_span!("example");
 
     // Execute our code within the context of the frame
     // If this function was async, then you would use `frame.in_future(..).await`

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -470,6 +470,113 @@ pub fn error_span(
 }
 
 /**
+Start a span.
+
+# Syntax
+
+```text
+(control_param),* tpl, (property),*
+```
+
+where
+
+- `control_param`: A Rust field-value with a pre-determined identifier (see below).
+- `tpl`: A template string literal.
+- `property`: A Rust field-value for a property to capture.
+
+# Control parameters
+
+This macro accepts the following optional control parameters:
+
+| name        | type                          | description                                                                                                                                                    |
+| ----------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rt`        | `impl emit::runtime::Runtime` | The runtime to emit the event through.                                                                                                                         |
+| `mdl`       | `impl Into<emit::Path>`       | The module the event belongs to. If unspecified the current module path is used.                                                                               |
+| `when`      | `impl emit::Filter`           | A filter to use instead of the one configured on the runtime.                                                                                                  |
+| `panic_lvl` | `str` or `emit::Level`        | Detect whether the function panics and use the given level if it does.                                                                                         |
+
+# Template
+
+The template for the event. See the [`macro@tpl`] macro for syntax.
+
+# Properties
+
+Properties that appear within the template or after it are added to the emitted event. The identifier of the property is its key. Property capturing can be adjusted through the `as_*` attribute macros.
+*/
+#[proc_macro]
+pub fn start_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_start_tokens(span::ExpandStartTokens {
+        level: None,
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
+}
+
+/**
+Start a debug span.
+
+# Syntax
+
+See the [`macro@start_span`] macro for syntax.
+*/
+#[proc_macro]
+pub fn start_debug_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_start_tokens(span::ExpandStartTokens {
+        level: Some(quote!(emit::Level::Debug)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
+}
+
+/**
+Start an info span.
+
+# Syntax
+
+See the [`macro@start_span`] macro for syntax.
+*/
+#[proc_macro]
+pub fn start_info_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_start_tokens(span::ExpandStartTokens {
+        level: Some(quote!(emit::Level::Info)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
+}
+
+/**
+Start a warning span.
+
+# Syntax
+
+See the [`macro@start_span`] macro for syntax.
+*/
+#[proc_macro]
+pub fn start_warn_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_start_tokens(span::ExpandStartTokens {
+        level: Some(quote!(emit::Level::Warn)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
+}
+
+/**
+Start an error span.
+
+# Syntax
+
+See the [`macro@start_span`] macro for syntax.
+*/
+#[proc_macro]
+pub fn start_error_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_start_tokens(span::ExpandStartTokens {
+        level: Some(quote!(emit::Level::Error)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
+}
+
+/**
 Construct a template.
 
 Templates are text literals that include regular text with _holes_. A hole is a point in the template where a property should be interpolated in.

--- a/test/ui/src/lib.rs
+++ b/test/ui/src/lib.rs
@@ -20,6 +20,7 @@ mod emit;
 mod event;
 mod props;
 mod span;
+mod start_span;
 mod tpl;
 
 #[cfg(feature = "std")]

--- a/test/ui/src/start_span.rs
+++ b/test/ui/src/start_span.rs
@@ -1,0 +1,179 @@
+use std::time::Duration;
+
+use emit::{Emitter, Props};
+
+use crate::util::{simple_runtime, Called};
+
+#[test]
+fn start_span_basic() {
+    for lvl in [
+        Some(emit::Level::Debug),
+        Some(emit::Level::Info),
+        Some(emit::Level::Warn),
+        Some(emit::Level::Error),
+        None,
+    ] {
+        let called = Called::new();
+
+        let rt = simple_runtime(
+            |evt| {
+                assert_eq!("Hello, Rust", evt.msg().to_string());
+                assert_eq!("Hello, {user}", evt.tpl().to_string());
+                assert_eq!(module_path!(), evt.mdl());
+
+                assert!(evt.extent().is_some());
+
+                assert_eq!("Rust", evt.props().pull::<&str, _>("user").unwrap());
+
+                assert_eq!(lvl, evt.props().pull::<emit::Level, _>("lvl"));
+
+                assert!(evt.props().get("trace_id").is_some());
+                assert!(evt.props().get("span_id").is_some());
+
+                called.record();
+            },
+            |_| true,
+        );
+
+        let user = "Rust";
+
+        match lvl {
+            None => {
+                let (guard, frame) = emit::start_span!(rt, "Hello, {user}");
+
+                frame.call(move || {
+                    guard.complete();
+                });
+            }
+            Some(emit::Level::Debug) => {
+                let (guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+
+                frame.call(move || {
+                    guard.complete();
+                });
+            }
+            Some(emit::Level::Info) => {
+                let (guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+
+                frame.call(move || {
+                    guard.complete();
+                });
+            }
+            Some(emit::Level::Warn) => {
+                let (guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+
+                frame.call(move || {
+                    guard.complete();
+                });
+            }
+            Some(emit::Level::Error) => {
+                let (guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+
+                frame.call(move || {
+                    guard.complete();
+                });
+            }
+        }
+
+        rt.emitter().blocking_flush(Duration::from_secs(1));
+
+        assert!(called.was_called());
+    }
+}
+
+#[tokio::test]
+async fn start_span_basic_async() {
+    for lvl in [
+        Some(emit::Level::Debug),
+        Some(emit::Level::Info),
+        Some(emit::Level::Warn),
+        Some(emit::Level::Error),
+        None,
+    ] {
+        let called = Called::new();
+
+        let rt = simple_runtime(
+            |evt| {
+                assert_eq!("Hello, Rust", evt.msg().to_string());
+                assert_eq!("Hello, {user}", evt.tpl().to_string());
+                assert_eq!(module_path!(), evt.mdl());
+
+                assert!(evt.extent().is_some());
+
+                assert_eq!("Rust", evt.props().pull::<&str, _>("user").unwrap());
+
+                assert_eq!(lvl, evt.props().pull::<emit::Level, _>("lvl"));
+
+                assert!(evt.props().get("trace_id").is_some());
+                assert!(evt.props().get("span_id").is_some());
+
+                called.record();
+            },
+            |_| true,
+        );
+
+        let user = "Rust";
+
+        match lvl {
+            None => {
+                let (guard, frame) = emit::start_span!(rt, "Hello, {user}");
+
+                frame
+                    .in_future(async move {
+                        tokio::time::sleep(Duration::from_micros(1)).await;
+
+                        guard.complete();
+                    })
+                    .await;
+            }
+            Some(emit::Level::Debug) => {
+                let (guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+
+                frame
+                    .in_future(async move {
+                        tokio::time::sleep(Duration::from_micros(1)).await;
+
+                        guard.complete();
+                    })
+                    .await;
+            }
+            Some(emit::Level::Info) => {
+                let (guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+
+                frame
+                    .in_future(async move {
+                        tokio::time::sleep(Duration::from_micros(1)).await;
+
+                        guard.complete();
+                    })
+                    .await;
+            }
+            Some(emit::Level::Warn) => {
+                let (guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+
+                frame
+                    .in_future(async move {
+                        tokio::time::sleep(Duration::from_micros(1)).await;
+
+                        guard.complete();
+                    })
+                    .await;
+            }
+            Some(emit::Level::Error) => {
+                let (guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+
+                frame
+                    .in_future(async move {
+                        tokio::time::sleep(Duration::from_micros(1)).await;
+
+                        guard.complete();
+                    })
+                    .await;
+            }
+        }
+
+        rt.emitter().blocking_flush(Duration::from_secs(1));
+
+        assert!(called.was_called());
+    }
+}


### PR DESCRIPTION
Closes #188 

This PR adds a `start_span!` macro that lets you lift a `#[span]` attribute into a `let` binding.

For example, this attribute:

```rust
#[emit::span(guard: span, "Running an example", i)]
fn example(i: i32) {
    let r = i + 1;

    if r == 4 {
        span.complete_with(emit::span::completion::from_fn(|evt| {
            emit::error!(evt, "Running an example failed with {r}");
        }));
    } else {
        span.complete_with(emit::span::completion::from_fn(|evt| {
            emit::info!(evt, "Running an example produced {r}");
        }));
    }
}
```

can also be written as:

```rust
fn example(i: i32) {
    let (span, frame) = emit::start_span!("Running an example", i);

    frame.call(move || {
        let r = i + 1;

        if r == 4 {
            span.complete_with(emit::span::completion::from_fn(|evt| {
                emit::error!(evt, "Running an example failed with {r}");
            }));
        } else {
            span.complete_with(emit::span::completion::from_fn(|evt| {
                emit::info!(evt, "Running an example produced {r}");
            }));
        }
    })
}
```

It's important that the `span` is completed within the `frame`, otherwise it won't have any ambient context (like its trace and span ids).