### PR TITLE
Include the top and bottom of the error chain in Value display

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -724,6 +724,18 @@ mod tests {
         );
 
         assert_eq!(
+            "outer (inner)",
+            Value::capture_error(&Error {
+                msg: "outer".into(),
+                source: Some(Box::new(Error {
+                    msg: "inner".into(),
+                    source: None,
+                })),
+            })
+            .to_string(),
+        );
+
+        assert_eq!(
             "outer (root)",
             Value::capture_error(&Error {
                 msg: "outer".into(),

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -38,6 +38,9 @@ version = "2.10"
 version = "2.10"
 features = ["std", "flatten"]
 
+[dependencies.sval_dynamic]
+version = "2.10"
+
 [dependencies.sval_protobuf]
 version = "0.2"
 features = ["bytes"]

--- a/emitter/otlp/src/data/logs.rs
+++ b/emitter/otlp/src/data/logs.rs
@@ -198,7 +198,7 @@ mod tests {
             })),
         };
 
-        encode_event::<LogsEventEncoder>(emit::evt!("failed: {err}", err), |buf| {
+        encode_event::<LogsEventEncoder>(emit::evt!("failed: {err}"), |buf| {
             let de = logs::LogRecord::decode(buf).unwrap();
 
             assert_eq!(2, de.attributes.len());
@@ -223,7 +223,7 @@ mod tests {
             source: None,
         };
 
-        encode_event::<LogsEventEncoder>(emit::evt!("failed: {err}", err), |buf| {
+        encode_event::<LogsEventEncoder>(emit::evt!("failed: {err}"), |buf| {
             let de = logs::LogRecord::decode(buf).unwrap();
 
             assert_eq!(1, de.attributes.len());


### PR DESCRIPTION
This PR tweaks the `Display` implementation of `Value` to include the top and bottom of the error cause chain when displaying them. This makes their output much more useful in situations where you're just rendering values with `.to_string()`.

Since Rust errors are typically an independent message fragment, we can usually combine multiple together with a separator without producing illogical output.

This only applies when formatting `Value`s containing errors using `Display`, it doesn't affect `Debug`.