### PR TITLE
Inline small strings when buffering values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ version = "1.4.0"
 path = "core"
 default-features = false
 
-[dependencies.value-bag]
-version = "1"
-
 [dependencies.sval]
 version = "2"
 optional = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,8 +20,8 @@ implicit_rt = ["implicit_internal_rt"]
 implicit_internal_rt = []
 
 [dependencies.value-bag]
-version = "1"
-features = ["inline-i128", "seq"]
+version = "1.11"
+features = ["inline-i128", "inline-str", "seq"]
 default-features = false
 
 [dependencies.unicode-ident]

--- a/core/src/ctxt.rs
+++ b/core/src/ctxt.rs
@@ -637,6 +637,21 @@ mod alloc_support {
     }
 
     #[test]
+    fn erased_frame_zero_sized() {
+        #[derive(PartialEq, Eq, Debug)]
+        struct Data;
+
+        assert!(internal::ErasedFrame::inline::<Data>());
+        let mut frame = internal::ErasedFrame::new(Data);
+
+        assert_eq!(Data, *unsafe { frame.get_mut::<Data>() });
+
+        let data = unsafe { frame.into_inner::<Data>() };
+
+        assert_eq!(Data, data);
+    }
+
+    #[test]
     fn erased_frame_inline() {
         struct Data(usize);
 


### PR DESCRIPTION
This PR pulls in `value-bag/inline-str` so small strings are stored inline instead of in `Box` or `Arc`.