### PR TITLE
Note that emit's metrics model is for samples, not meters

### DIFF
--- a/book/src/producing-events/metrics.md
+++ b/book/src/producing-events/metrics.md
@@ -1,6 +1,21 @@
 # Metrics
 
-Metrics are an effective approach to monitoring applications at scale. They can be cheap to collect, making them suitable for performance sensitive operations. They can also be compact to report, making them suitable for high-volume scenarios. `emit` doesn't provide much infrastructure for collecting or sampling metrics. What it does provide is a standard way to report metric samples as events.
+Metrics are an effective approach to monitoring applications at scale. They can be cheap to collect, making them suitable for performance sensitive operations. They can also be compact to report, making them suitable for high-volume scenarios.
+
+`emit` doesn't provide its own definitions of _meters_ or _instruments_, types like gauges and counters that you can set or increment. The way you track metrics in your application will depend on what kind of application it is, so it's up to you to decide how you want to do this.
+
+What `emit` does provide is a standard way to report metric samples you collect as events through its runtime:
+
+```mermaid
+flowchart
+    meter["`**meter/instrument**
+    _Gauges, counters, etc defined by your application_`"] -- sample --> emit
+    emit["`**emit event**
+    _Regular emit events using well-known properties to signal them as metric samples_
+    `"]
+```
+
+Emitters that are metric-aware, like [`emit_otlp`](../emitting-events/otlp.md), can then handle those samples differently from regular events.
 
 A standard kind of metric is a monotonic counter, which can be represented as an atomic integer. In this example, our counter is for the number of bytes written to a file, which we'll call `bytes_written`. We can report a sample of this counter as an event using some [well-known properties](./metrics/data-model.md):
 

--- a/book/src/producing-events/tracing.md
+++ b/book/src/producing-events/tracing.md
@@ -33,7 +33,7 @@ Event {
 }
 ```
 
-When the annotated function returns, a span event for its execution is emitted. The extent of a span event is a range, where the start is the time the function began executing, and the end is the time the function returned.
+When the annotated function returns, a span event for its execution is emitted. The extent of a span event is a range, where the start is the time the function began executing, and the end is the time the function returned. Emitters that are trace-aware, like [`emit_otlp`](../emitting-events/otlp.md), can then handle those spans differently from regular events.
 
 Asynchronous functions are also supported:
 


### PR DESCRIPTION
This PR just adds some more details to `emit`'s metrics model to note that it doesn't define instruments like counters or gauges for you. It's instead focused on how to represent samples taken from those types you define or pull in from elsewhere.