### PR TITLE
Add some tests for picking aggregation temporality

### DIFF
--- a/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_display_interpolated.stderr
@@ -2,8 +2,13 @@ error[E0277]: capturing requires `NotDisplay` implements `Display + Any` by defa
  --> src/compile_fail/std/emit_props_non_display_interpolated.rs:4:28
   |
 4 |     emit::emit!("template {x}");
-  |                            ^ the trait `std::fmt::Display` is not implemented for `NotDisplay`
+  |                            ^ unsatisfied trait bound
   |
+help: the trait `std::fmt::Display` is not implemented for `NotDisplay`
+ --> src/compile_fail/std/emit_props_non_display_interpolated.rs:7:1
+  |
+7 | struct NotDisplay;
+  | ^^^^^^^^^^^^^^^^^
   = help: the trait `CaptureWithDefault` is implemented for `str`
   = note: required for `NotDisplay` to implement `CaptureWithDefault`
 note: required by a bound in `__private_capture_as_default`


### PR DESCRIPTION
This PR just sanity checks we map `emit`'s metric types to the right aggregation temporality in `emit_otlp`, and stops using the _histogram_ terminology to refer to timeseries metrics.