### PR TITLE
Re-export DefaultEmitter and DefaultFilter from emit::platform

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -14,6 +14,16 @@ pub mod thread_local_ctxt;
 pub mod rand_rng;
 
 /**
+The default [`Emitter`].
+*/
+pub type DefaultEmitter = crate::Empty;
+
+/**
+The default [`Filter`].
+*/
+pub type DefaultFilter = crate::Empty;
+
+/**
 The default [`crate::Rng`].
 */
 #[cfg(not(feature = "rand"))]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -85,7 +85,6 @@ use emit_core::{
     clock::Clock,
     ctxt::Ctxt,
     emitter::Emitter,
-    empty::Empty,
     filter::Filter,
     rng::Rng,
     runtime::{
@@ -103,17 +102,7 @@ pub fn setup() -> Setup {
     Setup::default()
 }
 
-pub use crate::platform::{DefaultClock, DefaultCtxt, DefaultRng};
-
-/**
-The default [`Emitter`] to use in [`setup()`].
-*/
-pub type DefaultEmitter = Empty;
-
-/**
-The default [`Filter`] to use in [`setup()`].
-*/
-pub type DefaultFilter = Empty;
+pub use crate::platform::{DefaultEmitter, DefaultFilter, DefaultClock, DefaultCtxt, DefaultRng};
 
 /**
 A configuration builder for an `emit` runtime.


### PR DESCRIPTION
This PR just conveniently re-exports `DefaultEmitter` and `DefaultFilter` from the `emit::platform` module, since that's also where `DefaultClock` and `DefaultRng` are exported.