### PR TITLE
Some optimizations to Ctxt

### DIFF
--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -349,7 +349,11 @@ mod alloc_support {
         }
 
         // NOTE: This type uses the same approach as `erased-serde` does for erasing
-        // small values without needing to allocate for them
+        // small values without needing to allocate for them. We have enough local space
+        // to store a value up to 16 bytes, with an alignment up to 8 bytes, inline.
+        //
+        // The variant here is a bit simpler than `erased-serde`'s, because we already
+        // constraint `T` to be `Send + 'static`.
 
         pub struct ErasedFrame {
             data: RawErasedFrame,
@@ -640,7 +644,7 @@ mod alloc_support {
             fn drop(&mut self) {}
         }
 
-        assert!(internal::ErasedFrame::inline::<usize>());
+        assert!(internal::ErasedFrame::inline::<Data>());
         let mut frame = internal::ErasedFrame::new(Data(42));
 
         assert_eq!(42, unsafe { frame.get_mut::<Data>() }.0);

--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -289,23 +289,19 @@ mod internal {
 
 #[cfg(feature = "alloc")]
 mod alloc_support {
-    use alloc::boxed::Box;
-    use core::any::Any;
-
     use crate::props::ErasedProps;
 
     use super::*;
 
     mod internal {
-        use core::{marker::PhantomData, mem, ops::ControlFlow};
+        use alloc::boxed::Box;
+        use core::{marker::PhantomData, mem, mem::MaybeUninit, ops::ControlFlow, ptr};
 
         use crate::{
             props::{ErasedProps, Props},
             str::Str,
             value::Value,
         };
-
-        use super::ErasedFrame;
 
         pub trait DispatchCtxt {
             fn dispatch_with_current(&self, with: &mut dyn FnMut(&ErasedCurrent));
@@ -351,12 +347,103 @@ mod alloc_support {
                 self.get().for_each(for_each)
             }
         }
-    }
 
-    /**
-    An object-safe [`Ctxt::Frame`].
-    */
-    pub struct ErasedFrame(Box<dyn Any + Send>);
+        // NOTE: This type uses the same approach as `erased-serde` does for erasing
+        // small values without needing to allocate for them
+
+        pub struct ErasedFrame {
+            data: RawErasedFrame,
+            vtable: RawErasedFrameVTable,
+        }
+
+        // SAFETY: `ErasedFrame` can only be constructed from `T: Send`
+        unsafe impl Send for ErasedFrame {}
+
+        impl Drop for ErasedFrame {
+            fn drop(&mut self) {
+                // SAFETY: This frame was created from `T`
+                unsafe { (self.vtable.drop)(&mut self.data) }
+            }
+        }
+
+        union RawErasedFrame {
+            boxed: *mut (),
+            inline: MaybeUninit<[usize; 2]>,
+        }
+
+        struct RawErasedFrameVTable {
+            drop: unsafe fn(&mut RawErasedFrame),
+        }
+
+        impl ErasedFrame {
+            /**
+            Whether a value of type `T` can be stored inline.
+            */
+            pub(super) fn inline<T: Send + 'static>() -> bool {
+                mem::size_of::<T>() <= mem::size_of::<RawErasedFrame>()
+                    && mem::align_of::<T>() <= mem::align_of::<RawErasedFrame>()
+            }
+
+            /**
+            Erase a value, storing it inline if it's small enough.
+            */
+            pub(super) fn new<T: Send + 'static>(value: T) -> Self {
+                if Self::inline::<T>() {
+                    let mut data = RawErasedFrame {
+                        inline: MaybeUninit::uninit(),
+                    };
+
+                    unsafe { ptr::write(data.inline.as_mut_ptr() as *mut T, value) };
+
+                    unsafe fn vdrop<T>(data: &mut RawErasedFrame) {
+                        // SAFETY: This frame is storing `T` inline
+                        ptr::drop_in_place(data.inline.as_mut_ptr() as *mut T)
+                    }
+
+                    let vtable = RawErasedFrameVTable { drop: vdrop::<T> };
+
+                    ErasedFrame { data, vtable }
+                } else {
+                    let data = RawErasedFrame {
+                        boxed: Box::into_raw(Box::new(value)) as *mut (),
+                    };
+
+                    unsafe fn vdrop<T>(data: &mut RawErasedFrame) {
+                        // SAFETY: This frame is storing a boxed `T`
+                        drop(unsafe { Box::from_raw(data.boxed as *mut T) });
+                    }
+
+                    let vtable = RawErasedFrameVTable { drop: vdrop::<T> };
+
+                    ErasedFrame { data, vtable }
+                }
+            }
+
+            // SAFETY: This frame must have been created from `T`
+            pub(super) unsafe fn get_mut<T: Send + 'static>(&mut self) -> &mut T {
+                if Self::inline::<T>() {
+                    &mut *(self.data.inline.as_mut_ptr() as *mut T)
+                } else {
+                    &mut *(self.data.boxed as *mut T)
+                }
+            }
+
+            // SAFETY: This frame must have been created from `T`
+            pub(super) unsafe fn into_inner<T: Send + 'static>(mut self) -> T {
+                if Self::inline::<T>() {
+                    let data = ptr::read(self.data.inline.as_mut_ptr() as *mut T);
+                    mem::forget(self);
+
+                    data
+                } else {
+                    let data = Box::from_raw(self.data.boxed as *mut T);
+                    mem::forget(self);
+
+                    *data
+                }
+            }
+        }
+    }
 
     /**
     An object-safe [`Ctxt`].
@@ -381,47 +468,39 @@ mod alloc_support {
         C::Frame: Send + 'static,
     {
         fn dispatch_with_current(&self, with: &mut dyn FnMut(&internal::ErasedCurrent)) {
-            // SAFETY: The borrow passed to `with` is arbitarily short, so `ErasedCurrent::get`
+            // SAFETY: The borrow passed to `with` is arbitarily short, so `internal::ErasedCurrent::get`
             // cannot outlive `props`
             self.with_current(move |props| with(&unsafe { internal::ErasedCurrent::new(&props) }))
         }
 
-        fn dispatch_open_root(&self, props: &dyn ErasedProps) -> ErasedFrame {
-            ErasedFrame(Box::new(self.open_root(props)))
+        fn dispatch_open_root(&self, props: &dyn ErasedProps) -> internal::ErasedFrame {
+            internal::ErasedFrame::new(self.open_root(props))
         }
 
-        fn dispatch_open_push(&self, props: &dyn ErasedProps) -> ErasedFrame {
-            // TODO: For pointer-sized frames we could consider inlining
-            // to avoid boxing
-            ErasedFrame(Box::new(self.open_push(props)))
+        fn dispatch_open_push(&self, props: &dyn ErasedProps) -> internal::ErasedFrame {
+            internal::ErasedFrame::new(self.open_push(props))
         }
 
-        fn dispatch_open_disabled(&self, props: &dyn ErasedProps) -> ErasedFrame {
-            ErasedFrame(Box::new(self.open_disabled(props)))
+        fn dispatch_open_disabled(&self, props: &dyn ErasedProps) -> internal::ErasedFrame {
+            internal::ErasedFrame::new(self.open_disabled(props))
         }
 
-        fn dispatch_enter(&self, span: &mut ErasedFrame) {
-            if let Some(span) = span.0.downcast_mut() {
-                self.enter(span)
-            }
+        fn dispatch_enter(&self, span: &mut internal::ErasedFrame) {
+            self.enter(unsafe { span.get_mut::<C::Frame>() })
         }
 
-        fn dispatch_exit(&self, span: &mut ErasedFrame) {
-            if let Some(span) = span.0.downcast_mut() {
-                self.exit(span)
-            }
+        fn dispatch_exit(&self, span: &mut internal::ErasedFrame) {
+            self.exit(unsafe { span.get_mut::<C::Frame>() })
         }
 
-        fn dispatch_close(&self, span: ErasedFrame) {
-            if let Ok(span) = span.0.downcast() {
-                self.close(*span)
-            }
+        fn dispatch_close(&self, span: internal::ErasedFrame) {
+            self.close(unsafe { span.into_inner::<C::Frame>() })
         }
     }
 
     impl<'a> Ctxt for dyn ErasedCtxt + 'a {
         type Current = internal::ErasedCurrent;
-        type Frame = ErasedFrame;
+        type Frame = internal::ErasedFrame;
 
         fn with_current<R, F: FnOnce(&Self::Current) -> R>(&self, with: F) -> R {
             let mut f = Some(with);
@@ -551,6 +630,36 @@ mod alloc_support {
 
             ctxt.close(frame);
         }
+    }
+
+    #[test]
+    fn erased_frame_inline() {
+        struct Data(usize);
+
+        impl Drop for Data {
+            fn drop(&mut self) {}
+        }
+
+        assert!(internal::ErasedFrame::inline::<usize>());
+        let mut frame = internal::ErasedFrame::new(Data(42));
+
+        assert_eq!(42, unsafe { frame.get_mut::<Data>() }.0);
+
+        let data = unsafe { frame.into_inner::<Data>() };
+
+        assert_eq!(42, data.0);
+    }
+
+    #[test]
+    fn erased_frame_boxed() {
+        assert!(!internal::ErasedFrame::inline::<String>());
+        let mut frame = internal::ErasedFrame::new(String::from("some data"));
+
+        assert_eq!("some data", unsafe { frame.get_mut::<String>() });
+
+        let data = unsafe { frame.into_inner::<String>() };
+
+        assert_eq!("some data", data);
     }
 }
 

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -15,8 +15,10 @@ use emit_core::{
     props::Props,
     runtime::InternalCtxt,
     str::Str,
-    value::{OwnedValue, Value},
+    value::{OwnedValue, ToValue, Value},
 };
+
+use crate::span::{SpanId, TraceId};
 
 /**
 A [`Ctxt`] that stores ambient state in thread local storage.
@@ -55,7 +57,41 @@ A [`Ctxt::Frame`] on a [`ThreadLocalCtxt`].
 */
 #[derive(Clone)]
 pub struct ThreadLocalCtxtFrame {
-    props: Option<Arc<HashMap<Str<'static>, OwnedValue>>>,
+    props: Option<Arc<HashMap<Str<'static>, ThreadLocalValue>>>,
+}
+
+#[derive(Clone)]
+enum ThreadLocalValue {
+    TraceId(TraceId),
+    SpanId(SpanId),
+    Any(OwnedValue),
+}
+
+impl ThreadLocalValue {
+    fn from_value(value: Value) -> Self {
+        // Specialize a few common value types
+
+        if let Some(trace_id) = value.downcast_ref() {
+            return ThreadLocalValue::TraceId(*trace_id);
+        }
+
+        if let Some(span_id) = value.downcast_ref() {
+            return ThreadLocalValue::SpanId(*span_id);
+        }
+
+        // Fall back to buffering
+        ThreadLocalValue::Any(value.to_shared())
+    }
+}
+
+impl ToValue for ThreadLocalValue {
+    fn to_value(&self) -> Value {
+        match self {
+            ThreadLocalValue::TraceId(ref value) => value.to_value(),
+            ThreadLocalValue::SpanId(ref value) => value.to_value(),
+            ThreadLocalValue::Any(ref value) => value.to_value(),
+        }
+    }
 }
 
 impl Props for ThreadLocalCtxtFrame {
@@ -65,7 +101,7 @@ impl Props for ThreadLocalCtxtFrame {
     ) -> ControlFlow<()> {
         if let Some(ref props) = self.props {
             for (k, v) in &**props {
-                for_each(k.by_ref(), v.by_ref())?;
+                for_each(k.by_ref(), v.to_value())?;
             }
         }
 
@@ -94,7 +130,8 @@ impl Ctxt for ThreadLocalCtxt {
         let mut span = HashMap::new();
 
         let _ = props.for_each(|k, v| {
-            span.insert(k.to_shared(), v.to_shared());
+            span.insert(k.to_shared(), ThreadLocalValue::from_value(v));
+
             ControlFlow::Continue(())
         });
 
@@ -113,7 +150,8 @@ impl Ctxt for ThreadLocalCtxt {
         let span_props = Arc::make_mut(span.props.as_mut().unwrap());
 
         let _ = props.for_each(|k, v| {
-            span_props.insert(k.to_shared(), v.to_shared());
+            span_props.insert(k.to_shared(), ThreadLocalValue::from_value(v));
+
             ControlFlow::Continue(())
         });
 
@@ -176,7 +214,7 @@ mod tests {
     use std::thread;
 
     impl ThreadLocalCtxtFrame {
-        fn props(&self) -> HashMap<Str<'static>, OwnedValue> {
+        fn props(&self) -> HashMap<Str<'static>, ThreadLocalValue> {
             self.props
                 .as_ref()
                 .map(|props| (**props).clone())
@@ -225,7 +263,7 @@ mod tests {
             let props = props.props();
 
             assert_eq!(1, props.len());
-            assert_eq!(1, props["a"].by_ref().cast::<i32>().unwrap());
+            assert_eq!(1, props["a"].to_value().cast::<i32>().unwrap());
         });
 
         ctxt.clone().enter(&mut inner);
@@ -234,8 +272,8 @@ mod tests {
             let props = props.props();
 
             assert_eq!(2, props.len());
-            assert_eq!(2, props["a"].by_ref().cast::<i32>().unwrap());
-            assert_eq!(1, props["b"].by_ref().cast::<i32>().unwrap());
+            assert_eq!(2, props["a"].to_value().cast::<i32>().unwrap());
+            assert_eq!(1, props["b"].to_value().cast::<i32>().unwrap());
         });
 
         ctxt.clone().exit(&mut inner);

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -185,6 +185,22 @@ mod tests {
     }
 
     #[test]
+    fn can_inline() {
+        use std::mem;
+
+        // Mirrors the impl of `ErasedFrame`
+        union RawErasedFrame {
+            _data: *mut (),
+            _inline: mem::MaybeUninit<[usize; 2]>,
+        }
+
+        assert!(
+            mem::size_of::<ThreadLocalCtxt>() <= mem::size_of::<RawErasedFrame>()
+                && mem::align_of::<ThreadLocalCtxt>() <= mem::align_of::<RawErasedFrame>()
+        );
+    }
+
+    #[test]
     fn push_props() {
         let ctxt = ThreadLocalCtxt::new();
 


### PR DESCRIPTION
This PR applies a few optimizations to the `Ctxt` infrastructure to reduce the cost of contextual logging. The main changes are:

- Use the same approach as `erased-serde` to avoid needing to allocate for small frames by storing them inline in the value. I opted for the same 2-ptr size limit, which is enough to store a thread local frame, but not enough to bloat the size of the type too much.
- Avoid allocating some common value types in the thread local frame like trace and span ids.