### PR TITLE
Clean up some docs issues

### DIFF
--- a/book/src/emitting-events.md
+++ b/book/src/emitting-events.md
@@ -134,7 +134,7 @@ Also see [Filtering events](./filtering-events.md) for more details on filtering
 
 ## Flushing
 
-Events may be processed asynchronously, so to ensure they're fulling flushed before your `main` returns, you can call [`blocking_flush`](https://docs.rs/emit/1.5.0/emit/setup/struct.Init.html#method.blocking_flush) at the end of your `main` function:
+Events may be processed asynchronously, so to ensure they're fully flushed before your `main` returns, you can call [`blocking_flush`](https://docs.rs/emit/1.5.0/emit/setup/struct.Init.html#method.blocking_flush) at the end of your `main` function:
 
 ```rust
 # extern crate emit;

--- a/book/src/emitting-events/otlp.md
+++ b/book/src/emitting-events/otlp.md
@@ -2,9 +2,9 @@
 
 You can use [`emit_otlp`](https://docs.rs/emit_otlp/1.5.0/emit_otlp/index.html) to emit diagnostic events to remote OpenTelemetry-compatible services.
 
-OpenTelemtry defines a wire protocol for exchanging diagnostic data called [OTLP](https://opentelemetry.io/docs/specs/otlp/). If you're using a modern telemetry backend then chances are it supports OTLP either directly or through [OpenTelemetry's Collector](https://opentelemetry.io/docs/collector/).
+OpenTelemetry defines a wire protocol for exchanging diagnostic data called [OTLP](https://opentelemetry.io/docs/specs/otlp/). If you're using a modern telemetry backend then chances are it supports OTLP either directly or through [OpenTelemetry's Collector](https://opentelemetry.io/docs/collector/).
 
-`emit_otlp` is an independent implementation of OTLP that maps `emit`'s events onto the OpenTelemetry data model. `emit_otlp` doesn't rely on the OpenTelemtry SDK or any gRPC or protobuf tooling, so can be added to any Rust application without requiring changes to your build process.
+`emit_otlp` is an independent implementation of OTLP that maps `emit`'s events onto the OpenTelemetry data model. `emit_otlp` doesn't rely on the OpenTelemetry SDK or any gRPC or protobuf tooling, so can be added to any Rust application without requiring changes to your build process.
 
 ```toml
 [dependencies.emit_otlp]

--- a/book/src/filtering-events.md
+++ b/book/src/filtering-events.md
@@ -123,6 +123,8 @@ fn main() {
 }
 ```
 
+Events in this filter are matched by prefix, using the most specific relevant path. In the above example, `noisy_module::important_sub_module` will match `Info` and higher, but `noisy_module::other_sub_module` will match `Warn` and higher.
+
 See [the crate docs](https://docs.rs/emit/1.5.0/emit/level/struct.MinLevelPathMap.html) for more details.
 
 ## Filtering spans

--- a/book/src/producing-events/tracing/manual-span-creation.md
+++ b/book/src/producing-events/tracing/manual-span-creation.md
@@ -2,7 +2,7 @@
 
 ## Creating `SpanGuard`s
 
-The `#[span]` attribute [includes a `guard` control parameter](./manual-span-completion.md) that gives you access to a [`SpanGuard`](https://docs.rs/emit/1.5.0/emit/span/struct.SpanGuard.html) to manually complete it. The `#[span]` attribute takes care of constructing the `SpanGuard` for you and ensuring any ambient span properties are active in the body of your annotated function.
+The `#[span]` attribute [includes a `guard` control parameter](./manual-span-completion.md) that gives you access to a [`SpanGuard`](https://docs.rs/emit/1.5.0/emit/span/struct.SpanGuard.html) to manually complete it. The `#[span]` attribute takes care of constructing the `SpanGuard` for you and ensuring any ambient span properties are active in the body of your annotated function. See [Manual span completion](./manual-span-completion.md) for more details.
 
 You can also create `SpanGuard`s manually if you can't or don't want to use the `#[span]` attribute:
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -89,7 +89,7 @@ use emit_core::{
     rng::Rng,
     runtime::{
         AmbientRuntime, AmbientSlot, InternalClock, InternalCtxt, InternalEmitter, InternalFilter,
-        InternalRng,
+        InternalRng, Runtime,
     },
 };
 
@@ -286,6 +286,13 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt, TClock: Clock, TRng: Rng>
             rng,
         }
     }
+
+    /**
+    Initialize a standalone runtime.
+    */
+    pub fn init_runtime(self) -> Runtime<TEmitter, TFilter, TCtxt, TClock, TRng> {
+        Runtime::build(self.emitter, self.filter, self.ctxt, self.clock, self.rng)
+    }
 }
 
 impl<
@@ -346,7 +353,7 @@ where
     #[must_use = "call `flush_on_drop` or call `blocking_flush` at the end of `main` to ensure events are flushed."]
     pub fn try_init_slot<'a>(self, slot: &'a AmbientSlot) -> Option<Init<'a, TEmitter, TCtxt>> {
         let ambient = slot.init(
-            emit_core::runtime::Runtime::new()
+            Runtime::new()
                 .with_emitter(self.emitter)
                 .with_filter(self.filter)
                 .with_ctxt(self.ctxt)
@@ -400,7 +407,7 @@ where
         let slot = emit_core::runtime::internal_slot();
 
         let ambient = slot.init(
-            emit_core::runtime::Runtime::new()
+            Runtime::new()
                 .with_emitter(self.emitter)
                 .with_filter(self.filter)
                 .with_ctxt(self.ctxt)


### PR DESCRIPTION
This PR just cleans up some issues and typos I spotted in the docs.

I've also added a `Setup::into_runtime` method, because I keep finding myself wanting to create a standalone runtime, and the standard entrypoint to configuration is via `Setup`.