### PR TITLE
Add links to the macro syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ fn main() {
 
 ![The output of running the above program](https://github.com/emit-rs/emit/blob/main/asset/emit_term.png?raw=true)
 
+`emit` has a capable syntax for writing events that's different from the standard `format!` trait. You can read more about it in [the guide](https://emit-rs.io/reference/templates.html).
+
 ## Tracing
 
 `emit` can also produce trace data that's compatible with standard tracing tools, like Zipkin.

--- a/book/src/producing-events.md
+++ b/book/src/producing-events.md
@@ -6,3 +6,5 @@ This section describes how to use `emit` to produce diagnostics in your applicat
 - [Tracing operations](./producing-events/tracing.md).
 - [Sampling metrics](./producing-events/metrics.md).
 - [Quick debugging](./producing-events/quick-debugging.md).
+
+`emit`'s macros all use the same syntax for describing events. You can read more about that in [Template syntax and rendering](./reference/templates.md).

--- a/book/src/producing-events/logging.md
+++ b/book/src/producing-events/logging.md
@@ -36,6 +36,8 @@ Event {
 
 See [Levels](./logging/levels.md) for details.
 
+To learn more about `emit`'s macro syntax, see [Template syntax and rendering](../reference/templates.md).
+
 -----
 
 ![an example log rendered to the console](../asset/term-err.png)

--- a/book/src/producing-events/metrics.md
+++ b/book/src/producing-events/metrics.md
@@ -36,6 +36,8 @@ Event {
 }
 ```
 
+To learn more about `emit`'s macro syntax, see [Template syntax and rendering](../reference/templates.md).
+
 -----
 
 ![an example metric in Prometheus](../asset/metric-prometheus.png)

--- a/book/src/producing-events/tracing.md
+++ b/book/src/producing-events/tracing.md
@@ -50,6 +50,8 @@ wait_a_bit(1200).await;
 # }
 ```
 
+To learn more about `emit`'s macro syntax, see [Template syntax and rendering](../reference/templates.md).
+
 ## Spans with levels
 
 `emit` also defines macros for emitting spans at different levels for filtering:


### PR DESCRIPTION
This PR adds a few links to the macro syntax in a few places you might go looking for it as a new user.