### PR TITLE
Support `emit_batcher` in web-based wasm projects

### DIFF
--- a/.github/workflows/batcher.yml
+++ b/.github/workflows/batcher.yml
@@ -37,3 +37,23 @@ jobs:
       - name: Minimal versions
         working-directory: ./batcher
         run: cargo hack test --feature-powerset --lib -Z minimal-versions
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Rust toolchain
+        run: rustup default nightly
+
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Default features
+        working-directory: ./batcher
+        run: wasm-pack test --node
+
+      - name: Web
+        working-directory: ./batcher
+        run: wasm-pack test --node --features web

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 features = ["tokio"]
 
 [features]
-web = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:web-sys", "dep:futures"]
+web = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:futures"]
 
 [dependencies.emit]
 version = "1.3.1"
@@ -36,17 +36,13 @@ optional = true
 version = "0.3"
 optional = true
 
-[dependencies.web-sys]
-version = "0.3"
-optional = true
-features = [
-  "Window"
-]
-
 [dependencies.futures]
 version = "0.3"
 optional = true
 
-[dev-dependencies.tokio]
+[dev-dependencies.wasm-bindgen-test]
+version = "0.3"
+
+[target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dev-dependencies.tokio]
 version = "1"
 features = ["full"]

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 features = ["tokio"]
 
 [features]
-web = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:web-sys"]
+web = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:web-sys", "dep:futures"]
 
 [dependencies.emit]
 version = "1.3.1"
@@ -42,6 +42,10 @@ optional = true
 features = [
   "Window"
 ]
+
+[dependencies.futures]
+version = "0.3"
+optional = true
 
 [dev-dependencies.tokio]
 version = "1"

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 [package.metadata.docs.rs]
 features = ["tokio"]
 
+[features]
+web = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:web-sys"]
+
 [dependencies.emit]
 version = "1.3.1"
 path = "../"
@@ -20,6 +23,25 @@ default-features = false
 version = "1"
 features = ["rt-multi-thread", "sync", "time"]
 optional = true
+
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen]
+version = "0.2"
+optional = true
+
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen-futures]
+version = "0.4"
+optional = true
+
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.js-sys]
+version = "0.3"
+optional = true
+
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.web-sys]
+version = "0.3"
+optional = true
+features = [
+  "Window"
+]
 
 [dev-dependencies.tokio]
 version = "1"

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -24,19 +24,19 @@ version = "1"
 features = ["rt-multi-thread", "sync", "time"]
 optional = true
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen]
+[dependencies.wasm-bindgen]
 version = "0.2"
 optional = true
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen-futures]
+[dependencies.wasm-bindgen-futures]
 version = "0.4"
 optional = true
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.js-sys]
+[dependencies.js-sys]
 version = "0.3"
 optional = true
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.web-sys]
+[dependencies.web-sys]
 version = "0.3"
 optional = true
 features = [

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -7,6 +7,12 @@ This library implements a channel that can be used to spawn background workers o
 - **Retries with backoff:** If the worker fails or panics then the batch can be retried up to some number of times, with backoff applied between retries. The worker can decide how much of a batch needs to be retried.
 - **Maximum size management:** If the worker can't keep up then the channel truncates to avoid runaway memory use. The alternative would be to apply backpressure, but that would affect system availability so isn't suitable for diagnostics.
 - **Flushing:** Callers can ask the worker to signal when all diagnostic events in the channel at the point they called are processed. This can be used for auditing and flushing on shutdown.
+
+# WebAssembly
+
+This library can be used on the `wasm32-unknown-unknown` target by enabling the `web` Cargo feature.
+Instead of spawning background threads to run the batching receiver, it will instead spawn a fire-and-forget promise.
+Blocking functions like `blocking_send` and `blocking_flush` are not available, but asynchronous `send` and `flush` variants are.
 */
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/emit-rs/emit/main/asset/logo.svg")]

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -236,7 +236,7 @@ impl<T: Channel> Sender<T> {
                 loop {
                     let elapsed = elapsed();
 
-                    if elapsed > timeout {
+                    if elapsed >= timeout {
                         return Err(err);
                     }
 

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -738,7 +738,14 @@ impl Watchers {
 
 pub mod sync;
 
-#[cfg(feature = "tokio")]
+#[cfg(all(
+    feature = "tokio",
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))
+))]
 pub mod tokio;
 
 #[cfg(feature = "web")]
@@ -746,10 +753,24 @@ pub mod web;
 
 // Re-export an appropriate implementation of blocking functions based on crate features
 
-#[cfg(feature = "tokio")]
+#[cfg(all(
+    feature = "tokio",
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))
+))]
 pub use tokio::{blocking_flush, blocking_send};
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(not(all(
+    feature = "tokio",
+    not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))
+)))]
 pub use sync::{blocking_flush, blocking_send};
 
 #[cfg(test)]

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -741,6 +741,9 @@ pub mod sync;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
+#[cfg(feature = "web")]
+pub mod web;
+
 // Re-export an appropriate implementation of blocking functions based on crate features
 
 #[cfg(feature = "tokio")]

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -78,11 +78,7 @@ pub async fn send<T: Channel>(
         .send_or_wait(
             msg,
             timeout,
-            || {
-                let now = performance_now();
-
-                now.saturating_sub(start)
-            },
+            || performance_now().saturating_sub(start),
             |sender, timeout| async move {
                 let (notifier, notified) = futures::channel::oneshot::channel();
 

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -1,0 +1,120 @@
+/*!
+Run channels in a JavaScript runtime using a background promise.
+*/
+
+#![allow(missing_docs)]
+
+use std::{
+    cell::RefCell,
+    future::Future,
+    io, mem,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+use crate::{BatchError, Channel, Receiver};
+
+pub fn spawn<
+    T: Channel + Send + 'static,
+    F: Future<Output = Result<(), BatchError<T>>> + Send + 'static,
+>(
+    receiver: Receiver<T>,
+    on_batch: impl FnMut(T) -> F + Send + 'static,
+) -> io::Result<()>
+where
+    T::Item: Send + 'static,
+{
+    let _ = future_to_promise(async move {
+        // `exec` does not panic
+        receiver.exec(|delay| sleep(delay), on_batch).await;
+
+        Ok(JsValue::UNDEFINED)
+    });
+
+    Ok(())
+}
+
+async fn sleep(delay: Duration) {
+    let f = Timeout {
+        delay: Some(delay),
+        complete: None,
+        state: Rc::new(RefCell::new(TimeoutState {
+            done: false,
+            wakers: Vec::new(),
+        })),
+    };
+
+    f.await
+}
+
+struct Timeout {
+    delay: Option<Duration>,
+    complete: Option<Closure<dyn Fn()>>,
+    state: Rc<RefCell<TimeoutState>>,
+}
+
+struct TimeoutState {
+    done: bool,
+    wakers: Vec<Waker>,
+}
+
+impl Future for Timeout {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        let unpinned = unsafe { self.get_unchecked_mut() };
+
+        if unpinned.state.borrow_mut().done {
+            return Poll::Ready(());
+        }
+
+        // The timeout hasn't been scheduled, or hasn't expired yet
+
+        // Add this waker to the set to wake when the timeout resolves
+        let mut state = unpinned.state.borrow_mut();
+
+        let waker = cx.waker();
+
+        if !state.wakers.iter().any(|w| w.will_wake(waker)) {
+            state.wakers.push(waker.clone());
+        }
+
+        drop(state);
+
+        // Schedule the timeout if we haven't already
+        // The timeout is done using `window.setTimeout`
+        if let Some(delay) = unpinned.delay.take() {
+            let state = unpinned.state.clone();
+
+            let complete = Closure::<dyn Fn()>::new(move || {
+                let mut state = state.borrow_mut();
+
+                state.done = true;
+                let wakers = mem::take(&mut state.wakers);
+
+                drop(state);
+
+                for waker in wakers {
+                    waker.wake();
+                }
+            });
+
+            web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(
+                    complete.as_ref().unchecked_ref(),
+                    delay.as_millis() as i32,
+                )
+                .unwrap();
+
+            unpinned.complete = Some(complete);
+        }
+
+        Poll::Pending
+    }
+}

--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -606,7 +606,7 @@ mod tests {
             fn open_root<P: Props>(&self, props: P) -> Self::Frame {
                 let mut count = 0;
 
-                props.for_each(|_, _| {
+                let _ = props.for_each(|_, _| {
                     count += 1;
                     ControlFlow::Continue(())
                 });

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -201,7 +201,7 @@ impl<'a, P: Props> fmt::Debug for Event<'a, P> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let mut f = f.debug_map();
 
-                self.0.for_each(|k, v| {
+                let _ = self.0.for_each(|k, v| {
                     f.key(&k.get());
                     f.value(&v);
 

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -58,7 +58,7 @@ pub trait Props {
         let key = key.to_str();
         let mut value = None;
 
-        self.for_each(|k, v| {
+        let _ = self.for_each(|k, v| {
             if k == key {
                 value = Some(v);
 
@@ -282,7 +282,8 @@ mod alloc_support {
 
             let mut seen = alloc::collections::BTreeMap::new();
 
-            self.0.for_each(|key, value| {
+            // Ignore any break from this iteration
+            let _ = self.0.for_each(|key, value| {
                 seen.entry(key).or_insert(value);
 
                 ControlFlow::Continue(())
@@ -361,7 +362,7 @@ mod alloc_support {
             let mut ac = 0;
             let mut bc = 0;
 
-            deduped.for_each(|k, v| {
+            let _ = deduped.for_each(|k, v| {
                 match k.get() {
                     "a" => {
                         assert_eq!(1, v.cast::<i32>().unwrap());

--- a/emitter/file/src/lib.rs
+++ b/emitter/file/src/lib.rs
@@ -615,7 +615,7 @@ fn default_writer(
             sval::stream_display(&mut *stream, self.0.tpl())?;
             stream.record_value_end(None, &sval::Label::new(KEY_TPL))?;
 
-            self.0.props().dedup().for_each(|k, v| {
+            let _ = self.0.props().dedup().for_each(|k, v| {
                 match (|| {
                     stream.record_value_begin(None, &sval::Label::new_computed(k.get()))?;
                     stream.value_computed(&v)?;

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -171,7 +171,7 @@ impl OtlpBuilder {
             attributes: HashMap::new(),
         };
 
-        attributes.for_each(|k, v| {
+        let _ = attributes.for_each(|k, v| {
             resource.attributes.insert(k.to_owned(), v.to_owned());
 
             std::ops::ControlFlow::Continue(())

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -288,7 +288,7 @@ pub(crate) fn stream_attributes<'sval, S: sval::Stream<'sval> + ?Sized>(
 ) -> sval::Result {
     stream.seq_begin(None)?;
 
-    props.dedup().for_each(|k, v| {
+    let _ = props.dedup().for_each(|k, v| {
         for_each(AttributeStream(&mut *stream), k, v)
             .map(|_| ControlFlow::Continue(()))
             .unwrap_or(ControlFlow::Break(()))?;

--- a/emitter/otlp/src/data/metrics.rs
+++ b/emitter/otlp/src/data/metrics.rs
@@ -87,7 +87,7 @@ impl EventEncoder for MetricsEventEncoder {
             let mut metric_unit = None;
             let mut attributes = Vec::new();
 
-            evt.props().for_each(|k, v| match k.get() {
+            let _ = evt.props().for_each(|k, v| match k.get() {
                 KEY_METRIC_UNIT => {
                     metric_unit = Some(v);
 

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -93,7 +93,7 @@ impl Ctxt for ThreadLocalCtxt {
     fn open_root<P: Props>(&self, props: P) -> Self::Frame {
         let mut span = HashMap::new();
 
-        props.for_each(|k, v| {
+        let _ = props.for_each(|k, v| {
             span.insert(k.to_shared(), v.to_shared());
             ControlFlow::Continue(())
         });
@@ -112,7 +112,7 @@ impl Ctxt for ThreadLocalCtxt {
 
         let span_props = Arc::make_mut(span.props.as_mut().unwrap());
 
-        props.for_each(|k, v| {
+        let _ = props.for_each(|k, v| {
             span_props.insert(k.to_shared(), v.to_shared());
             ControlFlow::Continue(())
         });

--- a/test/ui/src/util.rs
+++ b/test/ui/src/util.rs
@@ -174,7 +174,7 @@ impl Ctxt for SimpleCtxt {
     fn open_root<P: Props>(&self, props: P) -> Self::Frame {
         let mut serialized = HashMap::new();
 
-        props.for_each(|k, v| {
+        let _ = props.for_each(|k, v| {
             if !serialized.contains_key(k.get()) {
                 serialized.insert(k.get().into(), v.to_string());
             }


### PR DESCRIPTION
Part of #243 

This PR makes `emit_batcher` work in `wasm32-unknown-unknown` when the `web` feature is enabled. It currently uses a fire-and-forget promise and timeouts based on `setTimeout` to run the batcher. There are a few features that aren't available, most notably `blocking_flush`. Since we're running on a single-threaded runtime, we can't block waiting for another task to complete.

Still TODO:

- [x] `async fn send()`, like the `emit_batcher::tokio` variant
- [x] Library docs on how to use `emit_batcher` in web environments, and how it works