### PR TITLE
Fix up batcher capacity calculation

### DIFF
--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -601,7 +601,7 @@ impl Capacity {
         // Note that this value is used for initial capacity, but is updated
         // based on the actual length, so adding more space here doesn't mean
         // the `max_len` value will always increase over time
-        max_len + cmp::max(1, max_len / 10)
+        max_len.saturating_add(cmp::max(1, max_len / 10))
     }
 }
 


### PR DESCRIPTION
The underlying calculation used for determining capacity was broken. Instead of using its rolling average value correctly, it would just assign and use the first slot indefinitely. I've fixed this up, added a little extra space to accommodate small shifts without needing to re-allocate, and slightly increased the rolling window size.