### PR TITLE
Make file dependencies private

### DIFF
--- a/emitter/file/Cargo.toml
+++ b/emitter/file/Cargo.toml
@@ -15,7 +15,7 @@ features = ["default_writer"]
 
 [features]
 default = ["default_writer"]
-default_writer = ["emit/sval", "sval_json"]
+default_writer = ["emit/sval", "dep:sval_json"]
 
 [dependencies.emit]
 version = "1.3.1"


### PR DESCRIPTION
Like #241, but for `emit_file`. I had a look through the rest of our `Cargo.toml`s and there don't seem to be any more cases of this accidental dependency leakage to fix.