### PR TITLE
Optimize Props::dedup

### DIFF
--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -390,9 +390,6 @@ mod alloc_support {
 
     use alloc::collections::BTreeMap;
 
-    #[cfg(feature = "std")]
-    use std::collections::HashMap;
-
     /**
     The result of calling [`Props::dedup`].
 
@@ -517,9 +514,6 @@ mod alloc_support {
             }
 
             struct Spilled<'a> {
-                #[cfg(feature = "std")]
-                values: HashMap<Str<'a>, Value<'a>>,
-                #[cfg(not(feature = "std"))]
                 values: BTreeMap<Str<'a>, Value<'a>>,
             }
 

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -127,7 +127,7 @@ impl<'v> Value<'v> {
     The absence of any meaningful value.
     */
     #[track_caller]
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Value(value_bag::ValueBag::empty())
     }
 

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -1054,4 +1054,8 @@ impl<'a, const N: usize> Props for __PrivateMacroProps<'a, N> {
     fn is_unique(&self) -> bool {
         true
     }
+
+    fn size(&self) -> Option<usize> {
+        Some(self.0.len())
+    }
 }


### PR DESCRIPTION
This PR introduces a new `Props::size` method that acts as a size hint. We then use this method to optimize `Props::dedup` for small numbers of properties. In some quick testing, this ends up being roughly 30% faster deduplicating 16 unique 13 character keys. Performance for deduplicating larger sets is largely unchanged.

I've also added non-default impls for more `Props` methods.