### PR TITLE
Support OpenTelemetry's span kinds in emit_otlp

### DIFF
--- a/core/src/timestamp.rs
+++ b/core/src/timestamp.rs
@@ -11,7 +11,7 @@ A timestamp can be converted into a point [`crate::extent::Extent`]. A pair of t
 /*
 Parts of this file are adapted from other libraries:
 
-Post:
+Prost:
 https://github.com/tokio-rs/prost/blob/master/prost-types/src/datetime.rs
 Licensed under Apache 2.0
 

--- a/core/src/well_known.rs
+++ b/core/src/well_known.rs
@@ -87,6 +87,17 @@ pub const KEY_SPAN_ID: &'static str = "span_id";
 /** The parent span id. */
 pub const KEY_SPAN_PARENT: &'static str = "span_parent";
 
+/** Internal spans represent operations which do not cross a process boundary. */
+pub const SPAN_KIND_INTERNAL: &'static str = "internal";
+/** Server-side handling of an RPC or other remote network request. */
+pub const SPAN_KIND_SERVER: &'static str = "server";
+/** A request to some remote service. */
+pub const SPAN_KIND_CLIENT: &'static str = "client";
+/** A producer sending a message to a broker. */
+pub const SPAN_KIND_PRODUCER: &'static str = "producer";
+/** A consumer receiving a message from a broker. */
+pub const SPAN_KIND_CONSUMER: &'static str = "consumer";
+
 // Metric
 /** The name of the underlying data source. */
 pub const KEY_METRIC_NAME: &'static str = "metric_name";

--- a/core/src/well_known.rs
+++ b/core/src/well_known.rs
@@ -22,6 +22,7 @@ Extensions to the data model are signaled by the well-known [`KEY_EVT_KIND`] pro
 
 - Tracing [`KEY_EVT_KIND`] = [`EVENT_KIND_SPAN`]:
     - [`KEY_SPAN_NAME`]: The informative name of the span.
+    - [`KEY_SPAN_KIND`]: The kind of the span.
     - [`KEY_TRACE_ID`]: The trace id.
     - [`KEY_SPAN_ID`]: The span id.
     - [`KEY_SPAN_PARENT`]: The parent span id.
@@ -77,6 +78,8 @@ pub const KEY_ERR: &'static str = "err";
 // Trace
 /** The informative name of the span. */
 pub const KEY_SPAN_NAME: &'static str = "span_name";
+/** The kind of the span. */
+pub const KEY_SPAN_KIND: &'static str = "span_kind";
 /** The trace id. */
 pub const KEY_TRACE_ID: &'static str = "trace_id";
 /** The span id. */

--- a/emitter/otlp/src/client/traces.rs
+++ b/emitter/otlp/src/client/traces.rs
@@ -94,6 +94,20 @@ impl OtlpTracesBuilder {
         self
     }
 
+    /**
+    Use the given `extractor` function to format the span kind of the OTLP span for a given [`emit::Event`].
+    */
+    pub fn kind(
+        mut self,
+        extractor: impl Fn(&emit::event::Event<&dyn emit::props::ErasedProps>) -> Option<emit::span::SpanKind>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        self.event_encoder.kind = Box::new(extractor);
+        self
+    }
+
     pub(in crate::client) fn build(
         self,
         metrics: Arc<InternalMetrics>,

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -407,9 +407,17 @@ pub(crate) mod util {
         evt: emit::Event<impl emit::Props>,
         proto: impl FnOnce(PreEncodedCursor),
     ) {
+        encode_event_with(E::default(), evt, proto)
+    }
+
+    pub(crate) fn encode_event_with(
+        encoder: impl EventEncoder,
+        evt: emit::Event<impl emit::Props>,
+        proto: impl FnOnce(PreEncodedCursor),
+    ) {
         // Ensure the JSON representation is valid JSON
         let _: serde_json::Value = serde_json::from_reader(
-            E::default()
+            encoder
                 .encode_event::<Json>(&evt)
                 .unwrap()
                 .payload
@@ -419,7 +427,7 @@ pub(crate) mod util {
         .unwrap();
 
         proto(
-            E::default()
+            encoder
                 .encode_event::<Proto>(&evt)
                 .unwrap()
                 .payload

--- a/emitter/otlp/src/data/logs/log_record.rs
+++ b/emitter/otlp/src/data/logs/log_record.rs
@@ -96,6 +96,7 @@ impl<
             &LOG_RECORD_ATTRIBUTES_INDEX,
             |stream| {
                 stream_attributes(stream, &self.0, |mut stream, k, v| match k.get() {
+                    // Well-known fields
                     emit::well_known::KEY_LVL => {
                         level = v.by_ref().cast::<emit::Level>().unwrap_or_default();
                         Ok(())
@@ -127,6 +128,9 @@ impl<
 
                         Ok(())
                     }
+                    // Ignored
+                    emit::well_known::KEY_SPAN_KIND | emit::well_known::KEY_SPAN_NAME => Ok(()),
+                    // Regular attributes
                     _ => stream.stream_attribute(k, v),
                 })
             },

--- a/emitter/otlp/src/data/traces.rs
+++ b/emitter/otlp/src/data/traces.rs
@@ -156,12 +156,54 @@ mod tests {
 
     #[test]
     fn encode_span_name() {
-        todo!()
+        let encoder = TracesEventEncoder {
+            name: Box::new(|_, f| f.write_str("custom name")),
+            kind: default_kind_extractor(),
+        };
+
+        encode_event_with(
+            encoder,
+            emit::evt!(
+                extent: ts(1)..ts(13),
+                "greet {user}",
+                user: "test",
+                evt_kind: "span",
+                span_name: "test",
+                trace_id: "00000000000000000000000000000001",
+                span_id: "0000000000000001"
+            ),
+            |buf| {
+                let de = trace::Span::decode(buf).unwrap();
+
+                assert_eq!("custom name", de.name);
+            },
+        );
     }
 
     #[test]
     fn encode_span_kind() {
-        todo!()
+        let encoder = TracesEventEncoder {
+            name: default_name_formatter(),
+            kind: Box::new(|_| Some(emit::span::SpanKind::Server)),
+        };
+
+        encode_event_with(
+            encoder,
+            emit::evt!(
+                extent: ts(1)..ts(13),
+                "greet {user}",
+                user: "test",
+                evt_kind: "span",
+                span_name: "test",
+                trace_id: "00000000000000000000000000000001",
+                span_id: "0000000000000001"
+            ),
+            |buf| {
+                let de = trace::Span::decode(buf).unwrap();
+
+                assert_eq!(trace::span::SpanKind::Server as i32, de.kind);
+            },
+        );
     }
 
     #[test]

--- a/emitter/otlp/src/data/traces.rs
+++ b/emitter/otlp/src/data/traces.rs
@@ -143,6 +143,7 @@ mod tests {
                 user: "test",
                 evt_kind: "span",
                 span_name: "test",
+                span_kind: "server",
                 trace_id: "00000000000000000000000000000001",
                 span_id: "0000000000000001"
             ),
@@ -150,6 +151,7 @@ mod tests {
                 let de = trace::Span::decode(buf).unwrap();
 
                 assert_eq!("test", de.name);
+                assert_eq!(trace::span::SpanKind::Server as i32, de.kind);
             },
         );
     }

--- a/emitter/otlp/src/data/traces/span.rs
+++ b/emitter/otlp/src/data/traces/span.rs
@@ -19,6 +19,24 @@ pub enum StatusCode {
 #[sval(unlabeled_variants)]
 pub enum SpanKind {
     Unspecified = 0,
+    Internal = 1,
+    Server = 2,
+    Client = 3,
+    Producer = 4,
+    Consumer = 5,
+}
+
+impl From<emit::span::SpanKind> for SpanKind {
+    fn from(kind: emit::span::SpanKind) -> SpanKind {
+        match kind {
+            emit::span::SpanKind::Internal => SpanKind::Internal,
+            emit::span::SpanKind::Server => SpanKind::Server,
+            emit::span::SpanKind::Client => SpanKind::Client,
+            emit::span::SpanKind::Producer => SpanKind::Producer,
+            emit::span::SpanKind::Consumer => SpanKind::Consumer,
+            _ => SpanKind::Unspecified,
+        }
+    }
 }
 
 #[derive(Value)]
@@ -124,6 +142,7 @@ impl<
                 stream_attributes(stream, &self.props, |mut stream, k, v| match k.get() {
                     emit::well_known::KEY_EVT_KIND => Ok(()),
                     emit::well_known::KEY_SPAN_NAME => Ok(()),
+                    emit::well_known::KEY_SPAN_KIND => Ok(()),
                     emit::well_known::KEY_LVL => {
                         level = v.by_ref().cast().unwrap_or_default();
                         Ok(())

--- a/emitter/otlp/src/data/traces/span.rs
+++ b/emitter/otlp/src/data/traces/span.rs
@@ -140,9 +140,7 @@ impl<
             &SPAN_ATTRIBUTES_INDEX,
             |stream| {
                 stream_attributes(stream, &self.props, |mut stream, k, v| match k.get() {
-                    emit::well_known::KEY_EVT_KIND => Ok(()),
-                    emit::well_known::KEY_SPAN_NAME => Ok(()),
-                    emit::well_known::KEY_SPAN_KIND => Ok(()),
+                    // Well-known fields
                     emit::well_known::KEY_LVL => {
                         level = v.by_ref().cast().unwrap_or_default();
                         Ok(())
@@ -172,6 +170,11 @@ impl<
                         has_err = true;
                         Ok(())
                     }
+                    // Ignored
+                    emit::well_known::KEY_EVT_KIND
+                    | emit::well_known::KEY_SPAN_NAME
+                    | emit::well_known::KEY_SPAN_KIND => Ok(()),
+                    // Regular attributes
                     _ => stream.stream_attribute(k, v),
                 })
             },

--- a/src/span.rs
+++ b/src/span.rs
@@ -833,13 +833,88 @@ impl Props for SpanCtxt {
 }
 
 /**
+An error encountered attempting to parse a [`TraceId`] or [`SpanId`].
+*/
+#[derive(Debug)]
+pub struct ParseKindError {}
+
+impl fmt::Display for ParseKindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "the input was not a valid kind")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseKindError {}
+
+/**
+A hint about the way a span and its child are linked.
+*/
+#[non_exhaustive]
+#[derive(Clone, Copy)]
+pub enum SpanKind {
+    /**
+    Internal spans represent operations which do not cross a process boundary.
+    */
+    Internal,
+    /**
+    Server-side handling of an RPC or other remote network request.
+
+    Paired with a `Client`.
+    */
+    Server,
+    /**
+    A request to some remote service.
+
+    Paired with a `Server`.
+    */
+    Client,
+    /**
+    A producer sending a message to a broker.
+
+    Paired with a `Consumer`.
+    */
+    Producer,
+    /**
+    A consumer receiving a message from a broker.
+
+    Paired with a `Producer`.
+    */
+    Consumer,
+}
+
+impl FromStr for SpanKind {
+    type Err = ParseKindError;
+
+    fn from_str(v: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}
+
+impl fmt::Display for SpanKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl ToValue for SpanKind {
+    fn to_value(&self) -> Value {
+        todo!()
+    }
+}
+
+impl<'v> FromValue<'v> for SpanKind {
+    fn from_value(v: Value<'v>) -> Option<Self> {
+        todo!()
+    }
+}
+
+/**
 An active span in a distributed trace.
 
 ## Creating active spans automatically
 
 This type is created by the [`macro@crate::span!`] macro with the `guard` control parameter, or with the [`macro@crate::new_span!`] macro.
-
-
 
 Call [`SpanGuard::complete_with`], or just drop the guard to complete it, passing the resulting [`Span`] to a [`Completion`].
 
@@ -1794,6 +1869,28 @@ mod tests {
             &TraceId::from_u128(0x0123456789abcdef0123456789abcdef).unwrap(),
             &[serde_test::Token::Str("0123456789abcdef0123456789abcdef")],
         );
+    }
+
+    #[test]
+    fn span_kind_parse() {
+        todo!()
+    }
+
+    #[test]
+    fn span_kind_roundtrip() {
+        todo!()
+    }
+
+    #[cfg(feature = "sval")]
+    #[test]
+    fn span_kind_stream() {
+        todo!()
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn span_kind_serialize() {
+        todo!()
     }
 
     #[test]


### PR DESCRIPTION
For #169 

This PR adds support for OpenTelemetry's span kinds to `emit_otlp`. It does this via a new well-known `span_kind` property, which other emitters may also opt-in to supporting if they want too.

The handling of span kinds in `emit_otlp` follows the same pattern as span names. If present, the `span_kind` property will inform the kind of the span, but can also be configured.