### PR TITLE
Bump thiserror to 2.0

### DIFF
--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../emitter/file"
 path = "../../traceparent"
 
 [dependencies.thiserror]
-version = "1"
+version = "2"
 
 [dependencies.anyhow]
 version = "1"


### PR DESCRIPTION
This is only used in examples. It looks like everything else is still current.