### PR TITLE
Add a FromProps trait for constructing collections from props

### DIFF
--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -281,6 +281,18 @@ mod alloc_support {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn owned_event_is_send_sync() {
+            fn check<T: Send + Sync>() {}
+
+            check::<Event<'static, OwnedProps>>();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -262,6 +262,27 @@ impl<'a, P: Props> ToEvent for Event<'a, P> {
     }
 }
 
+#[cfg(feature = "alloc")]
+mod alloc_support {
+    use super::*;
+
+    use crate::props::OwnedProps;
+
+    impl<'a, P: Props> Event<'a, P> {
+        /**
+        Get a new event, taking an owned copy of its data.
+        */
+        pub fn to_owned(&self) -> Event<'static, OwnedProps> {
+            Event {
+                mdl: self.mdl.to_owned(),
+                extent: self.extent.clone(),
+                tpl: self.tpl.to_owned(),
+                props: OwnedProps::collect_owned(&self.props),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{str::Str, value::Value};
@@ -297,5 +318,10 @@ mod tests {
         assert(&evt);
         assert(&evt.by_ref());
         assert(&evt.erase());
+
+        #[cfg(feature = "alloc")]
+        {
+            assert(&evt.to_owned());
+        }
     }
 }

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -1348,6 +1348,23 @@ mod alloc_support {
         }
 
         #[test]
+        fn owned_props_empty() {
+            let props = OwnedProps::collect_owned([] as [(Str, Value); 0]);
+
+            assert_eq!(Some(0), props.size());
+            assert!(props.is_unique());
+
+            let mut count = 0;
+
+            let _ = props.for_each(|_| {
+                count += 1;
+                ControlFlow::Continue(())
+            });
+
+            assert_eq!(0, count);
+        }
+
+        #[test]
         fn owned_props_collect() {
             for (description, case) in [
                 (
@@ -1421,6 +1438,9 @@ mod alloc_support {
                     .clone(),
                 ),
             ] {
+                assert_eq!(Some(3), case.size());
+                assert!(case.is_unique());
+
                 assert_eq!(Some(1), case.pull::<usize, _>("a"), "{description}");
                 assert_eq!(Some(2), case.pull::<usize, _>("b"), "{description}");
                 assert_eq!(Some(3), case.pull::<usize, _>("c"), "{description}");

--- a/core/src/str.rs
+++ b/core/src/str.rs
@@ -55,7 +55,9 @@ impl<'k> fmt::Display for Str<'k> {
     }
 }
 
+// SAFETY: `Str` synchronizes through `Arc` when ownership is shared
 unsafe impl<'k> Send for Str<'k> {}
+// SAFETY: `Str` does not use interior mutability
 unsafe impl<'k> Sync for Str<'k> {}
 
 impl<'k> Clone for Str<'k> {

--- a/core/src/str.rs
+++ b/core/src/str.rs
@@ -419,7 +419,7 @@ mod alloc_support {
         /**
         Get a new string, taking an owned copy of the data in this one.
 
-        If the string contains a `'static` or `Arc` value then this method is cheap and doesn't involve cloning. In other cases the underlying value will be passed through [`Str::new_shared`].
+        If the string contains a `'static` or `Arc` value then this method is cheap. In other cases the underlying value will be passed through [`Str::new_shared`].
         */
         pub fn to_shared(&self) -> Str<'static> {
             match self.owner {

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -545,6 +545,12 @@ mod alloc_support {
         }
     }
 
+    impl<'a> From<Value<'a>> for OwnedValue {
+        fn from(value: Value<'a>) -> Self {
+            value.to_owned()
+        }
+    }
+
     impl ToValue for OwnedValue {
         fn to_value(&self) -> Value<'_> {
             self.by_ref()

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -111,7 +111,6 @@ fn content_type_of(payload: &EncodedPayload) -> &'static str {
 impl HttpContent {
     fn new(
         allow_compression: bool,
-        uri: &HttpUri,
         configure: impl Fn(HttpContent) -> Result<HttpContent, Error>,
         metrics: &InternalMetrics,
         payload: EncodedPayload,
@@ -119,7 +118,7 @@ impl HttpContent {
         let body = {
             #[cfg(feature = "gzip")]
             {
-                if allow_compression && !uri.is_https() {
+                if allow_compression {
                     metrics.transport_request_compress_gzip.increment();
 
                     HttpContent::gzip(payload)?
@@ -130,7 +129,6 @@ impl HttpContent {
             #[cfg(not(feature = "gzip"))]
             {
                 let _ = allow_compression;
-                let _ = uri;
                 let _ = metrics;
 
                 HttpContent::raw(payload)

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -61,6 +61,11 @@ impl HttpUri {
         })?))
     }
 
+    #[cfg(not(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )))]
     pub fn is_https(&self) -> bool {
         self.0.scheme().unwrap() == &http::uri::Scheme::HTTPS
     }
@@ -126,6 +131,7 @@ impl HttpContent {
             {
                 let _ = allow_compression;
                 let _ = uri;
+                let _ = metrics;
 
                 HttpContent::raw(payload)
             }

--- a/emitter/otlp/src/client/http/tokio.rs
+++ b/emitter/otlp/src/client/http/tokio.rs
@@ -309,13 +309,8 @@ impl HttpConnection {
                 None => connect(&self.metrics, self.version, &self.uri).await?,
             };
 
-            let body = HttpContent::new(
-                self.allow_compression,
-                &self.uri,
-                &self.request,
-                &self.metrics,
-                body,
-            )?;
+            let body =
+                HttpContent::new(self.allow_compression, &self.request, &self.metrics, body)?;
 
             let res = send_request(
                 &self.metrics,
@@ -534,14 +529,8 @@ mod tests {
         let metrics = InternalMetrics::default();
         let uri = HttpUri::new("http://localhost:4718").unwrap();
         let headers = [] as [(&str, &str); 0];
-        let content = HttpContent::new(
-            false,
-            &uri,
-            |content| Ok(content),
-            &metrics,
-            Json::encode(42),
-        )
-        .unwrap();
+        let content =
+            HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
 
         let req = http_request(&metrics, &uri, headers.into_iter(), content).unwrap();
 
@@ -555,14 +544,8 @@ mod tests {
         let metrics = InternalMetrics::default();
         let uri = HttpUri::new("http://localhost:4718").unwrap();
         let headers = [("user-agent", "custom-agent")];
-        let content = HttpContent::new(
-            false,
-            &uri,
-            |content| Ok(content),
-            &metrics,
-            Json::encode(42),
-        )
-        .unwrap();
+        let content =
+            HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
 
         let req = http_request(&metrics, &uri, headers.into_iter(), content).unwrap();
 

--- a/emitter/otlp/src/client/http/web.rs
+++ b/emitter/otlp/src/client/http/web.rs
@@ -63,13 +63,7 @@ impl HttpConnection {
     pub async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
         let resource = self.uri.to_string();
 
-        let content = HttpContent::new(
-            self.allow_compression,
-            &self.uri,
-            &self.request,
-            &self.metrics,
-            body,
-        )?;
+        let content = HttpContent::new(self.allow_compression, &self.request, &self.metrics, body)?;
 
         // NOTE: Headers added here may affect CORS
         let headers = js_headers(

--- a/emitter/otlp/src/client/stub.rs
+++ b/emitter/otlp/src/client/stub.rs
@@ -59,6 +59,6 @@ impl Instant {
     }
 }
 
-pub(crate) async fn flush(_sender: &emit_batcher::Sender<Channel>, timeout: Duration) -> bool {
+pub(crate) async fn flush(_sender: &emit_batcher::Sender<Channel>, _timeout: Duration) -> bool {
     false
 }

--- a/emitter/otlp/src/lib.rs
+++ b/emitter/otlp/src/lib.rs
@@ -147,6 +147,7 @@ If the `gzip` Cargo feature is enabled then gzip compression will be applied aut
 You can disable any compression through an [`OtlpTransportBuilder`]:
 
 ```
+# #[cfg(feature = "gzip")]
 # fn build() -> emit_otlp::OtlpBuilder {
 emit_otlp::new()
    .logs(emit_otlp::logs_proto(emit_otlp::http("http://localhost:4318/v1/logs")

--- a/macros/src/format.rs
+++ b/macros/src/format.rs
@@ -1,23 +1,8 @@
 use proc_macro2::TokenStream;
-use syn::{parse::Parse, spanned::Spanned, FieldValue};
-
-use crate::args;
+use syn::spanned::Spanned;
 
 pub struct ExpandTokens {
     pub input: TokenStream,
-}
-
-struct Args {}
-
-impl Parse for Args {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        args::set_from_field_values(
-            input.parse_terminated(FieldValue::parse, Token![,])?.iter(),
-            [],
-        )?;
-
-        Ok(Args {})
-    }
 }
 
 pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
@@ -30,7 +15,22 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
     }
     #[cfg(feature = "std")]
     {
-        use crate::{template, util::ToRefTokens};
+        use syn::{parse::Parse, FieldValue};
+
+        use crate::{args, template, util::ToRefTokens};
+
+        struct Args {}
+
+        impl Parse for Args {
+            fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+                args::set_from_field_values(
+                    input.parse_terminated(FieldValue::parse, Token![,])?.iter(),
+                    [],
+                )?;
+
+                Ok(Args {})
+            }
+        }
 
         let span = opts.input.span();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,22 +17,22 @@ version = "1.11.1"
 
 ```rust
 # mod emit_term { pub fn stdout() -> impl emit::Emitter { emit::emitter::from_fn(|_| {}) } }
-# #[cfg(not(feature = "std"))] fn main() {}
-# #[cfg(feature = "std")]
+# #[cfg(not(all(feature = "implicit_rt", feature = "std")))] fn main() {}
+# #[cfg(all(feature = "implicit_rt", feature = "std"))]
 fn main() {
     let rt = emit::setup()
         .emit_to(emit_term::stdout())
         .init();
 
+    #[emit::span("Greet {user}")]
+    fn greet(user: &str) {
+        emit::info!("Hello, {user}!");
+    }
+
     // Your app code goes here
     greet("Rust");
 
     rt.blocking_flush(std::time::Duration::from_secs(5));
-}
-
-#[emit::span("Greet {user}")]
-fn greet(user: &str) {
-    emit::info!("Hello, {user}!");
 }
 ```
 


### PR DESCRIPTION
Part of #278 

This PR adds a `FromProps` trait and a `Props::collect` method that can be used to construct common collection types from a given `impl Props`. It aims to avoid the de-duplication footgun of manually constructing collections from `Props` and taking the last value for a key instead of the first.

I've opted to make this `FromProps` trait infallible instead of fallible or optional. That means the bounds used for values are `From<Value<'kv>>` instead of `FromValue`, and the trait returns `Self` instead of `Option<Self>`. That seemed like a better formulation than needing to figure out whether a failed conversion should be discarded, added to the collection as `None`, or cause the whole conversion to fail.

I've added a new `OwnedProps` type that collects any `P: Props` into an owned representation that preserves iteration order while deduplicating and making key lookup cheap.

Finally, there's a new `Event::to_owned` method to convert an `Event<'a, P>` into an `Event<'static, OwnedProps>`, which you can stash and share across threads.