### PR TITLE
Remove deprecated APIs in preparation for 1.0.0

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -442,18 +442,6 @@ mod alloc_support {
         /**
         Get a sequence of binary floating points from a captured sequence of values.
 
-        If the value is a sequence then each element will be converted into a `f64` in the same way as [`Value::as_f64`]. If the value is not a sequence then an empty result is returned, including if that value is itself an `f64`.
-        */
-        #[deprecated(
-            note = "use `to_f64_sequence` instead, which returns `None` if the value is not a sequence"
-        )]
-        pub fn as_f64_sequence(&self) -> Vec<f64> {
-            self.0.as_f64_seq()
-        }
-
-        /**
-        Get a sequence of binary floating points from a captured sequence of values.
-
         If the value is a sequence then `Some` is returned. Each element will be converted into a `f64` in the same way as [`Value::as_f64`].
         If the value is not a sequence then `None` is returned.
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -102,7 +102,7 @@ pub fn setup() -> Setup {
     Setup::default()
 }
 
-pub use crate::platform::{DefaultEmitter, DefaultFilter, DefaultClock, DefaultCtxt, DefaultRng};
+pub use crate::platform::{DefaultClock, DefaultCtxt, DefaultEmitter, DefaultFilter, DefaultRng};
 
 /**
 A configuration builder for an `emit` runtime.

--- a/src/span.rs
+++ b/src/span.rs
@@ -831,11 +831,6 @@ pub struct SpanGuard<'a, T: Clock, P: Props, F: Completion> {
     completion: Option<F>,
 }
 
-// NOTE: Deprecated; will be removed in `1.0.0`
-#[doc(hidden)]
-#[deprecated(note = "use `SpanGuard` instead")]
-pub type ActiveSpan<'a, T, P, F> = SpanGuard<'a, T, P, F>;
-
 struct SpanGuardData<'a, P: Props> {
     mdl: Path<'a>,
     name: Str<'a>,


### PR DESCRIPTION
This PR removes the APIs that have been deprecated since `0.11.0` before we stabilize `1.0.0` proper.