### PR TITLE
Implement serialization traits for more types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,9 @@ features = ["derive"]
 [dev-dependencies.tokio]
 version = "1"
 features = ["full"]
+
+[dev-dependencies.sval_test]
+version = "2"
+
+[dev-dependencies.serde_test]
+version = "1"

--- a/book/src/emitting-events/console.md
+++ b/book/src/emitting-events/console.md
@@ -65,6 +65,59 @@ write_to_file("./file.txt", b"Hello")?;
 
 ![`emit_term` output for the above program](../asset/term-span.png)
 
-## Writing your own console emitter
+## Emitting JSON
 
-The `emit_term` [source code](https://github.com/emit-rs/emit/blob/main/emitter/term/src/lib.rs) is written to be hackable. You can take and adapt its source to your needs, or write your own emitter that formats events the way you'd like. See [Writing an emitter](../for-developers/writing-an-emitter.md) for details.
+The `emit_term` [source code](https://github.com/emit-rs/emit/blob/main/emitter/term/src/lib.rs) is written to be hackable rather than configurable. It doesn't support changing its output into other formats, but you can write your own emitter that suits your specific needs. Here is an example of an emitter that writes minified JSON via [`serde_json`](docs.rs/serde_json) to the console using the [`println!`](https://doc.rust-lang.org/std/macro.println.html) macro:
+
+```rust
+# extern crate emit;
+# extern crate serde;
+# mod serde_json { pub fn to_string<T>(v: &T) -> Result<String, String> { Ok("".into()) } }
+# use serde::Serialize;
+# fn main() {
+let rt = emit::setup()
+    .emit_to(emit::emitter::from_fn(|evt| {
+        use emit::Props as _;
+
+        // Generics avoid needing to specify concrete types here
+        #[derive(Serialize)]
+        struct Event<E, M, R, P> {
+            #[serde(flatten)]
+            extent: E,
+            mdl: M,
+            msg: R,
+            #[serde(flatten)]
+            props: P,
+        }
+
+        let json = serde_json::to_string(&Event {
+            // `as_map()` serializes the extent as a map with one or two keys:
+            // `ts` for the end timestamp, and `ts_start` for the start, if there is one
+            extent: evt.extent().as_map(),
+            mdl: evt.mdl(),
+            msg: evt.msg(),
+            // `dedup()` ensures there are no duplicate properties
+            // `as_map()` serializes properties as a map where each property is a key-value pair
+            props: evt.props().dedup().as_map(),
+        })
+        .unwrap();
+
+        println!("{json}");
+    }))
+    .init();
+
+let user = "Rust";
+
+emit::info!("Hello, {user}");
+
+rt.blocking_flush(std::time::Duration::from_secs(5));
+# }
+```
+
+```json
+{"ts":"2025-03-02T08:13:29.497557000Z","mdl":"emit_json","msg":"Hello, Rust","lvl":"info","user":"Rust"}
+```
+
+Note that you'll need to enable the `serde` Cargo feature of `emit`.
+
+Instead of using `println!` here, you could adapt the [source of `emit_term`](https://github.com/emit-rs/emit/blob/main/emitter/term/src/lib.rs). See [Writing an emitter](../for-developers/writing-an-emitter.md) for details.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,3 +46,9 @@ default-features = false
 version = "1"
 optional = true
 default-features = false
+
+[dev-dependencies.sval_test]
+version = "2"
+
+[dev-dependencies.serde_test]
+version = "1"

--- a/core/src/extent.rs
+++ b/core/src/extent.rs
@@ -256,6 +256,13 @@ mod tests {
 
     #[test]
     fn as_props() {
-        todo!()
+        let ts = Extent::point(Timestamp::MIN);
+
+        assert_eq!(Timestamp::MIN, ts.pull::<Timestamp, _>("ts").unwrap());
+
+        let ts = Extent::range(Timestamp::MIN..Timestamp::MAX);
+
+        assert_eq!(Timestamp::MAX, ts.pull::<Timestamp, _>("ts").unwrap());
+        assert_eq!(Timestamp::MIN, ts.pull::<Timestamp, _>("ts_start").unwrap());
     }
 }

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -702,6 +702,56 @@ mod tests {
 
     #[test]
     fn as_map() {
-        todo!()
+        let props = [("a", 1), ("b", 2)].as_map();
+
+        assert_eq!("{\"a\": 1, \"b\": 2}", props.to_string());
+    }
+
+    #[cfg(feature = "sval")]
+    #[test]
+    fn as_map_stream() {
+        let props = [("a", 1), ("b", 2)].as_map();
+
+        sval_test::assert_tokens(
+            &props,
+            &[
+                sval_test::Token::MapBegin(None),
+                sval_test::Token::MapKeyBegin,
+                sval_test::Token::TextBegin(Some(1)),
+                sval_test::Token::TextFragmentComputed("a".to_owned()),
+                sval_test::Token::TextEnd,
+                sval_test::Token::MapKeyEnd,
+                sval_test::Token::MapValueBegin,
+                sval_test::Token::I64(1),
+                sval_test::Token::MapValueEnd,
+                sval_test::Token::MapKeyBegin,
+                sval_test::Token::TextBegin(Some(1)),
+                sval_test::Token::TextFragmentComputed("b".to_owned()),
+                sval_test::Token::TextEnd,
+                sval_test::Token::MapKeyEnd,
+                sval_test::Token::MapValueBegin,
+                sval_test::Token::I64(2),
+                sval_test::Token::MapValueEnd,
+                sval_test::Token::MapEnd,
+            ],
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn as_map_serialize() {
+        let props = [("a", 1), ("b", 2)].as_map();
+
+        serde_test::assert_ser_tokens(
+            &props,
+            &[
+                serde_test::Token::Map { len: None },
+                serde_test::Token::Str("a"),
+                serde_test::Token::I64(1),
+                serde_test::Token::Str("b"),
+                serde_test::Token::I64(2),
+                serde_test::Token::MapEnd,
+            ],
+        );
     }
 }

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -898,12 +898,37 @@ mod tests {
     }
 
     #[cfg(feature = "sval")]
+    #[test]
     fn stream() {
-        todo!()
+        sval_test::assert_tokens(
+            &Template::new_ref(&[Part::text("Hello, "), Part::hole("greet"), Part::text("!")]),
+            &[
+                sval_test::Token::TextBegin(None),
+                sval_test::Token::TextFragmentComputed("Hello, ".to_owned()),
+                sval_test::Token::TextFragmentComputed("{".to_owned()),
+                sval_test::Token::TextFragmentComputed("greet".to_owned()),
+                sval_test::Token::TextFragmentComputed("}".to_owned()),
+                sval_test::Token::TextFragmentComputed("!".to_owned()),
+                sval_test::Token::TextEnd,
+            ],
+        );
+
+        sval_test::assert_tokens(
+            &Template::literal("Hello!"),
+            &[
+                sval_test::Token::TextBegin(Some(6)),
+                sval_test::Token::TextFragment("Hello!"),
+                sval_test::Token::TextEnd,
+            ],
+        );
     }
 
     #[cfg(feature = "serde")]
+    #[test]
     fn serialize() {
-        todo!()
+        serde_test::assert_ser_tokens(
+            &Template::new_ref(&[Part::text("Hello, "), Part::hole("greet"), Part::text("!")]),
+            &[serde_test::Token::Str("Hello, {greet}!")],
+        );
     }
 }

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -745,6 +745,60 @@ mod alloc_support {
     }
 }
 
+#[cfg(feature = "sval")]
+impl<'k> sval::Value for Template<'k> {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        use sval_ref::ValueRef as _;
+
+        self.stream_ref(stream)
+    }
+}
+
+#[cfg(feature = "sval")]
+impl<'k> sval_ref::ValueRef<'k> for Template<'k> {
+    fn stream_ref<S: sval::Stream<'k> + ?Sized>(&self, stream: &mut S) -> sval::Result {
+        if let Some(v) = self.as_literal() {
+            sval_ref::stream_ref(stream, v)
+        } else {
+            sval::stream_display(stream, self)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'k> serde::Serialize for Template<'k> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "sval")]
+impl<'k, P: Props> sval::Value for Render<'k, P> {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        use sval_ref::ValueRef as _;
+
+        self.stream_ref(stream)
+    }
+}
+
+#[cfg(feature = "sval")]
+impl<'k, P: Props> sval_ref::ValueRef<'k> for Render<'k, P> {
+    fn stream_ref<S: sval::Stream<'k> + ?Sized>(&self, stream: &mut S) -> sval::Result {
+        if let Some(v) = self.as_literal() {
+            sval_ref::stream_ref(stream, v)
+        } else {
+            sval::stream_display(stream, self)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'k, P: Props> serde::Serialize for Render<'k, P> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -841,5 +895,15 @@ mod tests {
 
         assert_eq!("Hello, {greet}!", value.to_string());
         assert!(value.cast::<Str>().is_none());
+    }
+
+    #[cfg(feature = "sval")]
+    fn stream() {
+        todo!()
+    }
+
+    #[cfg(feature = "serde")]
+    fn serialize() {
+        todo!()
     }
 }

--- a/core/src/timestamp.rs
+++ b/core/src/timestamp.rs
@@ -752,12 +752,24 @@ mod tests {
     }
 
     #[cfg(feature = "sval")]
+    #[test]
     fn stream() {
-        todo!()
+        sval_test::assert_tokens(
+            &Timestamp::try_from_str("2024-01-01T00:13:00.000Z").unwrap(),
+            &[
+                sval_test::Token::TextBegin(None),
+                sval_test::Token::TextFragmentComputed("2024-01-01T00:13:00.000000000Z".to_owned()),
+                sval_test::Token::TextEnd,
+            ],
+        );
     }
 
     #[cfg(feature = "serde")]
+    #[test]
     fn serialize() {
-        todo!()
+        serde_test::assert_ser_tokens(
+            &Timestamp::try_from_str("2024-01-01T00:13:00.000Z").unwrap(),
+            &[serde_test::Token::Str("2024-01-01T00:13:00.000000000Z")],
+        );
     }
 }

--- a/core/src/timestamp.rs
+++ b/core/src/timestamp.rs
@@ -557,6 +557,20 @@ fn fmt_rfc3339(ts: Timestamp, f: &mut fmt::Formatter) -> fmt::Result {
     f.write_str(str::from_utf8(&buf[..=i]).expect("Conversion to utf8 failed"))
 }
 
+#[cfg(feature = "sval")]
+impl sval::Value for Timestamp {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        sval::stream_display(stream, self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Timestamp {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -735,5 +749,15 @@ mod tests {
         ] {
             assert_eq!(expected, case.cast::<Timestamp>());
         }
+    }
+
+    #[cfg(feature = "sval")]
+    fn stream() {
+        todo!()
+    }
+
+    #[cfg(feature = "serde")]
+    fn serialize() {
+        todo!()
     }
 }

--- a/examples/common_patterns/Cargo.toml
+++ b/examples/common_patterns/Cargo.toml
@@ -28,6 +28,9 @@ version = "1"
 version = "1"
 features = ["derive"]
 
+[dependencies.serde_json]
+version = "1"
+
 [[example]]
 name = "dbg"
 path = "dbg.rs"
@@ -63,6 +66,10 @@ path = "emit_debug_values.rs"
 [[example]]
 name = "emit_serde_values"
 path = "emit_serde_values.rs"
+
+[[example]]
+name = "emit_json"
+path = "emit_json.rs"
 
 [[example]]
 name = "filter_by_level"

--- a/examples/common_patterns/emit_json.rs
+++ b/examples/common_patterns/emit_json.rs
@@ -1,0 +1,48 @@
+/*!
+This example demonstrates an emitter that writes newline JSON to the terminal.
+
+The `Event` type doesn't implement `serde::Serialize` directly, so you're free to pick a representation
+that suits your needs. You can serialize types that implement `emit::Props` using the `as_map` method,
+which we use on both the extent and props to flatten them onto a single object.
+
+You can tweak the `Event` type as written here to produce a different result.
+*/
+
+fn main() {
+    let rt = emit::setup()
+        .emit_to(emit::emitter::from_fn(|evt| {
+            use emit::Props as _;
+
+            // Generics avoid needing to specify concrete types here
+            #[derive(serde::Serialize)]
+            struct Event<E, M, R, P> {
+                #[serde(flatten)]
+                extent: E,
+                mdl: M,
+                msg: R,
+                #[serde(flatten)]
+                props: P,
+            }
+
+            let json = serde_json::to_string(&Event {
+                // `as_map()` serializes the extent as a map with one or two keys:
+                // `ts` for the end timestamp, and `ts_start` for the start, if there is one
+                extent: evt.extent().as_map(),
+                mdl: evt.mdl(),
+                msg: evt.msg(),
+                // `dedup()` ensures there are no duplicate properties
+                // `as_map()` serializes properties as a map where each property is a key-value pair
+                props: evt.props().dedup().as_map(),
+            })
+            .unwrap();
+
+            println!("{json}");
+        }))
+        .init();
+
+    let user = "Rust";
+
+    emit::info!("Hello, {user}");
+
+    rt.blocking_flush(std::time::Duration::from_secs(5));
+}

--- a/examples/common_patterns/emit_json.rs
+++ b/examples/common_patterns/emit_json.rs
@@ -36,6 +36,9 @@ fn main() {
             })
             .unwrap();
 
+            // Instead of printing to the console here we could use `emit_file` or any other
+            // `io::Write`. If that destination requires flushing, consider implementing
+            // `emit::Emitter` instead of using `from_fn` here
             println!("{json}");
         }))
         .init();


### PR DESCRIPTION
Closes #233
Closes #126 

This PR implements `serde::Serialize` and `sval::Value` on more datatypes, and adds an `AsMap` adapter to `Props` that makes it easier to use in serialization code. Together, this makes it possible to write a custom serializer for events in any format using `serde` or `sval` that supports whatever conventions a specific use case may need without us needing to add a lot of configuration options to `emit_term` or `emit_file` for them.