### PR TITLE
Improve support for building on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ categories = ["development-tools::debugging"]
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["std", "sval", "serde", "implicit_rt", "implicit_internal_rt"]
+features = ["std", "rand", "sval", "serde", "implicit_rt", "implicit_internal_rt"]
 
 [features]
-default = ["std", "implicit_rt", "implicit_internal_rt"]
-std = ["alloc", "emit_macros/std", "emit_core/std", "rand"]
+default = ["std", "rand", "implicit_rt", "implicit_internal_rt"]
+std = ["alloc", "emit_macros/std", "emit_core/std"]
 alloc = ["emit_core/alloc"]
 sval = ["emit_macros/sval", "emit_core/sval", "dep:sval"]
 serde = ["emit_macros/serde", "emit_core/serde", "dep:serde"]

--- a/emitter/file/Cargo.toml
+++ b/emitter/file/Cargo.toml
@@ -21,7 +21,7 @@ default_writer = ["emit/sval", "sval_json"]
 version = "0.11.9"
 path = "../../"
 default-features = false
-features = ["std", "implicit_internal_rt"]
+features = ["std", "rand", "implicit_internal_rt"]
 
 [dependencies.sval]
 version = "2"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -28,12 +28,6 @@ pub type DefaultRng = rand_rng::RandRng;
 mod std_support {
     use super::*;
 
-    use emit_core::{
-        clock::{Clock, ErasedClock},
-        rng::{ErasedRng, Rng},
-        runtime::AssertInternal,
-    };
-
     /**
     The default [`crate::Clock`].
     */
@@ -58,37 +52,6 @@ mod std_support {
     The default [`crate::Ctxt`] to use in [`crate::setup()`].
     */
     pub type DefaultCtxt = thread_local_ctxt::ThreadLocalCtxt;
-
-    /**
-    A type-erased container for system services used when intiailizing runtimes.
-    */
-    pub(crate) struct Platform {
-        pub(crate) clock: AssertInternal<Box<dyn ErasedClock + Send + Sync>>,
-        pub(crate) rng: AssertInternal<Box<dyn ErasedRng + Send + Sync>>,
-    }
-
-    impl Default for Platform {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-
-    impl Platform {
-        pub fn new() -> Self {
-            Platform {
-                clock: AssertInternal(Box::new(DefaultClock::default())),
-                rng: AssertInternal(Box::new(DefaultRng::default())),
-            }
-        }
-
-        pub fn with_clock(&mut self, clock: impl Clock + Send + Sync + 'static) {
-            self.clock = AssertInternal(Box::new(clock));
-        }
-
-        pub fn with_rng(&mut self, rng: impl Rng + Send + Sync + 'static) {
-            self.rng = AssertInternal(Box::new(rng));
-        }
-    }
 }
 
 #[cfg(feature = "std")]
@@ -103,7 +66,7 @@ mod no_std_support {
     pub type DefaultClock = crate::Empty;
 
     /**
-    The default [`crate::Ctxt`]..
+    The default [`crate::Ctxt`].
     */
     #[cfg(not(feature = "std"))]
     pub type DefaultCtxt = crate::Empty;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -82,10 +82,12 @@ use core::time::Duration;
 
 use emit_core::{
     and::And,
+    clock::Clock,
     ctxt::Ctxt,
     emitter::Emitter,
     empty::Empty,
     filter::Filter,
+    rng::Rng,
     runtime::{AmbientRuntime, AmbientSlot, InternalCtxt, InternalEmitter, InternalFilter},
 };
 
@@ -238,6 +240,30 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, T
             ctxt: map(self.ctxt),
             platform: self.platform,
         }
+    }
+
+    /**
+    Set the [`Clock`] used to assign timestamps and run timers.
+    */
+    pub fn with_clock(
+        mut self,
+        clock: impl Clock + Send + Sync + 'static,
+    ) -> Setup<TEmitter, TFilter, TCtxt> {
+        self.platform.with_clock(clock);
+
+        self
+    }
+
+    /**
+    Set the [`Rng`] used to assign trace and span ids.
+    */
+    pub fn with_rng(
+        mut self,
+        rng: impl Rng + Send + Sync + 'static,
+    ) -> Setup<TEmitter, TFilter, TCtxt> {
+        self.platform.with_rng(rng);
+
+        self
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -88,10 +88,11 @@ use emit_core::{
     empty::Empty,
     filter::Filter,
     rng::Rng,
-    runtime::{AmbientRuntime, AmbientSlot, InternalCtxt, InternalEmitter, InternalFilter},
+    runtime::{
+        AmbientRuntime, AmbientSlot, InternalClock, InternalCtxt, InternalEmitter, InternalFilter,
+        InternalRng,
+    },
 };
-
-use crate::platform::{self, Platform};
 
 /**
 Configure `emit` with [`Emitter`]s, [`Filter`]s, and [`Ctxt`].
@@ -102,7 +103,7 @@ pub fn setup() -> Setup {
     Setup::default()
 }
 
-pub use platform::{DefaultClock, DefaultCtxt, DefaultRng};
+pub use crate::platform::{DefaultClock, DefaultCtxt, DefaultRng};
 
 /**
 The default [`Emitter`] to use in [`setup()`].
@@ -118,11 +119,18 @@ pub type DefaultFilter = Empty;
 A configuration builder for an `emit` runtime.
 */
 #[must_use = "call `.init()` to finish setup"]
-pub struct Setup<TEmitter = DefaultEmitter, TFilter = DefaultFilter, TCtxt = DefaultCtxt> {
+pub struct Setup<
+    TEmitter = DefaultEmitter,
+    TFilter = DefaultFilter,
+    TCtxt = DefaultCtxt,
+    TClock = DefaultClock,
+    TRng = DefaultRng,
+> {
     emitter: TEmitter,
     filter: TFilter,
     ctxt: TCtxt,
-    platform: Platform,
+    clock: TClock,
+    rng: TRng,
 }
 
 impl Default for Setup {
@@ -140,21 +148,28 @@ impl Setup {
             emitter: Default::default(),
             filter: Default::default(),
             ctxt: Default::default(),
-            platform: Default::default(),
+            clock: Default::default(),
+            rng: Default::default(),
         }
     }
 }
 
-impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, TCtxt> {
+impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt, TClock: Clock, TRng: Rng>
+    Setup<TEmitter, TFilter, TCtxt, TClock, TRng>
+{
     /**
     Set the [`Emitter`] that will receive diagnostic events.
     */
-    pub fn emit_to<UEmitter: Emitter>(self, emitter: UEmitter) -> Setup<UEmitter, TFilter, TCtxt> {
+    pub fn emit_to<UEmitter: Emitter>(
+        self,
+        emitter: UEmitter,
+    ) -> Setup<UEmitter, TFilter, TCtxt, TClock, TRng> {
         Setup {
             emitter,
             filter: self.filter,
             ctxt: self.ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
@@ -164,12 +179,13 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, T
     pub fn and_emit_to<UEmitter: Emitter>(
         self,
         emitter: UEmitter,
-    ) -> Setup<And<TEmitter, UEmitter>, TFilter, TCtxt> {
+    ) -> Setup<And<TEmitter, UEmitter>, TFilter, TCtxt, TClock, TRng> {
         Setup {
             emitter: self.emitter.and_to(emitter),
             filter: self.filter,
             ctxt: self.ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
@@ -179,24 +195,29 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, T
     pub fn map_emitter<UEmitter: Emitter>(
         self,
         map: impl FnOnce(TEmitter) -> UEmitter,
-    ) -> Setup<UEmitter, TFilter, TCtxt> {
+    ) -> Setup<UEmitter, TFilter, TCtxt, TClock, TRng> {
         Setup {
             emitter: map(self.emitter),
             filter: self.filter,
             ctxt: self.ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
     /**
     Set the [`Filter`] that will be applied before diagnostic events are emitted.
     */
-    pub fn emit_when<UFilter: Filter>(self, filter: UFilter) -> Setup<TEmitter, UFilter, TCtxt> {
+    pub fn emit_when<UFilter: Filter>(
+        self,
+        filter: UFilter,
+    ) -> Setup<TEmitter, UFilter, TCtxt, TClock, TRng> {
         Setup {
             emitter: self.emitter,
             filter,
             ctxt: self.ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
@@ -206,24 +227,29 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, T
     pub fn and_emit_when<UFilter: Filter>(
         self,
         filter: UFilter,
-    ) -> Setup<TEmitter, And<TFilter, UFilter>, TCtxt> {
+    ) -> Setup<TEmitter, And<TFilter, UFilter>, TCtxt, TClock, TRng> {
         Setup {
             emitter: self.emitter,
             filter: self.filter.and_when(filter),
             ctxt: self.ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
     /**
     Set the [`Ctxt`] that will store ambient properties and attach them to diagnostic events.
     */
-    pub fn with_ctxt<UCtxt: Ctxt>(self, ctxt: UCtxt) -> Setup<TEmitter, TFilter, UCtxt> {
+    pub fn with_ctxt<UCtxt: Ctxt>(
+        self,
+        ctxt: UCtxt,
+    ) -> Setup<TEmitter, TFilter, UCtxt, TClock, TRng> {
         Setup {
             emitter: self.emitter,
             filter: self.filter,
             ctxt,
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
@@ -233,37 +259,43 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt> Setup<TEmitter, TFilter, T
     pub fn map_ctxt<UCtxt: Ctxt>(
         self,
         map: impl FnOnce(TCtxt) -> UCtxt,
-    ) -> Setup<TEmitter, TFilter, UCtxt> {
+    ) -> Setup<TEmitter, TFilter, UCtxt, TClock, TRng> {
         Setup {
             emitter: self.emitter,
             filter: self.filter,
             ctxt: map(self.ctxt),
-            platform: self.platform,
+            clock: self.clock,
+            rng: self.rng,
         }
     }
 
     /**
     Set the [`Clock`] used to assign timestamps and run timers.
     */
-    pub fn with_clock(
-        mut self,
-        clock: impl Clock + Send + Sync + 'static,
-    ) -> Setup<TEmitter, TFilter, TCtxt> {
-        self.platform.with_clock(clock);
-
-        self
+    pub fn with_clock<UClock: Clock>(
+        self,
+        clock: UClock,
+    ) -> Setup<TEmitter, TFilter, TCtxt, UClock, TRng> {
+        Setup {
+            emitter: self.emitter,
+            filter: self.filter,
+            ctxt: self.ctxt,
+            clock,
+            rng: self.rng,
+        }
     }
 
     /**
     Set the [`Rng`] used to assign trace and span ids.
     */
-    pub fn with_rng(
-        mut self,
-        rng: impl Rng + Send + Sync + 'static,
-    ) -> Setup<TEmitter, TFilter, TCtxt> {
-        self.platform.with_rng(rng);
-
-        self
+    pub fn with_rng<URng: Rng>(self, rng: URng) -> Setup<TEmitter, TFilter, TCtxt, TClock, URng> {
+        Setup {
+            emitter: self.emitter,
+            filter: self.filter,
+            ctxt: self.ctxt,
+            clock: self.clock,
+            rng,
+        }
     }
 }
 
@@ -271,7 +303,9 @@ impl<
         TEmitter: Emitter + Send + Sync + 'static,
         TFilter: Filter + Send + Sync + 'static,
         TCtxt: Ctxt + Send + Sync + 'static,
-    > Setup<TEmitter, TFilter, TCtxt>
+        TClock: Clock + Send + Sync + 'static,
+        TRng: Rng + Send + Sync + 'static,
+    > Setup<TEmitter, TFilter, TCtxt, TClock, TRng>
 where
     TCtxt::Frame: Send + 'static,
 {
@@ -327,8 +361,8 @@ where
                 .with_emitter(self.emitter)
                 .with_filter(self.filter)
                 .with_ctxt(self.ctxt)
-                .with_clock(self.platform.clock)
-                .with_rng(self.platform.rng),
+                .with_clock(self.clock)
+                .with_rng(self.rng),
         )?;
 
         Some(Init {
@@ -343,7 +377,9 @@ impl<
         TEmitter: InternalEmitter + Send + Sync + 'static,
         TFilter: InternalFilter + Send + Sync + 'static,
         TCtxt: InternalCtxt + Send + Sync + 'static,
-    > Setup<TEmitter, TFilter, TCtxt>
+        TClock: InternalClock + Send + Sync + 'static,
+        TRng: InternalRng + Send + Sync + 'static,
+    > Setup<TEmitter, TFilter, TCtxt, TClock, TRng>
 where
     TCtxt::Frame: Send + 'static,
 {
@@ -379,8 +415,8 @@ where
                 .with_emitter(self.emitter)
                 .with_filter(self.filter)
                 .with_ctxt(self.ctxt)
-                .with_clock(self.platform.clock)
-                .with_rng(self.platform.rng),
+                .with_clock(self.clock)
+                .with_rng(self.rng),
         )?;
 
         Some(Init {


### PR DESCRIPTION
This change makes it easier to configure `emit` in environments with `std`, but where `getrandom` is undesirable.