### PR TITLE
Add support for using the native TLS support on the platform

### DIFF
--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -7,7 +7,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default nightly
 
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
       - name: Install certutil
         run: sudo apt-get update && sudo apt-get install -y libnss3-tools
 
@@ -66,7 +69,7 @@ jobs:
 
       - name: Integration Test
         working-directory: ./emitter/otlp/test/integration
-        run: cargo run
+        run: cargo hack run --feature-powerset
 
       - name: Throughput Test
         working-directory: ./emitter/otlp/test/throughput

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 default = ["tls", "gzip"]
 gzip = ["flate2"]
 tls = ["tokio-rustls", "rustls-native-certs"]
+tls-native = ["tls", "tokio-native-tls"]
 
 [dependencies.emit]
 version = "1.2.0"
@@ -72,6 +73,10 @@ features = ["ring"]
 
 [dependencies.rustls-native-certs]
 version = "0.8"
+optional = true
+
+[dependencies.tokio-native-tls]
+version = "0.3"
 optional = true
 
 [dependencies.flate2]

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -66,11 +66,7 @@ async fn tls_handshake(
 {
     use tokio_native_tls::{native_tls, TlsConnector};
 
-    let domain = uri.host().to_owned().try_into().map_err(|e| {
-        metrics.transport_conn_tls_failed.increment();
-
-        Error::new(format_args!("could not extract a DNS name from {uri}"), e)
-    })?;
+    let domain = uri.host();
 
     let connector = TlsConnector::from(
         native_tls::TlsConnector::new()

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -54,12 +54,49 @@ async fn connect(
     }
 }
 
-#[cfg(feature = "tls")]
+/*
+TLS using the native platform
+*/
+#[cfg(all(feature = "tls", feature = "tls-native"))]
 async fn tls_handshake(
     metrics: &InternalMetrics,
     io: tokio::net::TcpStream,
     uri: &HttpUri,
-) -> Result<tokio_rustls::client::TlsStream<tokio::net::TcpStream>, Error> {
+) -> Result<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + Unpin + 'static, Error>
+{
+    use tokio_native_tls::{native_tls, TlsConnector};
+
+    let domain = uri.host().to_owned().try_into().map_err(|e| {
+        metrics.transport_conn_tls_failed.increment();
+
+        Error::new(format_args!("could not extract a DNS name from {uri}"), e)
+    })?;
+
+    let connector = TlsConnector::from(
+        native_tls::TlsConnector::new()
+            .map_err(|e| Error::new("failed to create TLS connector", e))?,
+    );
+
+    let io = connector
+        .connect(domain, io)
+        .await
+        .map_err(|e| Error::new("failed to perform TLS handshake", e))?;
+
+    metrics.transport_conn_tls_handshake.increment();
+
+    Ok(io)
+}
+
+/*
+TLS using `rustls`
+*/
+#[cfg(all(feature = "tls", not(feature = "tls-native")))]
+async fn tls_handshake(
+    metrics: &InternalMetrics,
+    io: tokio::net::TcpStream,
+    uri: &HttpUri,
+) -> Result<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + Unpin + 'static, Error>
+{
     use tokio_rustls::{rustls, TlsConnector};
 
     let domain = uri.host().to_owned().try_into().map_err(|e| {
@@ -406,7 +443,9 @@ impl HttpUri {
     }
 
     pub fn port(&self) -> u16 {
-        self.0.port_u16().unwrap_or_else(|| if self.is_https() { 443 } else { 80 })
+        self.0
+            .port_u16()
+            .unwrap_or_else(|| if self.is_https() { 443 } else { 80 })
     }
 }
 

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -28,7 +28,9 @@ The emitter is based on an asynchronous, batching channel. A diagnostic event ma
 3. Put the serialized event into a channel. Each signal has its own internal queue in the channel.
 4. On a background worker, process the events in the channel by forming them up into OTLP export requests and sending them using the target protocol (HTTP/gRPC).
 
-This library is based on `hyper` with `tokio` for HTTP, and `rustls` with `ring` for TLS. These dependencies are not configurable and can't be swapped for alternative implementations.
+This library is based on [`hyper`](https://docs.rs/hyper) with [`tokio`](https://docs.rs/tokio) for HTTP, and [`rustls`](https://docs.rs/rustls) with [`ring`](https://docs.rs/ring) for TLS. Some of these dependencies can be configured using Cargo features:
+
+- `tls-native`: Use [`native-tls`](https://docs.rs/native-tls) instead of `rustls`.
 
 # Getting started
 
@@ -134,7 +136,9 @@ emit_otlp::new()
 
 # Configuring TLS
 
-If the `tls` Cargo feature is enabled, and the scheme of your endpoint uses the `https://` scheme then it will use TLS from `rustls` and `rustls-native-certs`.
+If the `tls` Cargo feature is enabled, and the scheme of your endpoint uses the `https://` scheme then it will use TLS from [`rustls`](https://docs.rs/rustls) and [`rustls-native-certs`](https://docs.rs/rustls-native-certs).
+
+You can specify the `tls-native` Cargo feature to use [`native-tls`](https://docs.rs/native-tls) instead of `rustls`.
 
 # Configuring compression
 

--- a/emitter/otlp/test/integration/Cargo.toml
+++ b/emitter/otlp/test/integration/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 publish = false
 edition = "2021"
 
+[features]
+tls-native = ["emit_otlp/tls-native"]
+
 [dependencies.emit]
 path = "../../../../"
 

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -148,7 +148,7 @@ fn assert_exporter(output: &str, exporter: &str, id: &str) {
         output.contains(&exporter),
         "{exporter} not found in:\n{output}"
     );
-    assert!(output.contains(id), "{id} noot found in:\n{output}");
+    assert!(output.contains(id), "{id} not found in:\n{output}");
 }
 
 struct OtelCol(Child);


### PR DESCRIPTION
I kind of knew this was coming, even though I wanted to avoid it. `rustls` has a very strict policy of feature support, which is admirable, but sometimes means you get stuck between a rock and a hard place trying to integrate with all manner of proxies and load balancers.

This PR adds support for using `native-tls` as the provider of TLS connections in `emit_otlp` by adding the `tls-native` Cargo feature. When enabled, it will take precedence over `rustls`.

Still TODO:

- [x] Ensure we build on major platforms. It's difficult to actually test TLS on many platforms, but we can at least ensure we build on them.
- [x] Update library docs
- [x] Update book