### PR TITLE
Mark emit_otlp dependencies as private

### DIFF
--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2021"
 
 [features]
 default = ["tls", "gzip"]
-gzip = ["flate2"]
-tls = ["tokio-rustls", "rustls-native-certs"]
-tls-native = ["tls", "tokio-native-tls"]
+gzip = ["dep:flate2"]
+tls = ["dep:tokio-rustls", "dep:rustls-native-certs"]
+tls-native = ["tls", "dep:tokio-native-tls"]
 
 [dependencies.emit]
 version = "1.3.0"


### PR DESCRIPTION
These dependencies are not intended to be public features.