### PR TITLE
Add some cmdline switches to otlp throughput harness

### DIFF
--- a/.github/workflows/otlp.yml
+++ b/.github/workflows/otlp.yml
@@ -76,4 +76,4 @@ jobs:
 
       - name: Throughput Test
         working-directory: ./emitter/otlp/test/throughput
-        run: cargo run --release
+        run: cargo run --release -- --spawn --flush

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "examples/opentelemetry/direct_otlp",
     "examples/trace_zipkin",
     "examples/metric_prometheus",
-    "test/ui", "examples/trace_zipkin", "examples/metric_prometheus",
+    "test/ui",
 ]
 
 [package]
@@ -78,3 +78,6 @@ version = "2"
 
 [dev-dependencies.serde_test]
 version = "1"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
This PR just continues making the OTLP throughput test more useful for investigating performance issues by adding a few switches to control whether to spawn an `otelcol` child process, and whether to wait for it to flush.