### PR TITLE
Add a guide page on wasm and note lack of monotonicity of timers

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -36,6 +36,7 @@
     - [Rolling files](./emitting-events/rolling-files.md)
     - [Via OTLP](./emitting-events/otlp.md)
 - [Advanced apps](./advanced-apps.md)
+    - [Instrumenting WebAssembly](./advanced-apps/web-assembly.md)
     - [Integrating with OpenTelemetry](./advanced-apps/integrating-with-open-telemetry.md)
     - [Setup outside of `main`](./advanced-apps/non-main-setup.md)
 - [For developers](./for-developers.md)

--- a/book/src/advanced-apps/web-assembly.md
+++ b/book/src/advanced-apps/web-assembly.md
@@ -1,0 +1,3 @@
+# Instrumenting WebAssembly
+
+You can use `emit` in WebAssembly applications. If you're targeting WASI via the `wasm32-wasi` target, you shouldn't need to do anything special to make `emit` work. If you're targeting NodeJS or the web via the `wasm32-unknown` target, you can use [`emit_web`](https://docs.rs/emit_web) to provide a clock and source of randomness. See [the crate docs](https://docs.rs/emit_web) for more details.

--- a/book/src/producing-events/tracing/limitations.md
+++ b/book/src/producing-events/tracing/limitations.md
@@ -5,3 +5,5 @@
 - No distinction between sampling and reporting; if a span exists, it's sampled.
 - No span links.
 - No span events.
+
+Additionally, there is no guarantee of monotonicity; span extents are based on a start and end timestamp, so shifts in the underlying clock can produce misleading results.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 /*!
 The [`Timer`] type.
 
-Timers are a simple mechanism to track the start and end times of some operation. They're based on readings from a [`Clock`], which isn't monotonic. That means timers can give an approximate timespan based on its readings, but are susceptible to clock drift.
+Timers are a simple mechanism to track the start and end times of some operation. They're based on readings from a [`Clock`], which isn't guaranteed to be monotonic. That means timers can give an approximate timespan based on its readings, but are susceptible to clock drift.
 
 Timers are used by [`crate::Span`]s to produce the [`Extent`] on their events.
 */
@@ -40,7 +40,7 @@ impl<C: Clock> Timer<C> {
     }
 
     /**
-    Get the value of the timer as a span [`Extent`], using [`Clock::now`] as its final reading.
+    Get the value of the timer as an [`Extent`], using [`Clock::now`] as its final reading.
 
     If the underlying [`Clock`] is unable to produce a reading then this method will return `None`.
     */
@@ -57,6 +57,9 @@ impl<C: Clock> Timer<C> {
     Get the timespan between the initial reading and [`Clock::now`].
 
     If the underlying [`Clock`] is unable to produce a reading, or it shifts to before the initial reading, then this method will return `None`.
+
+    This method is not guaranteed to return the actual time elapsed since the timer was started.
+    It's based on the difference between two readings of the underlying [`Clock`], which is not guaranteed to be monotonic.
     */
     pub fn elapsed(&self) -> Option<Duration> {
         self.extent().and_then(|extent| extent.len())


### PR DESCRIPTION
This PR adds a link to [`emit_web`](https://github.com/emit-rs/emit_web) in the guide. It also more strongly calls out the lack of guaranteed monotonicity in the tracing data model using a pair of timestamps.