### PR TITLE
Require ActiveSpans be manually started

### DIFF
--- a/book/src/producing-events/tracing/manual-span-creation.md
+++ b/book/src/producing-events/tracing/manual-span-creation.md
@@ -8,20 +8,20 @@ You can also create `ActiveSpan`s manually if you can't or don't want to use the
 
 ```rust
 # extern crate emit;
-let (span, frame) = emit::start_span!("manual span");
+let (mut span, frame) = emit::new_span!("manual span");
 
 frame.call(move || {
-    // Your code goes here
+    span.start();
 
-    span.complete();
+    // Your code goes here
 })
 ```
 
-The `start_span!` macro returns a tuple of [`ActiveSpan`](https://docs.rs/emit/0.11.0-alpha.21/emit/span/struct.ActiveSpan.html) for completing the span, and [`Frame`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html) for activating the span's ambient trace and span ids for correlation.
+The `new_span!` macro returns a tuple of [`ActiveSpan`](https://docs.rs/emit/0.11.0-alpha.21/emit/span/struct.ActiveSpan.html) for completing the span, and [`Frame`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html) for activating the span's ambient trace and span ids for correlation.
 
-The syntax accepted by the `start_span!` macro is the same as the [`#[span]`](https://docs.rs/emit/0.11.0-alpha.21/emit/attr.span.html) attribute.
+The syntax accepted by the `new_span!` macro is the same as the [`#[span]`](https://docs.rs/emit/0.11.0-alpha.21/emit/attr.span.html) attribute.
 
-**Make sure you pass ownership of the returned [`ActiveSpan`](https://docs.rs/emit/0.11.0-alpha.21/emit/span/struct.ActiveSpan.html) into the closure in [`Frame::call`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html#method.call) or async block in [`Frame::in_future`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html#method.in_future)**. If you don't, the span will complete early, without its ambient context.
+**Make sure you call [`ActiveSpan::start`](https://docs.rs/emit/0.11.0-alpha.21/emit/span/struct.ActiveSpan.html#method.start) in the closure in [`Frame::call`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html#method.call) or async block in [`Frame::in_future`](https://docs.rs/emit/0.11.0-alpha.21/emit/frame/struct.Frame.html#method.in_future)**. If you don't call `ActiveSpan::start`, the span won't be emitted. If you don't call it within the frame, the span may be emitted early and without its ambient context.
 
 Using `ActiveSpan`s is the recommended way to trace code with `emit`. It applies filtering for you, so the span is only created if it matches the configured filter. It also ensures a span is emitted even if the traced code panics or otherwise returns without explicitly completing.
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -389,7 +389,12 @@ pub fn span(
     args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    span::expand_tokens(span::ExpandTokens { level: None, input: TokenStream::from(args), item: TokenStream::from(item) }).unwrap_or_compile_error()
+    span::expand_tokens(span::ExpandTokens {
+        level: None,
+        input: TokenStream::from(args),
+        item: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -404,7 +409,12 @@ pub fn debug_span(
     args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    span::expand_tokens(span::ExpandTokens { level: Some(quote!(emit::Level::Debug)), input: TokenStream::from(args), item: TokenStream::from(item) }).unwrap_or_compile_error()
+    span::expand_tokens(span::ExpandTokens {
+        level: Some(quote!(emit::Level::Debug)),
+        input: TokenStream::from(args),
+        item: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -419,7 +429,12 @@ pub fn info_span(
     args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    span::expand_tokens(span::ExpandTokens { level: Some(quote!(emit::Level::Info)), input: TokenStream::from(args), item: TokenStream::from(item) }).unwrap_or_compile_error()
+    span::expand_tokens(span::ExpandTokens {
+        level: Some(quote!(emit::Level::Info)),
+        input: TokenStream::from(args),
+        item: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -434,7 +449,12 @@ pub fn warn_span(
     args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    span::expand_tokens(span::ExpandTokens { level: Some(quote!(emit::Level::Warn)), input: TokenStream::from(args), item: TokenStream::from(item) }).unwrap_or_compile_error()
+    span::expand_tokens(span::ExpandTokens {
+        level: Some(quote!(emit::Level::Warn)),
+        input: TokenStream::from(args),
+        item: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -449,7 +469,12 @@ pub fn error_span(
     args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    span::expand_tokens(span::ExpandTokens { level: Some(quote!(emit::Level::Error)), input: TokenStream::from(args), item: TokenStream::from(item) }).unwrap_or_compile_error()
+    span::expand_tokens(span::ExpandTokens {
+        level: Some(quote!(emit::Level::Error)),
+        input: TokenStream::from(args),
+        item: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -487,8 +512,8 @@ The template for the event. See the [`macro@tpl`] macro for syntax.
 Properties that appear within the template or after it are added to the emitted event. The identifier of the property is its key. Property capturing can be adjusted through the `as_*` attribute macros.
 */
 #[proc_macro]
-pub fn start_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    span::expand_start_tokens(span::ExpandStartTokens {
+pub fn new_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    span::expand_new_tokens(span::ExpandNewTokens {
         level: None,
         input: TokenStream::from(item),
     })
@@ -500,11 +525,11 @@ Start a debug span.
 
 # Syntax
 
-See the [`macro@start_span`] macro for syntax.
+See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
 pub fn start_debug_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    span::expand_start_tokens(span::ExpandStartTokens {
+    span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Debug)),
         input: TokenStream::from(item),
     })
@@ -516,11 +541,11 @@ Start an info span.
 
 # Syntax
 
-See the [`macro@start_span`] macro for syntax.
+See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
 pub fn start_info_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    span::expand_start_tokens(span::ExpandStartTokens {
+    span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Info)),
         input: TokenStream::from(item),
     })
@@ -532,11 +557,11 @@ Start a warning span.
 
 # Syntax
 
-See the [`macro@start_span`] macro for syntax.
+See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
 pub fn start_warn_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    span::expand_start_tokens(span::ExpandStartTokens {
+    span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Warn)),
         input: TokenStream::from(item),
     })
@@ -548,11 +573,11 @@ Start an error span.
 
 # Syntax
 
-See the [`macro@start_span`] macro for syntax.
+See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
 pub fn start_error_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    span::expand_start_tokens(span::ExpandStartTokens {
+    span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Error)),
         input: TokenStream::from(item),
     })
@@ -627,7 +652,11 @@ Properties that appear within the template or after it are added to the emitted 
 */
 #[proc_macro]
 pub fn emit(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    emit::expand_tokens(emit::ExpandTokens { level: None, input: TokenStream::from(item) }).unwrap_or_compile_error()
+    emit::expand_tokens(emit::ExpandTokens {
+        level: None,
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -639,11 +668,15 @@ See the [`macro@emit`] macro for syntax.
 */
 #[proc_macro]
 pub fn debug(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    emit::expand_tokens(emit::ExpandTokens { level: Some(quote!(emit::Level::Debug)), input: TokenStream::from(item) }).unwrap_or_compile_error()
+    emit::expand_tokens(emit::ExpandTokens {
+        level: Some(quote!(emit::Level::Debug)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
-Emit a info event.
+Emit an info event.
 
 # Syntax
 
@@ -651,7 +684,11 @@ See the [`macro@emit`] macro for syntax.
 */
 #[proc_macro]
 pub fn info(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    emit::expand_tokens(emit::ExpandTokens { level: Some(quote!(emit::Level::Info)), input: TokenStream::from(item) }).unwrap_or_compile_error()
+    emit::expand_tokens(emit::ExpandTokens {
+        level: Some(quote!(emit::Level::Info)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -663,7 +700,11 @@ See the [`macro@emit`] macro for syntax.
 */
 #[proc_macro]
 pub fn warn(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    emit::expand_tokens(emit::ExpandTokens { level: Some(quote!(emit::Level::Warn)), input: TokenStream::from(item) }).unwrap_or_compile_error()
+    emit::expand_tokens(emit::ExpandTokens {
+        level: Some(quote!(emit::Level::Warn)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**
@@ -675,7 +716,11 @@ See the [`macro@emit`] macro for syntax.
 */
 #[proc_macro]
 pub fn error(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    emit::expand_tokens(emit::ExpandTokens { level: Some(quote!(emit::Level::Error)), input: TokenStream::from(item) }).unwrap_or_compile_error()
+    emit::expand_tokens(emit::ExpandTokens {
+        level: Some(quote!(emit::Level::Error)),
+        input: TokenStream::from(item),
+    })
+    .unwrap_or_compile_error()
 }
 
 /**

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -480,6 +480,8 @@ pub fn error_span(
 /**
 Start a span.
 
+See the [`ActiveSpan::new`](https://docs.rs/emit/0.11.0-alpha.21/emit/span/struct.ActiveSpan.html#method.new) for details on starting and completing the returned span.
+
 # Syntax
 
 ```text
@@ -528,7 +530,7 @@ Start a debug span.
 See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
-pub fn start_debug_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn new_debug_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Debug)),
         input: TokenStream::from(item),
@@ -544,7 +546,7 @@ Start an info span.
 See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
-pub fn start_info_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn new_info_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Info)),
         input: TokenStream::from(item),
@@ -560,7 +562,7 @@ Start a warning span.
 See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
-pub fn start_warn_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn new_warn_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Warn)),
         input: TokenStream::from(item),
@@ -576,7 +578,7 @@ Start an error span.
 See the [`macro@new_span`] macro for syntax.
 */
 #[proc_macro]
-pub fn start_error_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn new_error_span(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     span::expand_new_tokens(span::ExpandNewTokens {
         level: Some(quote!(emit::Level::Error)),
         input: TokenStream::from(item),

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -295,7 +295,7 @@ fn inject_sync(
     Ok(quote!({
         #setup_tokens
 
-        let (__span_guard, __ctxt) = emit::__private::__private_begin_span(
+        let (mut __span_guard, __ctxt) = emit::__private::__private_begin_span(
             #rt_tokens,
             #mdl_tokens,
             #span_name_tokens,
@@ -306,6 +306,8 @@ fn inject_sync(
         );
 
         __ctxt.call(move || {
+            __span_guard.start();
+
             let #span_guard = __span_guard;
 
             #body_tokens
@@ -381,6 +383,8 @@ fn inject_async(
         );
 
         __ctxt.in_future(async move {
+            __span_guard.start();
+
             let #span_guard = __span_guard;
             #body_tokens
         }).await
@@ -516,15 +520,15 @@ fn completion(
     })
 }
 
-pub struct ExpandStartTokens {
+pub struct ExpandNewTokens {
     pub level: Option<TokenStream>,
     pub input: TokenStream,
 }
 
 /**
-The `start_span!` macro.
+The `new_span!` macro.
 */
-pub fn expand_start_tokens(opts: ExpandStartTokens) -> Result<TokenStream, syn::Error> {
+pub fn expand_new_tokens(opts: ExpandNewTokens) -> Result<TokenStream, syn::Error> {
     let span = opts.input.span();
 
     let (args, template, ctxt_props) =

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -838,7 +838,7 @@ pub fn __private_begin_span<
     let name = name.into();
     let lvl_prop = lvl.and_then(|lvl| lvl.capture()).map(|lvl| (KEY_LVL, lvl));
 
-    ActiveSpan::start(
+    ActiveSpan::new(
         filter::from_fn(|evt| {
             FirstDefined(when, rt.filter())
                 .matches(evt.map_props(|props| props.and_props(&lvl_prop)))

--- a/src/span.rs
+++ b/src/span.rs
@@ -1991,7 +1991,7 @@ mod tests {
         let custom_complete_called = Cell::new(false);
         let default_complete_called = Cell::new(false);
 
-        let (guard, _) = ActiveSpan::new(
+        let (mut guard, _) = ActiveSpan::new(
             filter::from_fn(|_| true),
             &ctxt,
             &clock,
@@ -2006,6 +2006,8 @@ mod tests {
         );
 
         assert!(guard.is_enabled());
+
+        guard.start();
 
         guard.complete_with(completion::from_fn(|_| {
             custom_complete_called.set(true);

--- a/src/span.rs
+++ b/src/span.rs
@@ -33,7 +33,7 @@ use crate::{
     Frame, Timer,
 };
 use core::{
-    fmt,
+    fmt, mem,
     num::{NonZeroU128, NonZeroU64},
     ops::ControlFlow,
     str::{self, FromStr},
@@ -820,23 +820,29 @@ The [`ActiveSpan::start`] method can be used to construct an `ActiveSpan` and [`
 **Make sure you pass ownership of the returned `ActiveSpan` into the closure in [`Frame::call`] or async block in [`Frame::in_future`]**. If you don't, the span will complete early, without its ambient context.
 */
 pub struct ActiveSpan<'a, T: Clock, P: Props, F: Completion> {
-    // `state` is `None` if the span is completed
-    state: Option<ActiveSpanState<'a, T, P>>,
+    state: ActiveSpanState<T>,
+    // `data` is `None` if the span is completed
+    data: Option<ActiveSpanData<'a, P>>,
     // `completion` is `None` if the span is disabled
     completion: Option<F>,
 }
 
-struct ActiveSpanState<'a, T: Clock, P: Props> {
+struct ActiveSpanData<'a, P: Props> {
     mdl: Path<'a>,
-    timer: Timer<T>,
     name: Str<'a>,
     ctxt: SpanCtxt,
     props: P,
 }
 
-impl<'a, T: Clock, P: Props> ActiveSpanState<'a, T, P> {
-    fn complete(self) -> Span<'a, P> {
-        Span::new(self.mdl, self.name, self.timer, self.props)
+enum ActiveSpanState<T: Clock> {
+    Initial(T),
+    Started(Timer<T>),
+    Completed,
+}
+
+impl<T: Clock> ActiveSpanState<T> {
+    fn take(&mut self) -> Self {
+        mem::replace(self, ActiveSpanState::Completed)
     }
 }
 
@@ -863,11 +869,11 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     2. The filter is checked to see if the span should be enabled or disabled. The event passed to the filter is a [`Span`] carrying the generated span context, but without an extent.
     3. A [`Frame`] carrying the generated [`SpanCtxt`] and `ctxt_props`, and an `ActiveSpan` for completing the span is returned.
 
-    The returned `ActiveSpan` will complete automatically on drop, or manually through [`ActiveSpan::complete`] or [`ActiveSpan::complete_with`].
+    Call [`ActiveSpan::start`] in the closure of [`Frame::call`] or async block of [`Frame::in_future`] on the returned [`Frame`] to begin the span. Once the span is started, it will complete automatically on drop, or manually through [`ActiveSpan::complete`].
 
     **Make sure you pass ownership of the returned `ActiveSpan` into the closure in [`Frame::call`] or async block in [`Frame::in_future`]**. If you don't, the span will complete early, without its ambient context.
     */
-    pub fn start<C: Ctxt>(
+    pub fn new<C: Ctxt>(
         filter: impl Filter,
         ctxt: C,
         clock: T,
@@ -882,7 +888,6 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
         let span_name = span_name.into();
 
         let span_ctxt = SpanCtxt::current(&ctxt).new_child(rng);
-        let span_timer = Timer::start(clock);
 
         // Check whether the span should be constructed using a dummy event
         let is_enabled = ctxt.with_current(|current_ctxt_props| {
@@ -905,8 +910,8 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
         // This can be completed automatically by dropping
         // or manually through the `complete` method
         let guard = ActiveSpan {
-            state: Some(ActiveSpanState {
-                timer: span_timer,
+            state: ActiveSpanState::Initial(clock),
+            data: Some(ActiveSpanData {
                 mdl: span_mdl,
                 ctxt: span_ctxt,
                 name: span_name,
@@ -923,13 +928,29 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     }
 
     fn push_ctxt<C: Ctxt>(&self, ctxt: C, ctxt_props: impl Props) -> Frame<C> {
-        let span_ctxt = self.state.as_ref().expect("span is already complete").ctxt;
+        let span_ctxt = self.data.as_ref().expect("span is already complete").ctxt;
 
         if self.is_enabled() {
             Frame::push(ctxt, ctxt_props.and_props(span_ctxt))
         } else {
             Frame::disabled(ctxt, ctxt_props.and_props(span_ctxt))
         }
+    }
+
+    /**
+    Start the span.
+
+    From this point the span can be completed by either dropping this value, or by calling [`ActiveSpan::complete`].
+    */
+    pub fn start(&mut self) {
+        let state = mem::replace(&mut self.state, ActiveSpanState::Completed);
+
+        let ActiveSpanState::Initial(clock) = state else {
+            self.state = state;
+            return;
+        };
+
+        self.state = ActiveSpanState::Started(Timer::start(clock));
     }
 
     /**
@@ -950,6 +971,7 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
 
         ActiveSpan {
             state: self.state.take(),
+            data: self.data.take(),
             completion: Some(completion),
         }
     }
@@ -958,8 +980,8 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     Set the module of the span.
     */
     pub fn with_mdl(mut self, mdl: impl Into<Path<'a>>) -> Self {
-        if let Some(ref mut state) = self.state {
-            state.mdl = mdl.into();
+        if let Some(ref mut data) = self.data {
+            data.mdl = mdl.into();
         }
         self
     }
@@ -968,8 +990,8 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     Set the name of the span.
     */
     pub fn with_name(mut self, name: impl Into<Str<'a>>) -> Self {
-        if let Some(ref mut state) = self.state {
-            state.name = name.into();
+        if let Some(ref mut data) = self.data {
+            data.name = name.into();
         }
         self
     }
@@ -985,16 +1007,16 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     Map the properties of the span.
     */
     pub fn map_props<U: Props>(mut self, map: impl FnOnce(P) -> U) -> ActiveSpan<'a, T, U, F> {
-        let state = self.state.take().map(|state| ActiveSpanState {
-            mdl: state.mdl,
-            timer: state.timer,
-            name: state.name,
-            ctxt: state.ctxt,
-            props: map(state.props),
+        let data = self.data.take().map(|data| ActiveSpanData {
+            mdl: data.mdl,
+            name: data.name,
+            ctxt: data.ctxt,
+            props: map(data.props),
         });
 
         ActiveSpan {
-            state,
+            state: self.state.take(),
+            data,
             completion: self.completion.take(),
         }
     }
@@ -1009,8 +1031,10 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     }
 
     fn complete_default(&mut self) -> bool {
-        if let (Some(state), Some(completion)) = (self.state.take(), self.completion.take()) {
-            completion.complete(state.complete());
+        if let (ActiveSpanState::Started(timer), Some(data), Some(completion)) =
+            (self.state.take(), self.data.take(), self.completion.take())
+        {
+            completion.complete(Span::new(data.mdl, data.name, timer, data.props));
 
             true
         } else {
@@ -1024,8 +1048,10 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
     If the span is disabled then the `complete` closure won't be called and this method will return `false`.
     */
     pub fn complete_with(mut self, completion: impl Completion) -> bool {
-        if let (Some(state), Some(_)) = (self.state.take(), self.completion.take()) {
-            completion.complete(state.complete());
+        if let (ActiveSpanState::Started(timer), Some(data), Some(_)) =
+            (self.state.take(), self.data.take(), self.completion.take())
+        {
+            completion.complete(Span::new(data.mdl, data.name, timer, data.props));
 
             true
         } else {
@@ -1830,14 +1856,14 @@ mod tests {
 
     #[test]
     #[cfg(all(feature = "std", feature = "rand", not(miri)))]
-    fn active_span_start() {
+    fn active_span_new() {
         let clock = MyClock(Cell::new(0));
         let rng = crate::platform::rand_rng::RandRng::new();
         let ctxt = crate::platform::thread_local_ctxt::ThreadLocalCtxt::new();
 
         let complete_called = Cell::new(false);
 
-        let (guard, frame) = ActiveSpan::start(
+        let (mut guard, frame) = ActiveSpan::new(
             filter::from_fn(|evt| {
                 assert_eq!(2, evt.props().pull::<usize, _>("ctxt_prop").unwrap());
 
@@ -1883,6 +1909,8 @@ mod tests {
         assert!(guard.is_enabled());
 
         frame.call(move || {
+            guard.start();
+
             drop(guard);
         });
 
@@ -1891,14 +1919,44 @@ mod tests {
 
     #[test]
     #[cfg(all(feature = "std", feature = "rand", not(miri)))]
-    fn active_span_start_disabled() {
+    fn active_span_unstarted_complete() {
+        let clock = MyClock(Cell::new(0));
+        let rng = crate::platform::rand_rng::RandRng::new();
+        let ctxt = crate::platform::thread_local_ctxt::ThreadLocalCtxt::new();
+
+        let complete_called = Cell::new(false);
+
+        let (guard, frame) = ActiveSpan::new(
+            filter::from_fn(|_| true),
+            &ctxt,
+            &clock,
+            &rng,
+            completion::from_fn(|_| {}),
+            Empty,
+            Path::new_raw("test"),
+            "span",
+            Empty,
+        );
+
+        assert!(guard.is_enabled());
+
+        frame.call(move || {
+            drop(guard);
+        });
+
+        assert!(!complete_called.get());
+    }
+
+    #[test]
+    #[cfg(all(feature = "std", feature = "rand", not(miri)))]
+    fn active_span_new_disabled() {
         let rng = crate::platform::rand_rng::RandRng::new();
         let clock = crate::platform::system_clock::SystemClock::new();
         let ctxt = crate::platform::thread_local_ctxt::ThreadLocalCtxt::new();
 
         let complete_called = Cell::new(false);
 
-        let (guard, frame) = ActiveSpan::start(
+        let (mut guard, frame) = ActiveSpan::new(
             filter::from_fn(|_| false),
             &ctxt,
             &clock,
@@ -1915,6 +1973,8 @@ mod tests {
         assert!(!guard.is_enabled());
 
         frame.call(move || {
+            guard.start();
+
             drop(guard);
         });
 
@@ -1931,7 +1991,7 @@ mod tests {
         let custom_complete_called = Cell::new(false);
         let default_complete_called = Cell::new(false);
 
-        let (guard, _) = ActiveSpan::start(
+        let (guard, _) = ActiveSpan::new(
             filter::from_fn(|_| true),
             &ctxt,
             &clock,
@@ -1964,7 +2024,7 @@ mod tests {
 
         let complete_called = Cell::new(false);
 
-        let (guard, frame) = ActiveSpan::start(
+        let (mut guard, frame) = ActiveSpan::new(
             filter::from_fn(|_| true),
             &ctxt,
             &clock,
@@ -1981,6 +2041,8 @@ mod tests {
         );
 
         frame.call(move || {
+            guard.start();
+
             let guard = guard.with_props(("event_prop", 2));
 
             drop(guard);

--- a/src/span.rs
+++ b/src/span.rs
@@ -809,13 +809,17 @@ An active span in a distributed trace.
 
 ## Creating active spans automatically
 
-This type is created by the [`macro@crate::span!`] macro with the `guard` control parameter. See the [`mod@crate::span`] module for details on creating spans.
+This type is created by the [`macro@crate::span!`] macro with the `guard` control parameter, or with the [`macro@crate::new_span!`] macro.
+
+
 
 Call [`ActiveSpan::complete_with`], or just drop the guard to complete it, passing the resulting [`Span`] to a [`Completion`].
 
 ## Creating active spans manually
 
-The [`ActiveSpan::start`] method can be used to construct an `ActiveSpan` and [`Frame`] manually.
+The [`ActiveSpan::new`] method can be used to construct an `ActiveSpan` and [`Frame`] manually.
+
+Call [`ActiveSpan::start`] in the closure of [`Frame::call`] or async block of [`Frame::in_future`] on the returned [`Frame`] to begin the span. Once the span is started, it will complete automatically on drop, or manually through [`ActiveSpan::complete`].
 
 **Make sure you pass ownership of the returned `ActiveSpan` into the closure in [`Frame::call`] or async block in [`Frame::in_future`]**. If you don't, the span will complete early, without its ambient context.
 */
@@ -865,9 +869,10 @@ impl<'a, T: Clock, P: Props, F: Completion> ActiveSpan<'a, T, P, F> {
 
     This method constructs a span based on the input properties and current context as follows:
 
-    1. A [`SpanCtxt`] for the span is generated using [`SpanCtxt::new_child`].
-    2. The filter is checked to see if the span should be enabled or disabled. The event passed to the filter is a [`Span`] carrying the generated span context, but without an extent.
-    3. A [`Frame`] carrying the generated [`SpanCtxt`] and `ctxt_props`, and an `ActiveSpan` for completing the span is returned.
+    - A [`SpanCtxt`] for the span is generated using [`SpanCtxt::new_child`].
+    - The filter is checked to see if the span should be enabled or disabled. The event passed to the filter is a [`Span`] carrying the generated span context, but without an extent.
+
+    This method returns a tuple of an `ActiveSpan` for starting and completing the span, and a [`Frame`] carrying the generated [`SpanCtxt`] and `ctxt_props`.
 
     Call [`ActiveSpan::start`] in the closure of [`Frame::call`] or async block of [`Frame::in_future`] on the returned [`Frame`] to begin the span. Once the span is started, it will complete automatically on drop, or manually through [`ActiveSpan::complete`].
 

--- a/test/ui/src/lib.rs
+++ b/test/ui/src/lib.rs
@@ -18,9 +18,9 @@ mod util;
 
 mod emit;
 mod event;
+mod new_span;
 mod props;
 mod span;
-mod start_span;
 mod tpl;
 
 #[cfg(feature = "std")]

--- a/test/ui/src/new_span.rs
+++ b/test/ui/src/new_span.rs
@@ -46,28 +46,28 @@ fn new_span_basic() {
                 });
             }
             Some(emit::Level::Debug) => {
-                let (mut guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_debug_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
                     guard.start();
                 });
             }
             Some(emit::Level::Info) => {
-                let (mut guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_info_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
                     guard.start();
                 });
             }
             Some(emit::Level::Warn) => {
-                let (mut guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_warn_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
                     guard.start();
                 });
             }
             Some(emit::Level::Error) => {
-                let (mut guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_error_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
                     guard.start();
@@ -129,7 +129,7 @@ async fn new_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Debug) => {
-                let (mut guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_debug_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
@@ -142,7 +142,7 @@ async fn new_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Info) => {
-                let (mut guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_info_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
@@ -155,7 +155,7 @@ async fn new_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Warn) => {
-                let (mut guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_warn_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
@@ -168,7 +168,7 @@ async fn new_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Error) => {
-                let (mut guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_error_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {

--- a/test/ui/src/new_span.rs
+++ b/test/ui/src/new_span.rs
@@ -5,7 +5,7 @@ use emit::{Emitter, Props};
 use crate::util::{simple_runtime, Called};
 
 #[test]
-fn start_span_basic() {
+fn new_span_basic() {
     for lvl in [
         Some(emit::Level::Debug),
         Some(emit::Level::Info),
@@ -39,38 +39,38 @@ fn start_span_basic() {
 
         match lvl {
             None => {
-                let (guard, frame) = emit::start_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
-                    guard.complete();
+                    guard.start();
                 });
             }
             Some(emit::Level::Debug) => {
-                let (guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
-                    guard.complete();
+                    guard.start();
                 });
             }
             Some(emit::Level::Info) => {
-                let (guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
-                    guard.complete();
+                    guard.start();
                 });
             }
             Some(emit::Level::Warn) => {
-                let (guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
-                    guard.complete();
+                    guard.start();
                 });
             }
             Some(emit::Level::Error) => {
-                let (guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
 
                 frame.call(move || {
-                    guard.complete();
+                    guard.start();
                 });
             }
         }
@@ -82,7 +82,7 @@ fn start_span_basic() {
 }
 
 #[tokio::test]
-async fn start_span_basic_async() {
+async fn new_span_basic_async() {
     for lvl in [
         Some(emit::Level::Debug),
         Some(emit::Level::Info),
@@ -116,10 +116,12 @@ async fn start_span_basic_async() {
 
         match lvl {
             None => {
-                let (guard, frame) = emit::start_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::new_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
+                        guard.start();
+
                         tokio::time::sleep(Duration::from_micros(1)).await;
 
                         guard.complete();
@@ -127,10 +129,12 @@ async fn start_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Debug) => {
-                let (guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_debug_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
+                        guard.start();
+
                         tokio::time::sleep(Duration::from_micros(1)).await;
 
                         guard.complete();
@@ -138,10 +142,12 @@ async fn start_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Info) => {
-                let (guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_info_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
+                        guard.start();
+
                         tokio::time::sleep(Duration::from_micros(1)).await;
 
                         guard.complete();
@@ -149,10 +155,12 @@ async fn start_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Warn) => {
-                let (guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_warn_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
+                        guard.start();
+
                         tokio::time::sleep(Duration::from_micros(1)).await;
 
                         guard.complete();
@@ -160,10 +168,12 @@ async fn start_span_basic_async() {
                     .await;
             }
             Some(emit::Level::Error) => {
-                let (guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
+                let (mut guard, frame) = emit::start_error_span!(rt, "Hello, {user}");
 
                 frame
                     .in_future(async move {
+                        guard.start();
+
                         tokio::time::sleep(Duration::from_micros(1)).await;
 
                         guard.complete();


### PR DESCRIPTION
This PR tweaks the new `ActiveSpan` creation API to reduce the footgun of not passing ownership of the span into the frame. It does this by requiring a call to `ActiveSpan::start` to actually start the span, which can easily be done at the top of the `Frame::call` or `Frame::in_future` body.