### PR TITLE
Add an inherent blocking_flush method to Runtime

### DIFF
--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -300,6 +300,15 @@ impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt, TClock: Clock, TRng: Rng>
     pub fn emit<E: ToEvent>(&self, evt: E) {
         crate::emit(&self.emitter, &self.filter, &self.ctxt, &self.clock, evt)
     }
+
+    /**
+    Block for up to `timeout`, waiting for all diagnostic data emitted up to this point to be fully processed.
+
+    This method defers to the runtime's [`Emitter::blocking_flush`].
+    */
+    pub fn blocking_flush(&self, timeout: core::time::Duration) -> bool {
+        self.emitter.blocking_flush(timeout)
+    }
 }
 
 impl<TEmitter: Emitter, TFilter: Filter, TCtxt: Ctxt, TClock: Clock, TRng: Rng> Emitter

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -2,8 +2,6 @@
 An integration test between `emit_otlp` and the OpenTelemetry Collector.
 */
 
-use emit::Emitter;
-
 use std::{
     io::Read,
     path::Path,


### PR DESCRIPTION
This PR just introduces an inherent `Runtime::blocking_flush` method, which just lets you flush a custom runtime without having to import the `Emitter` trait.