### PR TITLE
Replace `Value::as_f64_seq` with `Value::to_f64_seq` with clearer semantics

### DIFF
--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -247,7 +247,7 @@ fn write_event(buf: &mut Buffer, evt: emit::event::Event<impl emit::props::Props
     }
 
     if let Some(value) = evt.props().get(KEY_METRIC_VALUE) {
-        let buckets = value.as_f64_sequence();
+        let buckets = value.to_f64_sequence().unwrap_or_default();
 
         if !buckets.is_empty() {
             write_timeseries(buf, &buckets);


### PR DESCRIPTION
Closes #210 

Rather than getting spongy with sequence semantics, I've opted to just return an optional vec instead. That way, if you want an empty one you can `unwrap_or_default()`, or if you want one with a single element you can `unwrap_or_else(|| vec![v.as_f64()])`.