### PR TITLE
feat: `in_fn` to simplify some call sites

### DIFF
--- a/book/src/producing-events/tracing/propagating-across-threads.md
+++ b/book/src/producing-events/tracing/propagating-across-threads.md
@@ -5,11 +5,23 @@ Ambient span properties are not shared across threads by default. This context n
 ```rust
 # extern crate emit;
 # fn my_operation() {}
-std::thread::spawn({
-    let ctxt = emit::Frame::current(emit::ctxt());
+std::thread::spawn(emit::Frame::current(emit::ctxt()).in_fn(||{
+    // Your code goes here
+}));
+```
 
-    move || ctxt.call(|| {
-        // Your code goes here
+or scoped threads:
+
+```rust
+# extern crate emit;
+# fn my_operation() {}
+let ctxt = emit::Frame::current(emit::ctxt());
+std::thread::scope(|s| {
+    frame.call(|| {
+        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}))
+        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}))
+
+        // Also active here
     })
 });
 ```

--- a/book/src/producing-events/tracing/propagating-across-threads.md
+++ b/book/src/producing-events/tracing/propagating-across-threads.md
@@ -17,9 +17,9 @@ or scoped threads:
 # fn my_operation() {}
 let ctxt = emit::Frame::current(emit::ctxt());
 std::thread::scope(|s| {
-    frame.call(|| {
-        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}))
-        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}))
+    ctxt.call(|| {
+        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}));
+        s.spawn(emit::Frame::current(emit::ctxt()).in_fn(|| {/* frame active here */}));
 
         // Also active here
     })


### PR DESCRIPTION
This makes usage more similar to `in_future` when one wants to pass the current props to another thread.

The common case is for pusing the current frame into a spawned thread. The previous recommendation was this:

```rust
std::thread::spawn({
  let ctxt = emit::Frame::current(emit::ctxt());
  move || ctxt.call(|| { /* useful stuff */ })
});
```

which is a lot to take in with the 2 closures.

With this change, the same code becomes:

```rust
std::thread::spawn(emit::Frame::current(emit::ctxt()).in_fn(move || {/* useful stuff */}));
```

simplifying a common pattern and making it more similar to the async version.

The previous style is still necessary for anything that's not `FnOnce() -> T` (e.g.: any function that takes an argument), so I've left that style in the documentation as well.