### PR TITLE
Support exponential histograms in `emit_core` and `emit`

### DIFF
--- a/core/src/well_known.rs
+++ b/core/src/well_known.rs
@@ -37,6 +37,15 @@ Extensions to the data model are signaled by the well-known [`KEY_EVT_KIND`] pro
         - [`METRIC_AGG_LAST`]: The sample is the last or most recent value.
     - [`KEY_METRIC_VALUE`]: The sample itself.
     - [`KEY_METRIC_UNIT`]: The measurement unit the sample is in.
+    - [`KEY_METRIC_DESCRIPTION`]: A description of the underlying data source.
+    - [`KEY_DIST_BUCKET_MIDPOINTS`]: The midpoint values of buckets in a distribution.
+    - [`KEY_DIST_BUCKET_COUNTS`]: The count of values in a bucket in a distribution.
+    - [`KEY_DIST_BUCKET_SCALE`]: The scale of buckets in a distribution.
+    - [`KEY_DIST_COUNT`]: The count of values in a distribution.
+    - [`KEY_DIST_SUM`]: The sum of values in a distribution.
+    - [`KEY_DIST_MIN`]: The minimum value in a distribution.
+    - [`KEY_DIST_MAX`]: The maximum value in a distribution.
+    - [`KEY_DIST_LAST`]: The last value in a distribution.
 */
 
 // Event
@@ -107,6 +116,25 @@ pub const KEY_METRIC_AGG: &'static str = "metric_agg";
 pub const KEY_METRIC_VALUE: &'static str = "metric_value";
 /** The measurement unit the sample is in. */
 pub const KEY_METRIC_UNIT: &'static str = "metric_unit";
+/** A description of the underlying data source. */
+pub const KEY_METRIC_DESCRIPTION: &'static str = "metric_description";
+
+/** The midpoint values of buckets in a distribution. */
+pub const KEY_DIST_BUCKET_MIDPOINTS: &'static str = "dist_bucket_midpoints";
+/** The count of values in a bucket in a distribution. */
+pub const KEY_DIST_BUCKET_COUNTS: &'static str = "dist_bucket_counts";
+/** The scale of buckets in a distribution. */
+pub const KEY_DIST_BUCKET_SCALE: &'static str = "dist_bucket_scale";
+/** The count of values in a distribution. */
+pub const KEY_DIST_COUNT: &'static str = "dist_count";
+/** The sum of values in a distribution. */
+pub const KEY_DIST_SUM: &'static str = "dist_sum";
+/** The minimum value in a distribution. */
+pub const KEY_DIST_MIN: &'static str = "dist_min";
+/** The maximum value in a distribution. */
+pub const KEY_DIST_MAX: &'static str = "dist_max";
+/** The last value in a distribution. */
+pub const KEY_DIST_LAST: &'static str = "dist_last";
 
 /** The sample is the possibly non-monotonic sum of values. */
 pub const METRIC_AGG_SUM: &'static str = "sum";

--- a/emitter/otlp/src/data/metrics.rs
+++ b/emitter/otlp/src/data/metrics.rs
@@ -438,7 +438,10 @@ mod tests {
                 match de.data {
                     Some(metrics::metric::Data::Sum(sum)) => {
                         assert!(sum.is_monotonic);
-                        assert_eq!(AggregationTemporality::Unspecified as i32, sum.aggregation_temporality);
+                        assert_eq!(
+                            AggregationTemporality::Unspecified as i32,
+                            sum.aggregation_temporality
+                        );
 
                         assert_eq!(Some(int_point(43)), sum.data_points[0].value);
                     }
@@ -531,7 +534,10 @@ mod tests {
 
                 match de.data {
                     Some(metrics::metric::Data::Sum(sum)) => {
-                        assert_eq!(AggregationTemporality::Cumulative as i32, sum.aggregation_temporality);
+                        assert_eq!(
+                            AggregationTemporality::Cumulative as i32,
+                            sum.aggregation_temporality
+                        );
                     }
                     other => panic!("unexpected {other:?}"),
                 }
@@ -555,7 +561,10 @@ mod tests {
 
                 match de.data {
                     Some(metrics::metric::Data::Sum(sum)) => {
-                        assert_eq!(AggregationTemporality::Delta as i32, sum.aggregation_temporality);
+                        assert_eq!(
+                            AggregationTemporality::Delta as i32,
+                            sum.aggregation_temporality
+                        );
                     }
                     other => panic!("unexpected {other:?}"),
                 }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1249,8 +1249,7 @@ pub mod dist {
     The implementation here uses a portable implementation of `powf` and `log` that is consistent across platforms.
     You may also consider using a native port of it for performance reasons.
     */
-    // TODO: Mark as `const` once `1.90.0` stabilizes
-    pub fn bucket_midpoint(value: f64, scale: i32) -> f64 {
+    pub const fn bucket_midpoint(value: f64, scale: i32) -> f64 {
         let sign = if value == 0.0 || value.is_sign_positive() {
             1.0
         } else {
@@ -1259,7 +1258,7 @@ pub mod dist {
         let value = value.abs();
 
         let gamma = libm::pow(2.0, libm::pow(2.0, -(scale as f64)));
-        let index = libm::log(value, gamma).ceil();
+        let index = libm::ceil(libm::log(value, gamma));
 
         let lower = libm::pow(gamma, index - 1.0);
         let upper = lower * gamma;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1312,7 +1312,7 @@ pub mod dist {
     Convert an error parameter `e` into a scale `s`.
     */
     pub const fn error_to_scale(e: f64) -> f64 {
-        libm::log2(libm::log2(-((1.0 + e) / (1.0 - e)))).floor()
+        (-libm::log2(libm::log2((1.0 + e) / (1.0 - e)))).round()
     }
 
     /**
@@ -1328,21 +1328,24 @@ pub mod dist {
 
         #[test]
         fn errors() {
-            let errors = [
-                scale_to_error(0.0),
-                scale_to_error(1.0),
-                scale_to_error(2.0),
-                scale_to_error(3.0),
-                scale_to_error(4.0),
-                scale_to_error(5.0),
-                scale_to_error(6.0),
-                scale_to_error(7.0),
-                scale_to_error(8.0),
-                scale_to_error(9.0),
-                scale_to_error(10.0),
-            ];
+            for (scale, error) in [
+                (1.0, 0.17157287525380996),
+                (2.0, 0.08642723372588978),
+                (3.0, 0.04329461749938919),
+                (4.0, 0.02165746232622625),
+                (5.0, 0.010830001253373618),
+                (6.0, 0.005415159415902577),
+                (7.0, 0.002707599557476281),
+                (8.0, 0.0013538022599560973),
+                (9.0, 0.0006769014401311412),
+                (10.0, 0.00033845075883475454),
+            ] {
+                let actual_error = scale_to_error(scale);
+                assert_eq!(error, actual_error, "scale: {scale}, error: {error}");
 
-            panic!("{errors:?}");
+                let actual_scale = error_to_scale(error);
+                assert_eq!(scale, actual_scale, "scale: {scale}, error: {error}");
+            }
         }
     }
 }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1249,7 +1249,8 @@ pub mod dist {
     The implementation here uses a portable implementation of `powf` and `log` that is consistent across platforms.
     You may also consider using a native port of it for performance reasons.
     */
-    pub const fn bucket_midpoint(value: f64, scale: i32) -> f64 {
+    // TODO: Mark as `const` once `1.90.0` stabilizes
+    pub fn bucket_midpoint(value: f64, scale: i32) -> f64 {
         let sign = if value == 0.0 || value.is_sign_positive() {
             1.0
         } else {

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1209,13 +1209,13 @@ pub mod sampler {
 
 pub mod dist {
     /*!
-    Functions to produce exponential buckets.
+    Functions for working with metric distributions.
     */
 
     use crate::platform::libm;
 
     /**
-    Compute the exponential bucket midpoint for the given value `v` and scale `s`.
+    Compute the exponential bucket midpoint for the given input value at a given scale.
 
     This function accepts the following parameters:
 
@@ -1223,11 +1223,10 @@ pub mod dist {
     - `scale`: The size of exponential buckets. Larger scales produce larger numbers of smaller buckets.
 
     This function can be used to compress an input data stream by feeding it input values and tracking the counts of resulting buckets.
-    Larger buckets count more unique input values in fewer unique bucket values, and so are more compressed but less accurate.
     The choice of `scale` is a trade-off between size and accuracy.
+    Larger buckets (smaller scales) count more unique input values in fewer unique bucket values, and resulting in higher compression but lower accuracy.
 
-    This function uses the same `scale` as OpenTelemetry's metrics, but returns the midpoint of the bucket instead of its index.
-    The index can still be computed from the midpoint if needed.
+    This function uses the same `scale` as OpenTelemetry's metrics data model, but returns the midpoint of the bucket a value belongs to instead of its index.
 
     ## Algorithm
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1372,6 +1372,10 @@ pub mod dist {
                 for (case, expected) in cases.iter().copied().zip(expected.iter().copied()) {
                     let actual = bucket_midpoint(case, scale);
 
+                    if expected.is_nan() && actual.is_nan() {
+                        continue;
+                    }
+
                     assert_eq!(expected.to_bits(), actual.to_bits(), "expected bucket_midpoint({case}, {scale}) to be {expected}, but got {actual}");
                 }
             }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -166,3 +166,5 @@ The default [`crate::Rng`].
     target_os = "unknown"
 ))]
 pub type DefaultRng = web::crypto_rng::CryptoRng;
+
+pub(crate) mod libm;

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -64,7 +64,7 @@ mod scalbn {
     > If the calculation does not overflow or underflow, the returned value is exact and
     > independent of the current rounding direction mode.
     */
-    pub const fn scalbn(mut x: f64, mut n: i32) -> f64 {
+    pub fn scalbn(mut x: f64, mut n: i32) -> f64 {
         let zero = 0;
 
         // Bits including the implicit bit
@@ -232,7 +232,7 @@ mod sqrt {
     computed at the same time, i.e. there is no need to calculate `1/sqrt(x)` and invert it.
     */
     #[inline]
-    pub const fn sqrt(x: f64) -> f64 {
+    pub fn sqrt(x: f64) -> f64 {
         let mut ix = x.to_bits();
 
         // Top is the exponent and sign, which may or may not be shifted. If the float fits into a
@@ -344,16 +344,16 @@ mod sqrt {
         y
     }
 
-    const fn wmulh_u32(a: u32, b: u32) -> u32 {
+    fn wmulh_u32(a: u32, b: u32) -> u32 {
         (((a as u64).wrapping_mul(b as u64)) >> 32) as u32
     }
 
-    const fn wmulh_u64(a: u64, b: u64) -> u64 {
+    fn wmulh_u64(a: u64, b: u64) -> u64 {
         (((a as u128).wrapping_mul(b as u128)) >> 64) as u64
     }
 
     #[inline]
-    const fn goldschmidt_r2(mut r_u0: u32, mut s_u2: u32, count: u32) -> (u32, u32) {
+    fn goldschmidt_r2(mut r_u0: u32, mut s_u2: u32, count: u32) -> (u32, u32) {
         let three_u2 = (0b11u32) << (u32::BITS - 2);
         let mut u_u0 = r_u0;
 
@@ -389,7 +389,7 @@ mod sqrt {
     }
 
     #[inline]
-    const fn goldschmidt_final(mut r_u0: u64, mut s_u2: u64, count: u32) -> (u64, u64) {
+    fn goldschmidt_final(mut r_u0: u64, mut s_u2: u64, count: u32) -> (u64, u64) {
         let three_u2 = (0b11u64) << (u64::BITS - 2);
         let mut u_u0 = r_u0;
 
@@ -595,7 +595,7 @@ mod pow {
     compiler will convert from decimal to binary accurately enough
     to produce the hexadecimal values shown.
     */
-    pub const fn pow(x: f64, y: f64) -> f64 {
+    pub fn pow(x: f64, y: f64) -> f64 {
         let t1: f64;
         let t2: f64;
 
@@ -1167,7 +1167,7 @@ mod log {
     as in log.c, then combine and scale in extra precision:
        `log2(x) = (f - f*f/2 + r)/log(2) + k`
     */
-    pub const fn log2(mut x: f64) -> f64 {
+    pub fn log2(mut x: f64) -> f64 {
         let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
         let mut ui: u64 = x.to_bits();
@@ -1245,7 +1245,7 @@ mod log {
     /**
     Compute the base `b` logarithm of `v`.
     */
-    pub const fn log(v: f64, b: f64) -> f64 {
+    pub fn log(v: f64, b: f64) -> f64 {
         log2(v) / log2(b)
     }
 
@@ -1318,10 +1318,10 @@ pub use self::log::*;
 
 #[inline(never)]
 #[cold]
-const fn cold_path() {}
+fn cold_path() {}
 
 #[inline]
-const fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
+fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
     let sign = if negative { 1u64 } else { 0 };
     f64::from_bits(
         (sign << (BITS - 1))
@@ -1331,12 +1331,12 @@ const fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
 }
 
 #[inline]
-const fn get_high_word(x: f64) -> u32 {
+fn get_high_word(x: f64) -> u32 {
     (x.to_bits() >> 32) as u32
 }
 
 #[inline]
-const fn with_set_high_word(f: f64, hi: u32) -> f64 {
+fn with_set_high_word(f: f64, hi: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0x00000000_ffffffff;
     tmp |= (hi as u64) << 32;
@@ -1344,7 +1344,7 @@ const fn with_set_high_word(f: f64, hi: u32) -> f64 {
 }
 
 #[inline]
-const fn with_set_low_word(f: f64, lo: u32) -> f64 {
+fn with_set_low_word(f: f64, lo: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0xffffffff_00000000;
     tmp |= lo as u64;
@@ -1352,6 +1352,6 @@ const fn with_set_low_word(f: f64, lo: u32) -> f64 {
 }
 
 #[inline]
-const fn ex(v: f64) -> u32 {
+fn ex(v: f64) -> u32 {
     ((v.to_bits() >> SIG_BITS) as u32) & EXP_SAT
 }

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -1,3 +1,30 @@
+/*
+This file comes from rust-lang/libm, including the functionality needed for exponential bucketing
+in `const` functions. It includes the following license:
+
+rust-lang/libm as a whole is available for use under the MIT license:
+
+------------------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+*/
+
 const BITS: u32 = 64;
 const SIG_BITS: u32 = 52;
 const EXP_BITS: u32 = BITS - SIG_BITS - 1;

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -1300,6 +1300,10 @@ mod log {
             {
                 let actual = log(case, base);
 
+                if expected.is_nan() && actual.is_nan() {
+                    continue;
+                }
+
                 assert_eq!(
                     expected.to_bits(),
                     actual.to_bits(),

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -985,10 +985,6 @@ mod pow {
                     let exp = expected(*val);
                     let res = computed(*val);
 
-                    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
-                    let exp = force_eval!(exp);
-                    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
-                    let res = force_eval!(res);
                     assert!(
                         if exp.is_nan() {
                             res.is_nan()

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -1,0 +1,944 @@
+const BITS: u32 = 64;
+const SIG_BITS: u32 = 52;
+const EXP_BITS: u32 = BITS - SIG_BITS - 1;
+const EXP_SAT: u32 = (1 << EXP_BITS) - 1;
+const EXP_BIAS: u32 = EXP_SAT >> 1;
+const EXP_MAX: i32 = EXP_BIAS as i32;
+const EXP_MIN: i32 = -(EXP_MAX - 1);
+const IMPLICIT_BIT: u64 = 1 << SIG_BITS;
+const SIGN_MASK: u64 = 1 << (BITS - 1);
+const SIG_MASK: u64 = (1 << SIG_BITS) - 1;
+const EXP_MASK: u64 = !(SIGN_MASK | SIG_MASK);
+
+#[inline(never)]
+#[cold]
+const fn cold_path() {}
+
+#[inline]
+const fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
+    let sign = if negative { 1u64 } else { 0 };
+    f64::from_bits(
+        (sign << (BITS - 1))
+            | (((exponent & EXP_SAT) as u64) << SIG_BITS)
+            | (significand & SIG_MASK),
+    )
+}
+
+#[inline]
+const fn get_high_word(x: f64) -> u32 {
+    (x.to_bits() >> 32) as u32
+}
+
+#[inline]
+const fn get_low_word(x: f64) -> u32 {
+    x.to_bits() as u32
+}
+
+#[inline]
+const fn with_set_high_word(f: f64, hi: u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0x00000000_ffffffff;
+    tmp |= (hi as u64) << 32;
+    f64::from_bits(tmp)
+}
+
+#[inline]
+const fn with_set_low_word(f: f64, lo: u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0xffffffff_00000000;
+    tmp |= lo as u64;
+    f64::from_bits(tmp)
+}
+
+const fn scalbn(mut x: f64, mut n: i32) -> f64 {
+    let zero = 0;
+
+    // Bits including the implicit bit
+    let sig_total_bits = SIG_BITS + 1;
+
+    // Maximum and minimum values when biased
+    let exp_max = EXP_MAX;
+    let exp_min = EXP_MIN;
+
+    // 2 ^ Emax, maximum positive with null significand (0x1p1023 for f64)
+    let f_exp_max = from_parts(false, EXP_BIAS << 1, zero);
+
+    // 2 ^ Emin, minimum positive normal with null significand (0x1p-1022 for f64)
+    let f_exp_min = from_parts(false, 1, zero);
+
+    // 2 ^ sig_total_bits, moltiplier to normalize subnormals (0x1p53 for f64)
+    let f_pow_subnorm = from_parts(false, sig_total_bits + EXP_BIAS, zero);
+
+    /*
+     * The goal is to multiply `x` by a scale factor that applies `n`. However, there are cases
+     * where `2^n` is not representable by `F` but the result should be, e.g. `x = 2^Emin` with
+     * `n = -EMin + 2` (one out of range of 2^Emax). To get around this, reduce the magnitude of
+     * the final scale operation by prescaling by the max/min power representable by `F`.
+     */
+
+    if n > exp_max {
+        // Worse case positive `n`: `x`  is the minimum subnormal value, the result is `MAX`.
+        // This can be reached by three scaling multiplications (two here and one final).
+        debug_assert!(-exp_min + SIG_BITS as i32 + exp_max <= exp_max * 3);
+
+        x *= f_exp_max;
+        n -= exp_max;
+        if n > exp_max {
+            x *= f_exp_max;
+            n -= exp_max;
+            if n > exp_max {
+                n = exp_max;
+            }
+        }
+    } else if n < exp_min {
+        // `mul` s.t. `!(x * mul).is_subnormal() ∀ x`
+        let mul = f_exp_min * f_pow_subnorm;
+        let add = -exp_min - sig_total_bits as i32;
+
+        // Worse case negative `n`: `x`  is the maximum positive value, the result is `MIN`.
+        // This must be reachable by three scaling multiplications (two here and one final).
+        debug_assert!(-exp_min + SIG_BITS as i32 + exp_max <= add * 2 + -exp_min);
+
+        x *= mul;
+        n += add;
+
+        if n < exp_min {
+            x *= mul;
+            n += add;
+
+            if n < exp_min {
+                n = exp_min;
+            }
+        }
+    }
+
+    let scale = from_parts(false, (EXP_BIAS as i32 + n) as u32, zero);
+    x * scale
+}
+
+const fn ex(v: f64) -> u32 {
+    ((v.to_bits() >> SIG_BITS) as u32) & EXP_SAT
+}
+
+pub mod sqrt {
+    /* SPDX-License-Identifier: MIT */
+    /* origin: musl src/math/sqrt.c. Ported to generic Rust algorithm in 2025, TG. */
+
+    //! Generic square root algorithm.
+    //!
+    //! This routine operates around `m_u2`, a U.2 (fixed point with two integral bits) mantissa
+    //! within the range [1, 4). A table lookup provides an initial estimate, then goldschmidt
+    //! iterations at various widths are used to approach the real values.
+    //!
+    //! For the iterations, `r` is a U0 number that approaches `1/sqrt(m_u2)`, and `s` is a U2 number
+    //! that approaches `sqrt(m_u2)`. Recall that m_u2 ∈ [1, 4).
+    //!
+    //! With Newton-Raphson iterations, this would be:
+    //!
+    //! - `w = r * r           w ~ 1 / m`
+    //! - `u = 3 - m * w       u ~ 3 - m * w = 3 - m / m = 2`
+    //! - `r = r * u / 2       r ~ r`
+    //!
+    //! (Note that the righthand column does not show anything analytically meaningful (i.e. r ~ r),
+    //! since the value of performing one iteration is in reducing the error representable by `~`).
+    //!
+    //! Instead of Newton-Raphson iterations, Goldschmidt iterations are used to calculate
+    //! `s = m * r`:
+    //!
+    //! - `s = m * r           s ~ m / sqrt(m)`
+    //! - `u = 3 - s * r       u ~ 3 - (m / sqrt(m)) * (1 / sqrt(m)) = 3 - m / m = 2`
+    //! - `r = r * u / 2       r ~ r`
+    //! - `s = s * u / 2       s ~ s`
+    //!
+    //! The above is precise because it uses the original value `m`. There is also a faster version
+    //! that performs fewer steps but does not use `m`:
+    //!
+    //! - `u = 3 - s * r       u ~ 3 - 1`
+    //! - `r = r * u / 2       r ~ r`
+    //! - `s = s * u / 2       s ~ s`
+    //!
+    //! Rounding errors accumulate faster with the second version, so it is only used for subsequent
+    //! iterations within the same width integer. The first version is always used for the first
+    //! iteration at a new width in order to avoid this accumulation.
+    //!
+    //! Goldschmidt has the advantage over Newton-Raphson that `sqrt(x)` and `1/sqrt(x)` are
+    //! computed at the same time, i.e. there is no need to calculate `1/sqrt(x)` and invert it.
+
+    use super::*;
+
+    #[inline]
+    pub const fn sqrt(x: f64) -> f64 {
+        let zero = 0;
+        let one = 1;
+
+        let mut ix = x.to_bits();
+
+        // Top is the exponent and sign, which may or may not be shifted. If the float fits into a
+        // `u32`, we can get by without paying shifting costs.
+        let mut top = (ix >> SIG_BITS) as u32;
+        let special_case = top.wrapping_sub(1) >= EXP_SAT - 1;
+
+        // Handle NaN, zero, and out of domain (<= 0)
+        if special_case {
+            cold_path();
+
+            // +/-0
+            if ix << 1 == zero {
+                return x;
+            }
+
+            // Positive infinity
+            if ix == EXP_MASK {
+                return x;
+            }
+
+            // NaN or negative
+            if ix > EXP_MASK {
+                return f64::NAN;
+            }
+
+            // Normalize subnormals by multiplying by 1.0 << SIG_BITS (e.g. 0x1p52 for doubles).
+            let scaled = x * from_parts(false, SIG_BITS + EXP_BIAS, zero);
+            ix = scaled.to_bits();
+            top = ex(scaled).wrapping_sub(SIG_BITS);
+        }
+
+        // Reduce arguments such that `x = 4^e * m`:
+        //
+        // - m_u2 ∈ [1, 4), a fixed point U2.BITS number
+        // - 2^e is the exponent part of the result
+        // We now know `x` is positive, so `top` is just its (biased) exponent
+        let mut exp = top;
+        // Construct a fixed point representation of the mantissa.
+        let mut m_u2 = (ix | IMPLICIT_BIT) << EXP_BITS;
+        let even = (exp & 1) != 0;
+        if even {
+            m_u2 >>= 1;
+        }
+        exp = (exp.wrapping_add(EXP_SAT >> 1)) >> 1;
+
+        // Extract the top 6 bits of the significand with the lowest bit of the exponent.
+        let i = ((ix >> (SIG_BITS - 6)) as usize) & 0b1111111;
+
+        // Start with an initial guess for `r = 1 / sqrt(m)` from the table, and shift `m` as an
+        // initial value for `s = sqrt(m)`. See the module documentation for details.
+        let r1_u0: u32 = (RSQRT_TAB[i] as u32) << (u32::BITS - 16);
+        let s1_u2: u32 = ((m_u2) >> (BITS - u32::BITS)) as u32;
+
+        // Perform iterations, if any, at quarter width (used for `f128`).
+        let (r1_u0, _s1_u2) = goldschmidt_r1(r1_u0, s1_u2, 2);
+
+        // Widen values and perform iterations at half width (used for `f64` and `f128`).
+        let r2_u0: u32 = (r1_u0 as u32) << (u32::BITS - u32::BITS);
+        let s2_u2: u32 = ((m_u2) >> (BITS - u32::BITS)) as u32;
+        let (r2_u0, _s2_u2) = goldschmidt_r2(r2_u0, s2_u2, 2);
+
+        // Perform final iterations at full width (used for all float types).
+        let r_u0: u64 = (r2_u0 as u64) << (BITS - u32::BITS);
+        let s_u2: u64 = m_u2;
+        let (_r_u0, s_u2) = goldschmidt_final(r_u0, s_u2, 2);
+
+        // Shift back to mantissa position.
+        let mut m = s_u2 >> (EXP_BITS - 2);
+
+        // The musl source includes the following comment (with literals replaced):
+        //
+        // > s < sqrt(m) < s + 0x1.09p-SIG_BITS
+        // > compute nearest rounded result: the nearest result to SIG_BITS bits is either s or
+        // > s+0x1p-SIG_BITS, we can decide by comparing (2^SIG_BITS s + 0.5)^2 to 2^(2*SIG_BITS) m.
+        //
+        // Expanding this with , with `SIG_BITS = p` and adjusting based on the operations done to
+        // `d0` and `d1`:
+        //
+        // - `2^(2p)m ≟ ((2^p)m + 0.5)^2`
+        // - `2^(2p)m ≟ 2^(2p)m^2 + (2^p)m + 0.25`
+        // - `2^(2p)m - m^2 ≟ (2^(2p) - 1)m^2 + (2^p)m + 0.25`
+        // - `(1 - 2^(2p))m + m^2 ≟ (1 - 2^(2p))m^2 + (1 - 2^p)m + 0.25` (?)
+        //
+        // I do not follow how the rounding bit is extracted from this comparison with the below
+        // operations. In any case, the algorithm is well tested.
+
+        // The value needed to shift `m_u2` by to create `m*2^(2p)`. `2p = 2 * SIG_BITS`,
+        // `BITS - 2` accounts for the offset that `m_u2` already has.
+        let shift = 2 * SIG_BITS - (BITS - 2);
+
+        // `2^(2p)m - m^2`
+        let d0 = (m_u2 << shift).wrapping_sub(m.wrapping_mul(m));
+        // `m - 2^(2p)m + m^2`
+        let d1 = m.wrapping_sub(d0);
+        m += d1 >> (BITS - 1);
+        m &= SIG_MASK;
+        m |= (exp as u64) << SIG_BITS;
+
+        let mut y = f64::from_bits(m);
+
+        // FIXME(f16): the fenv math does not work for `f16`
+        if BITS > 16 {
+            // Handle rounding and inexact. `(m + 1)^2 == 2^shift m` is exact; for all other cases, add
+            // a tiny value to cause fenv effects.
+            let d2 = d1.wrapping_add(m).wrapping_add(one);
+            let mut tiny = if d2 == zero {
+                cold_path();
+                zero
+            } else {
+                IMPLICIT_BIT
+            };
+
+            tiny |= (d1 ^ d2) & SIGN_MASK;
+            let t = f64::from_bits(tiny);
+            y = y + t;
+        }
+
+        y
+    }
+
+    const fn wmulh_u32(a: u32, b: u32) -> u32 {
+        (((a as u64).wrapping_mul(b as u64)) >> 32) as u32
+    }
+
+    const fn wmulh_u64(a: u64, b: u64) -> u64 {
+        (((a as u128).wrapping_mul(b as u128)) >> 64) as u64
+    }
+
+    #[inline]
+    const fn goldschmidt_r1(r_u0: u32, s_u2: u32, count: u32) -> (u32, u32) {
+        let _ = count;
+        (r_u0, s_u2)
+    }
+
+    #[inline]
+    const fn goldschmidt_r2(mut r_u0: u32, mut s_u2: u32, count: u32) -> (u32, u32) {
+        let three_u2 = (0b11u8 as u32) << (u32::BITS - 2);
+        let mut u_u0 = r_u0;
+
+        let mut i = 0;
+        while i < count {
+            // First iteration: `s = m*r` (`u_u0 = r_u0` set above)
+            // Subsequent iterations: `s=s*u/2`
+            s_u2 = wmulh_u32(s_u2, u_u0);
+
+            // Perform `s /= 2` if:
+            //
+            // 1. This is not the first iteration (the first iteration is `s = m*r`)...
+            // 2. ... and this is not the last set of iterations
+            // 3. ... or, if this is the last set, it is not the last iteration
+            //
+            // This step is not performed for the final iteration because the shift is combined with
+            // a later shift (moving `s` into the mantissa).
+            if i > 0 {
+                s_u2 <<= 1;
+            }
+
+            // u = 3 - s*r
+            let d_u2 = wmulh_u32(s_u2, r_u0);
+            u_u0 = three_u2.wrapping_sub(d_u2);
+
+            // r = r*u/2
+            r_u0 = wmulh_u32(r_u0, u_u0) << 1;
+
+            i += 1;
+        }
+
+        (r_u0, s_u2)
+    }
+
+    /// Perform `count` goldschmidt iterations, returning `(r_u0, s_u?)`.
+    ///
+    /// - `r_u0` is the reciprocal `r ~ 1 / sqrt(m)`, as U0.
+    /// - `s_u2` is the square root, `s ~ sqrt(m)`, as U2.
+    /// - `count` is the number of iterations to perform.
+    /// - `final_set` should be true if this is the last round (same-sized integer). If so, the
+    ///   returned `s` will be U3, for later shifting. Otherwise, the returned `s` is U2.
+    ///
+    /// Note that performance relies on the optimizer being able to unroll these loops (reasonably
+    /// trivial, `count` is a constant when called).
+    #[inline]
+    const fn goldschmidt_final(mut r_u0: u64, mut s_u2: u64, count: u32) -> (u64, u64) {
+        let three_u2 = (0b11u8 as u64) << (u64::BITS - 2);
+        let mut u_u0 = r_u0;
+
+        let mut i = 0;
+        while i < count {
+            // First iteration: `s = m*r` (`u_u0 = r_u0` set above)
+            // Subsequent iterations: `s=s*u/2`
+            s_u2 = wmulh_u64(s_u2, u_u0);
+
+            // Perform `s /= 2` if:
+            //
+            // 1. This is not the first iteration (the first iteration is `s = m*r`)...
+            // 2. ... and this is not the last set of iterations
+            // 3. ... or, if this is the last set, it is not the last iteration
+            //
+            // This step is not performed for the final iteration because the shift is combined with
+            // a later shift (moving `s` into the mantissa).
+            if i > 0 && i + 1 < count {
+                s_u2 <<= 1;
+            }
+
+            // u = 3 - s*r
+            let d_u2 = wmulh_u64(s_u2, r_u0);
+            u_u0 = three_u2.wrapping_sub(d_u2);
+
+            // r = r*u/2
+            r_u0 = wmulh_u64(r_u0, u_u0) << 1;
+
+            i += 1;
+        }
+
+        (r_u0, s_u2)
+    }
+
+    /// A U0.16 representation of `1/sqrt(x)`.
+    ///
+    /// The index is a 7-bit number consisting of a single exponent bit and 6 bits of significand.
+    #[rustfmt::skip]
+    static RSQRT_TAB: [u16; 128] = [
+        0xb451, 0xb2f0, 0xb196, 0xb044, 0xaef9, 0xadb6, 0xac79, 0xab43,
+        0xaa14, 0xa8eb, 0xa7c8, 0xa6aa, 0xa592, 0xa480, 0xa373, 0xa26b,
+        0xa168, 0xa06a, 0x9f70, 0x9e7b, 0x9d8a, 0x9c9d, 0x9bb5, 0x9ad1,
+        0x99f0, 0x9913, 0x983a, 0x9765, 0x9693, 0x95c4, 0x94f8, 0x9430,
+        0x936b, 0x92a9, 0x91ea, 0x912e, 0x9075, 0x8fbe, 0x8f0a, 0x8e59,
+        0x8daa, 0x8cfe, 0x8c54, 0x8bac, 0x8b07, 0x8a64, 0x89c4, 0x8925,
+        0x8889, 0x87ee, 0x8756, 0x86c0, 0x862b, 0x8599, 0x8508, 0x8479,
+        0x83ec, 0x8361, 0x82d8, 0x8250, 0x81c9, 0x8145, 0x80c2, 0x8040,
+        0xff02, 0xfd0e, 0xfb25, 0xf947, 0xf773, 0xf5aa, 0xf3ea, 0xf234,
+        0xf087, 0xeee3, 0xed47, 0xebb3, 0xea27, 0xe8a3, 0xe727, 0xe5b2,
+        0xe443, 0xe2dc, 0xe17a, 0xe020, 0xdecb, 0xdd7d, 0xdc34, 0xdaf1,
+        0xd9b3, 0xd87b, 0xd748, 0xd61a, 0xd4f1, 0xd3cd, 0xd2ad, 0xd192,
+        0xd07b, 0xcf69, 0xce5b, 0xcd51, 0xcc4a, 0xcb48, 0xca4a, 0xc94f,
+        0xc858, 0xc764, 0xc674, 0xc587, 0xc49d, 0xc3b7, 0xc2d4, 0xc1f4,
+        0xc116, 0xc03c, 0xbf65, 0xbe90, 0xbdbe, 0xbcef, 0xbc23, 0xbb59,
+        0xba91, 0xb9cc, 0xb90a, 0xb84a, 0xb78c, 0xb6d0, 0xb617, 0xb560,
+    ];
+}
+
+pub use self::sqrt::*;
+
+pub mod pow {
+    /* origin: FreeBSD /usr/src/lib/msun/src/e_pow.c */
+    /*
+     * ====================================================
+     * Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
+     *
+     * Permission to use, copy, modify, and distribute this
+     * software is freely granted, provided that this notice
+     * is preserved.
+     * ====================================================
+     */
+
+    // pow(x,y) return x**y
+    //
+    //                    n
+    // Method:  Let x =  2   * (1+f)
+    //      1. Compute and return log2(x) in two pieces:
+    //              log2(x) = w1 + w2,
+    //         where w1 has 53-24 = 29 bit trailing zeros.
+    //      2. Perform y*log2(x) = n+y' by simulating multi-precision
+    //         arithmetic, where |y'|<=0.5.
+    //      3. Return x**y = 2**n*exp(y'*log2)
+    //
+    // Special cases:
+    //      1.  (anything) ** 0  is 1
+    //      2.  1 ** (anything)  is 1
+    //      3.  (anything except 1) ** NAN is NAN
+    //      4.  NAN ** (anything except 0) is NAN
+    //      5.  +-(|x| > 1) **  +INF is +INF
+    //      6.  +-(|x| > 1) **  -INF is +0
+    //      7.  +-(|x| < 1) **  +INF is +0
+    //      8.  +-(|x| < 1) **  -INF is +INF
+    //      9.  -1          ** +-INF is 1
+    //      10. +0 ** (+anything except 0, NAN)               is +0
+    //      11. -0 ** (+anything except 0, NAN, odd integer)  is +0
+    //      12. +0 ** (-anything except 0, NAN)               is +INF, raise divbyzero
+    //      13. -0 ** (-anything except 0, NAN, odd integer)  is +INF, raise divbyzero
+    //      14. -0 ** (+odd integer) is -0
+    //      15. -0 ** (-odd integer) is -INF, raise divbyzero
+    //      16. +INF ** (+anything except 0,NAN) is +INF
+    //      17. +INF ** (-anything except 0,NAN) is +0
+    //      18. -INF ** (+odd integer) is -INF
+    //      19. -INF ** (anything) = -0 ** (-anything), (anything except odd integer)
+    //      20. (anything) ** 1 is (anything)
+    //      21. (anything) ** -1 is 1/(anything)
+    //      22. (-anything) ** (integer) is (-1)**(integer)*(+anything**integer)
+    //      23. (-anything except 0 and inf) ** (non-integer) is NAN
+    //
+    // Accuracy:
+    //      pow(x,y) returns x**y nearly rounded. In particular
+    //                      pow(integer,integer)
+    //      always returns the correct integer provided it is
+    //      representable.
+    //
+    // Constants :
+    // The hexadecimal values are the intended ones for the following
+    // constants. The decimal values may be used, provided that the
+    // compiler will convert from decimal to binary accurately enough
+    // to produce the hexadecimal values shown.
+    //
+    use super::*;
+
+    const BP: [f64; 2] = [1.0, 1.5];
+    const DP_H: [f64; 2] = [0.0, 5.84962487220764160156e-01]; /* 0x3fe2b803_40000000 */
+    const DP_L: [f64; 2] = [0.0, 1.35003920212974897128e-08]; /* 0x3E4CFDEB, 0x43CFD006 */
+    const TWO53: f64 = 9007199254740992.0; /* 0x43400000_00000000 */
+    const HUGE: f64 = 1.0e300;
+    const TINY: f64 = 1.0e-300;
+
+    // poly coefs for (3/2)*(log(x)-2s-2/3*s**3:
+    const L1: f64 = 5.99999999999994648725e-01; /* 0x3fe33333_33333303 */
+    const L2: f64 = 4.28571428578550184252e-01; /* 0x3fdb6db6_db6fabff */
+    const L3: f64 = 3.33333329818377432918e-01; /* 0x3fd55555_518f264d */
+    const L4: f64 = 2.72728123808534006489e-01; /* 0x3fd17460_a91d4101 */
+    const L5: f64 = 2.30660745775561754067e-01; /* 0x3fcd864a_93c9db65 */
+    const L6: f64 = 2.06975017800338417784e-01; /* 0x3fca7e28_4a454eef */
+    const P1: f64 = 1.66666666666666019037e-01; /* 0x3fc55555_5555553e */
+    const P2: f64 = -2.77777777770155933842e-03; /* 0xbf66c16c_16bebd93 */
+    const P3: f64 = 6.61375632143793436117e-05; /* 0x3f11566a_af25de2c */
+    const P4: f64 = -1.65339022054652515390e-06; /* 0xbebbbd41_c5d26bf1 */
+    const P5: f64 = 4.13813679705723846039e-08; /* 0x3e663769_72bea4d0 */
+    const LG2: f64 = 6.93147180559945286227e-01; /* 0x3fe62e42_fefa39ef */
+    const LG2_H: f64 = 6.93147182464599609375e-01; /* 0x3fe62e43_00000000 */
+    const LG2_L: f64 = -1.90465429995776804525e-09; /* 0xbe205c61_0ca86c39 */
+    const OVT: f64 = 8.0085662595372944372e-017; /* -(1024-log2(ovfl+.5ulp)) */
+    const CP: f64 = 9.61796693925975554329e-01; /* 0x3feec709_dc3a03fd =2/(3ln2) */
+    const CP_H: f64 = 9.61796700954437255859e-01; /* 0x3feec709_e0000000 =(float)cp */
+    const CP_L: f64 = -7.02846165095275826516e-09; /* 0xbe3e2fe0_145b01f5 =tail of cp_h*/
+    const IVLN2: f64 = 1.44269504088896338700e+00; /* 0x3ff71547_652b82fe =1/ln2 */
+    const IVLN2_H: f64 = 1.44269502162933349609e+00; /* 0x3ff71547_60000000 =24b 1/ln2*/
+    const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 tail*/
+
+    /// Returns `x` to the power of `y` (f64).
+    pub fn pow(x: f64, y: f64) -> f64 {
+        let t1: f64;
+        let t2: f64;
+
+        let (hx, lx): (i32, u32) = ((x.to_bits() >> 32) as i32, x.to_bits() as u32);
+        let (hy, ly): (i32, u32) = ((y.to_bits() >> 32) as i32, y.to_bits() as u32);
+
+        let mut ix: i32 = hx & 0x7fffffff_i32;
+        let iy: i32 = hy & 0x7fffffff_i32;
+
+        /* x**0 = 1, even if x is NaN */
+        if ((iy as u32) | ly) == 0 {
+            return 1.0;
+        }
+
+        /* 1**y = 1, even if y is NaN */
+        if hx == 0x3ff00000 && lx == 0 {
+            return 1.0;
+        }
+
+        /* NaN if either arg is NaN */
+        if ix > 0x7ff00000
+            || (ix == 0x7ff00000 && lx != 0)
+            || iy > 0x7ff00000
+            || (iy == 0x7ff00000 && ly != 0)
+        {
+            return x + y;
+        }
+
+        /* determine if y is an odd int when x < 0
+         * yisint = 0       ... y is not an integer
+         * yisint = 1       ... y is an odd int
+         * yisint = 2       ... y is an even int
+         */
+        let mut yisint: i32 = 0;
+        let mut k: i32;
+        let mut j: i32;
+        if hx < 0 {
+            if iy >= 0x43400000 {
+                yisint = 2; /* even integer y */
+            } else if iy >= 0x3ff00000 {
+                k = (iy >> 20) - 0x3ff; /* exponent */
+
+                if k > 20 {
+                    j = (ly >> (52 - k)) as i32;
+
+                    if (j << (52 - k)) == (ly as i32) {
+                        yisint = 2 - (j & 1);
+                    }
+                } else if ly == 0 {
+                    j = iy >> (20 - k);
+
+                    if (j << (20 - k)) == iy {
+                        yisint = 2 - (j & 1);
+                    }
+                }
+            }
+        }
+
+        if ly == 0 {
+            /* special value of y */
+            if iy == 0x7ff00000 {
+                /* y is +-inf */
+
+                return if ((ix - 0x3ff00000) | (lx as i32)) == 0 {
+                    /* (-1)**+-inf is 1 */
+                    1.0
+                } else if ix >= 0x3ff00000 {
+                    /* (|x|>1)**+-inf = inf,0 */
+                    if hy >= 0 {
+                        y
+                    } else {
+                        0.0
+                    }
+                } else {
+                    /* (|x|<1)**+-inf = 0,inf */
+                    if hy >= 0 {
+                        0.0
+                    } else {
+                        -y
+                    }
+                };
+            }
+
+            if iy == 0x3ff00000 {
+                /* y is +-1 */
+                return if hy >= 0 { x } else { 1.0 / x };
+            }
+
+            if hy == 0x40000000 {
+                /* y is 2 */
+                return x * x;
+            }
+
+            if hy == 0x3fe00000 {
+                /* y is 0.5 */
+                if hx >= 0 {
+                    /* x >= +0 */
+                    return sqrt(x);
+                }
+            }
+        }
+
+        let mut ax: f64 = x.abs();
+        if lx == 0 {
+            /* special value of x */
+            if ix == 0x7ff00000 || ix == 0 || ix == 0x3ff00000 {
+                /* x is +-0,+-inf,+-1 */
+                let mut z: f64 = ax;
+
+                if hy < 0 {
+                    /* z = (1/|x|) */
+                    z = 1.0 / z;
+                }
+
+                if hx < 0 {
+                    if ((ix - 0x3ff00000) | yisint) == 0 {
+                        z = (z - z) / (z - z); /* (-1)**non-int is NaN */
+                    } else if yisint == 1 {
+                        z = -z; /* (x<0)**odd = -(|x|**odd) */
+                    }
+                }
+
+                return z;
+            }
+        }
+
+        let mut s: f64 = 1.0; /* sign of result */
+        if hx < 0 {
+            if yisint == 0 {
+                /* (x<0)**(non-int) is NaN */
+                return (x - x) / (x - x);
+            }
+
+            if yisint == 1 {
+                /* (x<0)**(odd int) */
+                s = -1.0;
+            }
+        }
+
+        /* |y| is HUGE */
+        if iy > 0x41e00000 {
+            /* if |y| > 2**31 */
+            if iy > 0x43f00000 {
+                /* if |y| > 2**64, must o/uflow */
+                if ix <= 0x3fefffff {
+                    return if hy < 0 { HUGE * HUGE } else { TINY * TINY };
+                }
+
+                if ix >= 0x3ff00000 {
+                    return if hy > 0 { HUGE * HUGE } else { TINY * TINY };
+                }
+            }
+
+            /* over/underflow if x is not close to one */
+            if ix < 0x3fefffff {
+                return if hy < 0 {
+                    s * HUGE * HUGE
+                } else {
+                    s * TINY * TINY
+                };
+            }
+            if ix > 0x3ff00000 {
+                return if hy > 0 {
+                    s * HUGE * HUGE
+                } else {
+                    s * TINY * TINY
+                };
+            }
+
+            /* now |1-x| is TINY <= 2**-20, suffice to compute
+            log(x) by x-x^2/2+x^3/3-x^4/4 */
+            let t: f64 = ax - 1.0; /* t has 20 trailing zeros */
+            let w: f64 = (t * t) * (0.5 - t * (0.3333333333333333333333 - t * 0.25));
+            let u: f64 = IVLN2_H * t; /* ivln2_h has 21 sig. bits */
+            let v: f64 = t * IVLN2_L - w * IVLN2;
+            t1 = with_set_low_word(u + v, 0);
+            t2 = v - (t1 - u);
+        } else {
+            // double ss,s2,s_h,s_l,t_h,t_l;
+            let mut n: i32 = 0;
+
+            if ix < 0x00100000 {
+                /* take care subnormal number */
+                ax *= TWO53;
+                n -= 53;
+                ix = get_high_word(ax) as i32;
+            }
+
+            n += (ix >> 20) - 0x3ff;
+            j = ix & 0x000fffff;
+
+            /* determine interval */
+            let k: i32;
+            ix = j | 0x3ff00000; /* normalize ix */
+            if j <= 0x3988E {
+                /* |x|<sqrt(3/2) */
+                k = 0;
+            } else if j < 0xBB67A {
+                /* |x|<sqrt(3)   */
+                k = 1;
+            } else {
+                k = 0;
+                n += 1;
+                ix -= 0x00100000;
+            }
+            ax = with_set_high_word(ax, ix as u32);
+
+            /* compute ss = s_h+s_l = (x-1)/(x+1) or (x-1.5)/(x+1.5) */
+            let u: f64 = ax - BP[k as usize]; /* bp[0]=1.0, bp[1]=1.5 */
+            let v: f64 = 1.0 / (ax + BP[k as usize]);
+            let ss: f64 = u * v;
+            let s_h = with_set_low_word(ss, 0);
+
+            /* t_h=ax+bp[k] High */
+            let t_h: f64 = with_set_high_word(
+                0.0,
+                ((ix as u32 >> 1) | 0x20000000) + 0x00080000 + ((k as u32) << 18),
+            );
+            let t_l: f64 = ax - (t_h - BP[k as usize]);
+            let s_l: f64 = v * ((u - s_h * t_h) - s_h * t_l);
+
+            /* compute log(ax) */
+            let s2: f64 = ss * ss;
+            let mut r: f64 =
+                s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
+            r += s_l * (s_h + ss);
+            let s2: f64 = s_h * s_h;
+            let t_h: f64 = with_set_low_word(3.0 + s2 + r, 0);
+            let t_l: f64 = r - ((t_h - 3.0) - s2);
+
+            /* u+v = ss*(1+...) */
+            let u: f64 = s_h * t_h;
+            let v: f64 = s_l * t_h + t_l * ss;
+
+            /* 2/(3log2)*(ss+...) */
+            let p_h: f64 = with_set_low_word(u + v, 0);
+            let p_l = v - (p_h - u);
+            let z_h: f64 = CP_H * p_h; /* cp_h+cp_l = 2/(3*log2) */
+            let z_l: f64 = CP_L * p_h + p_l * CP + DP_L[k as usize];
+
+            /* log2(ax) = (ss+..)*2/(3*log2) = n + dp_h + z_h + z_l */
+            let t: f64 = n as f64;
+            t1 = with_set_low_word(((z_h + z_l) + DP_H[k as usize]) + t, 0);
+            t2 = z_l - (((t1 - t) - DP_H[k as usize]) - z_h);
+        }
+
+        /* split up y into y1+y2 and compute (y1+y2)*(t1+t2) */
+        let y1: f64 = with_set_low_word(y, 0);
+        let p_l: f64 = (y - y1) * t1 + y * t2;
+        let mut p_h: f64 = y1 * t1;
+        let z: f64 = p_l + p_h;
+        let mut j: i32 = (z.to_bits() >> 32) as i32;
+        let i: i32 = z.to_bits() as i32;
+        // let (j, i): (i32, i32) = ((z.to_bits() >> 32) as i32, z.to_bits() as i32);
+
+        if j >= 0x40900000 {
+            /* z >= 1024 */
+            if (j - 0x40900000) | i != 0 {
+                /* if z > 1024 */
+                return s * HUGE * HUGE; /* overflow */
+            }
+
+            if p_l + OVT > z - p_h {
+                return s * HUGE * HUGE; /* overflow */
+            }
+        } else if (j & 0x7fffffff) >= 0x4090cc00 {
+            /* z <= -1075 */
+            // FIXME: instead of abs(j) use unsigned j
+
+            if (((j as u32) - 0xc090cc00) | (i as u32)) != 0 {
+                /* z < -1075 */
+                return s * TINY * TINY; /* underflow */
+            }
+
+            if p_l <= z - p_h {
+                return s * TINY * TINY; /* underflow */
+            }
+        }
+
+        /* compute 2**(p_h+p_l) */
+        let i: i32 = j & 0x7fffffff_i32;
+        k = (i >> 20) - 0x3ff;
+        let mut n: i32 = 0;
+
+        if i > 0x3fe00000 {
+            /* if |z| > 0.5, set n = [z+0.5] */
+            n = j + (0x00100000 >> (k + 1));
+            k = ((n & 0x7fffffff) >> 20) - 0x3ff; /* new k for n */
+            let t: f64 = with_set_high_word(0.0, (n & !(0x000fffff >> k)) as u32);
+            n = ((n & 0x000fffff) | 0x00100000) >> (20 - k);
+            if j < 0 {
+                n = -n;
+            }
+            p_h -= t;
+        }
+
+        let t: f64 = with_set_low_word(p_l + p_h, 0);
+        let u: f64 = t * LG2_H;
+        let v: f64 = (p_l - (t - p_h)) * LG2 + t * LG2_L;
+        let mut z: f64 = u + v;
+        let w: f64 = v - (z - u);
+        let t: f64 = z * z;
+        let t1: f64 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
+        let r: f64 = (z * t1) / (t1 - 2.0) - (w + z * w);
+        z = 1.0 - (r - z);
+        j = get_high_word(z) as i32;
+        j += n << 20;
+
+        if (j >> 20) <= 0 {
+            /* subnormal output */
+            z = scalbn(z, n);
+        } else {
+            z = with_set_high_word(z, j as u32);
+        }
+
+        s * z
+    }
+}
+
+pub use self::pow::*;
+
+pub mod log {
+    /* origin: FreeBSD /usr/src/lib/msun/src/e_log2.c */
+    /*
+     * ====================================================
+     * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+     *
+     * Developed at SunSoft, a Sun Microsystems, Inc. business.
+     * Permission to use, copy, modify, and distribute this
+     * software is freely granted, provided that this notice
+     * is preserved.
+     * ====================================================
+     */
+    /*
+     * Return the base 2 logarithm of x.  See log.c for most comments.
+     *
+     * Reduce x to 2^k (1+f) and calculate r = log(1+f) - f + f*f/2
+     * as in log.c, then combine and scale in extra precision:
+     *    log2(x) = (f - f*f/2 + r)/log(2) + k
+     */
+
+    use core::f64;
+
+    const IVLN2HI: f64 = 1.44269504072144627571e+00; /* 0x3ff71547, 0x65200000 */
+    const IVLN2LO: f64 = 1.67517131648865118353e-10; /* 0x3de705fc, 0x2eefa200 */
+    const LG1: f64 = 6.666666666666735130e-01; /* 3FE55555 55555593 */
+    const LG2: f64 = 3.999999999940941908e-01; /* 3FD99999 9997FA04 */
+    const LG3: f64 = 2.857142874366239149e-01; /* 3FD24924 94229359 */
+    const LG4: f64 = 2.222219843214978396e-01; /* 3FCC71C5 1D8E78AF */
+    const LG5: f64 = 1.818357216161805012e-01; /* 3FC74664 96CB03DE */
+    const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
+    const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
+
+    pub const fn log2(mut x: f64) -> f64 {
+        let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
+
+        let mut ui: u64 = x.to_bits();
+        let hfsq: f64;
+        let f: f64;
+        let s: f64;
+        let z: f64;
+        let r: f64;
+        let mut w: f64;
+        let t1: f64;
+        let t2: f64;
+        let y: f64;
+        let mut hi: f64;
+        let lo: f64;
+        let mut val_hi: f64;
+        let mut val_lo: f64;
+        let mut hx: u32;
+        let mut k: i32;
+
+        hx = (ui >> 32) as u32;
+        k = 0;
+        if hx < 0x00100000 || (hx >> 31) > 0 {
+            if ui << 1 == 0 {
+                return -1. / (x * x); /* log(+-0)=-inf */
+            }
+            if (hx >> 31) > 0 {
+                return (x - x) / 0.0; /* log(-#) = NaN */
+            }
+            /* subnormal number, scale x up */
+            k -= 54;
+            x *= x1p54;
+            ui = x.to_bits();
+            hx = (ui >> 32) as u32;
+        } else if hx >= 0x7ff00000 {
+            return x;
+        } else if hx == 0x3ff00000 && ui << 32 == 0 {
+            return 0.;
+        }
+
+        /* reduce x into [sqrt(2)/2, sqrt(2)] */
+        hx += 0x3ff00000 - 0x3fe6a09e;
+        k += (hx >> 20) as i32 - 0x3ff;
+        hx = (hx & 0x000fffff) + 0x3fe6a09e;
+        ui = ((hx as u64) << 32) | (ui & 0xffffffff);
+        x = f64::from_bits(ui);
+
+        f = x - 1.0;
+        hfsq = 0.5 * f * f;
+        s = f / (2.0 + f);
+        z = s * s;
+        w = z * z;
+        t1 = w * (LG2 + w * (LG4 + w * LG6));
+        t2 = z * (LG1 + w * (LG3 + w * (LG5 + w * LG7)));
+        r = t2 + t1;
+
+        /* hi+lo = f - hfsq + s*(hfsq+R) ~ log(1+f) */
+        hi = f - hfsq;
+        ui = hi.to_bits();
+        ui &= (-1i64 as u64) << 32;
+        hi = f64::from_bits(ui);
+        lo = f - hi - hfsq + s * (hfsq + r);
+
+        val_hi = hi * IVLN2HI;
+        val_lo = (lo + hi) * IVLN2LO + lo * IVLN2HI;
+
+        /* spadd(val_hi, val_lo, y), except for not using double_t: */
+        y = k as f64;
+        w = y + val_hi;
+        val_lo += (y - w) + val_hi;
+        val_hi = w;
+
+        val_lo + val_hi
+    }
+
+    pub const fn log(v: f64, b: f64) -> f64 {
+        log2(v) / log2(b)
+    }
+}
+
+pub use self::log::*;

--- a/src/platform/libm.rs
+++ b/src/platform/libm.rs
@@ -1,6 +1,12 @@
 /*
-This file comes from rust-lang/libm, including the functionality needed for exponential bucketing
-in `const` functions. It includes the following license:
+This file comes from `rust-lang/libm`
+
+It includes the functionality needed for exponential bucketing.
+These functions have been made `const` and specialized to `f64`.
+This implementation lives here so that bucketing can be done consistently
+across platforms, including in `no_std` programs.
+
+`rust-lang/libm` includes the following license:
 
 rust-lang/libm as a whole is available for use under the MIT license:
 
@@ -37,44 +43,27 @@ const SIGN_MASK: u64 = 1 << (BITS - 1);
 const SIG_MASK: u64 = (1 << SIG_BITS) - 1;
 const EXP_MASK: u64 = !(SIGN_MASK | SIG_MASK);
 
-#[inline(never)]
-#[cold]
-const fn cold_path() {}
-
-#[inline]
-const fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
-    let sign = if negative { 1u64 } else { 0 };
-    f64::from_bits(
-        (sign << (BITS - 1))
-            | (((exponent & EXP_SAT) as u64) << SIG_BITS)
-            | (significand & SIG_MASK),
-    )
-}
-
-#[inline]
-const fn get_high_word(x: f64) -> u32 {
-    (x.to_bits() >> 32) as u32
-}
-
-#[inline]
-const fn with_set_high_word(f: f64, hi: u32) -> f64 {
-    let mut tmp = f.to_bits();
-    tmp &= 0x00000000_ffffffff;
-    tmp |= (hi as u64) << 32;
-    f64::from_bits(tmp)
-}
-
-#[inline]
-const fn with_set_low_word(f: f64, lo: u32) -> f64 {
-    let mut tmp = f.to_bits();
-    tmp &= 0xffffffff_00000000;
-    tmp |= lo as u64;
-    f64::from_bits(tmp)
-}
-
-pub mod scalbn {
+mod scalbn {
     use super::*;
 
+    /**
+    Scale the exponent.
+
+    From N3220:
+
+    > The scalbn and scalbln functions compute `x * b^n`, where `b = FLT_RADIX` if the return type
+    > of the function is a standard floating type, or `b = 10` if the return type of the function
+    > is a decimal floating type. A range error occurs for some finite x, depending on n.
+    >
+    > [...]
+    >
+    > * `scalbn(±0, n)` returns `±0`.
+    > * `scalbn(x, 0)` returns `x`.
+    > * `scalbn(±∞, n)` returns `±∞`.
+    >
+    > If the calculation does not overflow or underflow, the returned value is exact and
+    > independent of the current rounding direction mode.
+    */
     pub const fn scalbn(mut x: f64, mut n: i32) -> f64 {
         let zero = 0;
 
@@ -91,7 +80,7 @@ pub mod scalbn {
         // 2 ^ Emin, minimum positive normal with null significand (0x1p-1022 for f64)
         let f_exp_min = from_parts(false, 1, zero);
 
-        // 2 ^ sig_total_bits, moltiplier to normalize subnormals (0x1p53 for f64)
+        // 2 ^ sig_total_bits, multiplier to normalize subnormals (0x1p53 for f64)
         let f_pow_subnorm = from_parts(false, sig_total_bits + EXP_BIAS, zero);
 
         /*
@@ -195,56 +184,53 @@ pub mod scalbn {
 
 pub use self::scalbn::*;
 
-const fn ex(v: f64) -> u32 {
-    ((v.to_bits() >> SIG_BITS) as u32) & EXP_SAT
-}
-
-pub mod sqrt {
+mod sqrt {
     /* SPDX-License-Identifier: MIT */
     /* origin: musl src/math/sqrt.c. Ported to generic Rust algorithm in 2025, TG. */
 
-    //! Generic square root algorithm.
-    //!
-    //! This routine operates around `m_u2`, a U.2 (fixed point with two integral bits) mantissa
-    //! within the range [1, 4). A table lookup provides an initial estimate, then goldschmidt
-    //! iterations at various widths are used to approach the real values.
-    //!
-    //! For the iterations, `r` is a U0 number that approaches `1/sqrt(m_u2)`, and `s` is a U2 number
-    //! that approaches `sqrt(m_u2)`. Recall that m_u2 ∈ [1, 4).
-    //!
-    //! With Newton-Raphson iterations, this would be:
-    //!
-    //! - `w = r * r           w ~ 1 / m`
-    //! - `u = 3 - m * w       u ~ 3 - m * w = 3 - m / m = 2`
-    //! - `r = r * u / 2       r ~ r`
-    //!
-    //! (Note that the righthand column does not show anything analytically meaningful (i.e. r ~ r),
-    //! since the value of performing one iteration is in reducing the error representable by `~`).
-    //!
-    //! Instead of Newton-Raphson iterations, Goldschmidt iterations are used to calculate
-    //! `s = m * r`:
-    //!
-    //! - `s = m * r           s ~ m / sqrt(m)`
-    //! - `u = 3 - s * r       u ~ 3 - (m / sqrt(m)) * (1 / sqrt(m)) = 3 - m / m = 2`
-    //! - `r = r * u / 2       r ~ r`
-    //! - `s = s * u / 2       s ~ s`
-    //!
-    //! The above is precise because it uses the original value `m`. There is also a faster version
-    //! that performs fewer steps but does not use `m`:
-    //!
-    //! - `u = 3 - s * r       u ~ 3 - 1`
-    //! - `r = r * u / 2       r ~ r`
-    //! - `s = s * u / 2       s ~ s`
-    //!
-    //! Rounding errors accumulate faster with the second version, so it is only used for subsequent
-    //! iterations within the same width integer. The first version is always used for the first
-    //! iteration at a new width in order to avoid this accumulation.
-    //!
-    //! Goldschmidt has the advantage over Newton-Raphson that `sqrt(x)` and `1/sqrt(x)` are
-    //! computed at the same time, i.e. there is no need to calculate `1/sqrt(x)` and invert it.
-
     use super::*;
 
+    /**
+    Generic square root algorithm.
+
+    This routine operates around `m_u2`, a U.2 (fixed point with two integral bits) mantissa
+    within the range [1, 4). A table lookup provides an initial estimate, then goldschmidt
+    iterations at various widths are used to approach the real values.
+
+    For the iterations, `r` is a U0 number that approaches `1/sqrt(m_u2)`, and `s` is a U2 number
+    that approaches `sqrt(m_u2)`. Recall that m_u2 ∈ [1, 4).
+
+    With Newton-Raphson iterations, this would be:
+
+    - `w = r * r           w ~ 1 / m`
+    - `u = 3 - m * w       u ~ 3 - m * w = 3 - m / m = 2`
+    - `r = r * u / 2       r ~ r`
+
+    (Note that the righthand column does not show anything analytically meaningful (i.e. r ~ r),
+    since the value of performing one iteration is in reducing the error representable by `~`).
+
+    Instead of Newton-Raphson iterations, Goldschmidt iterations are used to calculate
+    `s = m * r`:
+
+    - `s = m * r           s ~ m / sqrt(m)`
+    - `u = 3 - s * r       u ~ 3 - (m / sqrt(m)) * (1 / sqrt(m)) = 3 - m / m = 2`
+    - `r = r * u / 2       r ~ r`
+    - `s = s * u / 2       s ~ s`
+
+    The above is precise because it uses the original value `m`. There is also a faster version
+    that performs fewer steps but does not use `m`:
+
+    - `u = 3 - s * r       u ~ 3 - 1`
+    - `r = r * u / 2       r ~ r`
+    - `s = s * u / 2       s ~ s`
+
+    Rounding errors accumulate faster with the second version, so it is only used for subsequent
+    iterations within the same width integer. The first version is always used for the first
+    iteration at a new width in order to avoid this accumulation.
+
+    Goldschmidt has the advantage over Newton-Raphson that `sqrt(x)` and `1/sqrt(x)` are
+    computed at the same time, i.e. there is no need to calculate `1/sqrt(x)` and invert it.
+    */
     #[inline]
     pub const fn sqrt(x: f64) -> f64 {
         let mut ix = x.to_bits();
@@ -402,16 +388,6 @@ pub mod sqrt {
         (r_u0, s_u2)
     }
 
-    /// Perform `count` goldschmidt iterations, returning `(r_u0, s_u?)`.
-    ///
-    /// - `r_u0` is the reciprocal `r ~ 1 / sqrt(m)`, as U0.
-    /// - `s_u2` is the square root, `s ~ sqrt(m)`, as U2.
-    /// - `count` is the number of iterations to perform.
-    /// - `final_set` should be true if this is the last round (same-sized integer). If so, the
-    ///   returned `s` will be U3, for later shifting. Otherwise, the returned `s` is U2.
-    ///
-    /// Note that performance relies on the optimizer being able to unroll these loops (reasonably
-    /// trivial, `count` is a constant when called).
     #[inline]
     const fn goldschmidt_final(mut r_u0: u64, mut s_u2: u64, count: u32) -> (u64, u64) {
         let three_u2 = (0b11u64) << (u64::BITS - 2);
@@ -527,7 +503,7 @@ pub mod sqrt {
 
 pub use self::sqrt::*;
 
-pub mod pow {
+mod pow {
     /* origin: FreeBSD /usr/src/lib/msun/src/e_pow.c */
     /*
      * ====================================================
@@ -539,54 +515,6 @@ pub mod pow {
      * ====================================================
      */
 
-    // pow(x,y) return x**y
-    //
-    //                    n
-    // Method:  Let x =  2   * (1+f)
-    //      1. Compute and return log2(x) in two pieces:
-    //              log2(x) = w1 + w2,
-    //         where w1 has 53-24 = 29 bit trailing zeros.
-    //      2. Perform y*log2(x) = n+y' by simulating multi-precision
-    //         arithmetic, where |y'|<=0.5.
-    //      3. Return x**y = 2**n*exp(y'*log2)
-    //
-    // Special cases:
-    //      1.  (anything) ** 0  is 1
-    //      2.  1 ** (anything)  is 1
-    //      3.  (anything except 1) ** NAN is NAN
-    //      4.  NAN ** (anything except 0) is NAN
-    //      5.  +-(|x| > 1) **  +INF is +INF
-    //      6.  +-(|x| > 1) **  -INF is +0
-    //      7.  +-(|x| < 1) **  +INF is +0
-    //      8.  +-(|x| < 1) **  -INF is +INF
-    //      9.  -1          ** +-INF is 1
-    //      10. +0 ** (+anything except 0, NAN)               is +0
-    //      11. -0 ** (+anything except 0, NAN, odd integer)  is +0
-    //      12. +0 ** (-anything except 0, NAN)               is +INF, raise divbyzero
-    //      13. -0 ** (-anything except 0, NAN, odd integer)  is +INF, raise divbyzero
-    //      14. -0 ** (+odd integer) is -0
-    //      15. -0 ** (-odd integer) is -INF, raise divbyzero
-    //      16. +INF ** (+anything except 0,NAN) is +INF
-    //      17. +INF ** (-anything except 0,NAN) is +0
-    //      18. -INF ** (+odd integer) is -INF
-    //      19. -INF ** (anything) = -0 ** (-anything), (anything except odd integer)
-    //      20. (anything) ** 1 is (anything)
-    //      21. (anything) ** -1 is 1/(anything)
-    //      22. (-anything) ** (integer) is (-1)**(integer)*(+anything**integer)
-    //      23. (-anything except 0 and inf) ** (non-integer) is NAN
-    //
-    // Accuracy:
-    //      pow(x,y) returns x**y nearly rounded. In particular
-    //                      pow(integer,integer)
-    //      always returns the correct integer provided it is
-    //      representable.
-    //
-    // Constants :
-    // The hexadecimal values are the intended ones for the following
-    // constants. The decimal values may be used, provided that the
-    // compiler will convert from decimal to binary accurately enough
-    // to produce the hexadecimal values shown.
-    //
     use super::*;
 
     const BP: [f64; 2] = [1.0, 1.5];
@@ -619,16 +547,63 @@ pub mod pow {
     const IVLN2_H: f64 = 1.44269502162933349609e+00; /* 0x3ff71547_60000000 =24b 1/ln2*/
     const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 tail*/
 
-    /// Returns `x` to the power of `y` (f64).
+    /**
+    pow(x,y) return x**y
+                       n
+    Method:  Let x =  2   * (1+f)
+         1. Compute and return log2(x) in two pieces:
+                 log2(x) = w1 + w2,
+            where w1 has 53-24 = 29 bit trailing zeros.
+         2. Perform y*log2(x) = n+y' by simulating multi-precision
+            arithmetic, where |y'|<=0.5.
+         3. Return x**y = 2**n*exp(y'*log2)
+
+    Special cases:
+         1.  (anything) ** 0  is 1
+         2.  1 ** (anything)  is 1
+         3.  (anything except 1) ** NAN is NAN
+         4.  NAN ** (anything except 0) is NAN
+         5.  +-(|x| > 1) **  +INF is +INF
+         6.  +-(|x| > 1) **  -INF is +0
+         7.  +-(|x| < 1) **  +INF is +0
+         8.  +-(|x| < 1) **  -INF is +INF
+         9.  -1          ** +-INF is 1
+         10. +0 ** (+anything except 0, NAN)               is +0
+         11. -0 ** (+anything except 0, NAN, odd integer)  is +0
+         12. +0 ** (-anything except 0, NAN)               is +INF, raise divbyzero
+         13. -0 ** (-anything except 0, NAN, odd integer)  is +INF, raise divbyzero
+         14. -0 ** (+odd integer) is -0
+         15. -0 ** (-odd integer) is -INF, raise divbyzero
+         16. +INF ** (+anything except 0,NAN) is +INF
+         17. +INF ** (-anything except 0,NAN) is +0
+         18. -INF ** (+odd integer) is -INF
+         19. -INF ** (anything) = -0 ** (-anything), (anything except odd integer)
+         20. (anything) ** 1 is (anything)
+         21. (anything) ** -1 is 1/(anything)
+         22. (-anything) ** (integer) is (-1)**(integer)*(+anything**integer)
+         23. (-anything except 0 and inf) ** (non-integer) is NAN
+
+    Accuracy:
+         pow(x,y) returns x**y nearly rounded. In particular
+                         pow(integer,integer)
+         always returns the correct integer provided it is
+         representable.
+
+    Constants :
+    The hexadecimal values are the intended ones for the following
+    constants. The decimal values may be used, provided that the
+    compiler will convert from decimal to binary accurately enough
+    to produce the hexadecimal values shown.
+    */
     pub const fn pow(x: f64, y: f64) -> f64 {
         let t1: f64;
         let t2: f64;
 
-        let (hx, lx): (i32, u32) = ((x.to_bits() >> 32) as i32, x.to_bits() as u32);
-        let (hy, ly): (i32, u32) = ((y.to_bits() >> 32) as i32, y.to_bits() as u32);
+        let (hx, lx) = ((x.to_bits() >> 32) as i32, x.to_bits() as u32);
+        let (hy, ly) = ((y.to_bits() >> 32) as i32, y.to_bits() as u32);
 
-        let mut ix: i32 = hx & 0x7fffffff_i32;
-        let iy: i32 = hy & 0x7fffffff_i32;
+        let mut ix = hx & 0x7fffffffi32;
+        let iy = hy & 0x7fffffffi32;
 
         /* x**0 = 1, even if x is NaN */
         if ((iy as u32) | ly) == 0 {
@@ -723,12 +698,12 @@ pub mod pow {
             }
         }
 
-        let mut ax: f64 = x.abs();
+        let mut ax = x.abs();
         if lx == 0 {
             /* special value of x */
             if ix == 0x7ff00000 || ix == 0 || ix == 0x3ff00000 {
                 /* x is +-0,+-inf,+-1 */
-                let mut z: f64 = ax;
+                let mut z = ax;
 
                 if hy < 0 {
                     /* z = (1/|x|) */
@@ -747,7 +722,7 @@ pub mod pow {
             }
         }
 
-        let mut s: f64 = 1.0; /* sign of result */
+        let mut s = 1.0; /* sign of result */
         if hx < 0 {
             if yisint == 0 {
                 /* (x<0)**(non-int) is NaN */
@@ -792,10 +767,10 @@ pub mod pow {
 
             /* now |1-x| is TINY <= 2**-20, suffice to compute
             log(x) by x-x^2/2+x^3/3-x^4/4 */
-            let t: f64 = ax - 1.0; /* t has 20 trailing zeros */
-            let w: f64 = (t * t) * (0.5 - t * (0.3333333333333333333333 - t * 0.25));
-            let u: f64 = IVLN2_H * t; /* ivln2_h has 21 sig. bits */
-            let v: f64 = t * IVLN2_L - w * IVLN2;
+            let t = ax - 1.0; /* t has 20 trailing zeros */
+            let w = (t * t) * (0.5 - t * (0.3333333333333333333333 - t * 0.25));
+            let u = IVLN2_H * t; /* ivln2_h has 21 sig. bits */
+            let v = t * IVLN2_L - w * IVLN2;
             t1 = with_set_low_word(u + v, 0);
             t2 = v - (t1 - u);
         } else {
@@ -829,52 +804,50 @@ pub mod pow {
             ax = with_set_high_word(ax, ix as u32);
 
             /* compute ss = s_h+s_l = (x-1)/(x+1) or (x-1.5)/(x+1.5) */
-            let u: f64 = ax - BP[k as usize]; /* bp[0]=1.0, bp[1]=1.5 */
-            let v: f64 = 1.0 / (ax + BP[k as usize]);
-            let ss: f64 = u * v;
+            let u = ax - BP[k as usize]; /* bp[0]=1.0, bp[1]=1.5 */
+            let v = 1.0 / (ax + BP[k as usize]);
+            let ss = u * v;
             let s_h = with_set_low_word(ss, 0);
 
             /* t_h=ax+bp[k] High */
-            let t_h: f64 = with_set_high_word(
+            let t_h = with_set_high_word(
                 0.0,
                 ((ix as u32 >> 1) | 0x20000000) + 0x00080000 + ((k as u32) << 18),
             );
-            let t_l: f64 = ax - (t_h - BP[k as usize]);
-            let s_l: f64 = v * ((u - s_h * t_h) - s_h * t_l);
+            let t_l = ax - (t_h - BP[k as usize]);
+            let s_l = v * ((u - s_h * t_h) - s_h * t_l);
 
             /* compute log(ax) */
-            let s2: f64 = ss * ss;
-            let mut r: f64 =
-                s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
+            let s2 = ss * ss;
+            let mut r = s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
             r += s_l * (s_h + ss);
-            let s2: f64 = s_h * s_h;
-            let t_h: f64 = with_set_low_word(3.0 + s2 + r, 0);
-            let t_l: f64 = r - ((t_h - 3.0) - s2);
+            let s2 = s_h * s_h;
+            let t_h = with_set_low_word(3.0 + s2 + r, 0);
+            let t_l = r - ((t_h - 3.0) - s2);
 
             /* u+v = ss*(1+...) */
-            let u: f64 = s_h * t_h;
-            let v: f64 = s_l * t_h + t_l * ss;
+            let u = s_h * t_h;
+            let v = s_l * t_h + t_l * ss;
 
             /* 2/(3log2)*(ss+...) */
-            let p_h: f64 = with_set_low_word(u + v, 0);
+            let p_h = with_set_low_word(u + v, 0);
             let p_l = v - (p_h - u);
-            let z_h: f64 = CP_H * p_h; /* cp_h+cp_l = 2/(3*log2) */
-            let z_l: f64 = CP_L * p_h + p_l * CP + DP_L[k as usize];
+            let z_h = CP_H * p_h; /* cp_h+cp_l = 2/(3*log2) */
+            let z_l = CP_L * p_h + p_l * CP + DP_L[k as usize];
 
             /* log2(ax) = (ss+..)*2/(3*log2) = n + dp_h + z_h + z_l */
-            let t: f64 = n as f64;
+            let t = n as f64;
             t1 = with_set_low_word(((z_h + z_l) + DP_H[k as usize]) + t, 0);
             t2 = z_l - (((t1 - t) - DP_H[k as usize]) - z_h);
         }
 
         /* split up y into y1+y2 and compute (y1+y2)*(t1+t2) */
-        let y1: f64 = with_set_low_word(y, 0);
-        let p_l: f64 = (y - y1) * t1 + y * t2;
-        let mut p_h: f64 = y1 * t1;
-        let z: f64 = p_l + p_h;
-        let mut j: i32 = (z.to_bits() >> 32) as i32;
-        let i: i32 = z.to_bits() as i32;
-        // let (j, i): (i32, i32) = ((z.to_bits() >> 32) as i32, z.to_bits() as i32);
+        let y1 = with_set_low_word(y, 0);
+        let p_l = (y - y1) * t1 + y * t2;
+        let mut p_h = y1 * t1;
+        let z = p_l + p_h;
+        let mut j = (z.to_bits() >> 32) as i32;
+        let i = z.to_bits() as i32;
 
         if j >= 0x40900000 {
             /* z >= 1024 */
@@ -888,7 +861,6 @@ pub mod pow {
             }
         } else if (j & 0x7fffffff) >= 0x4090cc00 {
             /* z <= -1075 */
-            // FIXME: instead of abs(j) use unsigned j
 
             if (((j as u32) - 0xc090cc00) | (i as u32)) != 0 {
                 /* z < -1075 */
@@ -901,15 +873,15 @@ pub mod pow {
         }
 
         /* compute 2**(p_h+p_l) */
-        let i: i32 = j & 0x7fffffff_i32;
+        let i = j & 0x7fffffffi32;
         k = (i >> 20) - 0x3ff;
-        let mut n: i32 = 0;
+        let mut n = 0;
 
         if i > 0x3fe00000 {
             /* if |z| > 0.5, set n = [z+0.5] */
             n = j + (0x00100000 >> (k + 1));
             k = ((n & 0x7fffffff) >> 20) - 0x3ff; /* new k for n */
-            let t: f64 = with_set_high_word(0.0, (n & !(0x000fffff >> k)) as u32);
+            let t = with_set_high_word(0.0, (n & !(0x000fffff >> k)) as u32);
             n = ((n & 0x000fffff) | 0x00100000) >> (20 - k);
             if j < 0 {
                 n = -n;
@@ -917,14 +889,14 @@ pub mod pow {
             p_h -= t;
         }
 
-        let t: f64 = with_set_low_word(p_l + p_h, 0);
-        let u: f64 = t * LG2_H;
-        let v: f64 = (p_l - (t - p_h)) * LG2 + t * LG2_L;
-        let mut z: f64 = u + v;
-        let w: f64 = v - (z - u);
-        let t: f64 = z * z;
-        let t1: f64 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
-        let r: f64 = (z * t1) / (t1 - 2.0) - (w + z * w);
+        let t = with_set_low_word(p_l + p_h, 0);
+        let u = t * LG2_H;
+        let v = (p_l - (t - p_h)) * LG2 + t * LG2_L;
+        let mut z = u + v;
+        let w = v - (z - u);
+        let t = z * z;
+        let t1 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
+        let r = (z * t1) / (t1 - 2.0) - (w + z * w);
         z = 1.0 - (r - z);
         j = get_high_word(z) as i32;
         j += n << 20;
@@ -1167,7 +1139,7 @@ pub mod pow {
 
 pub use self::pow::*;
 
-pub mod log {
+mod log {
     /* origin: FreeBSD /usr/src/lib/msun/src/e_log2.c */
     /*
      * ====================================================
@@ -1178,13 +1150,6 @@ pub mod log {
      * software is freely granted, provided that this notice
      * is preserved.
      * ====================================================
-     */
-    /*
-     * Return the base 2 logarithm of x.  See log.c for most comments.
-     *
-     * Reduce x to 2^k (1+f) and calculate r = log(1+f) - f + f*f/2
-     * as in log.c, then combine and scale in extra precision:
-     *    log2(x) = (f - f*f/2 + r)/log(2) + k
      */
 
     use core::f64;
@@ -1199,6 +1164,13 @@ pub mod log {
     const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
     const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
+    /**
+    Return the base 2 logarithm of x.
+
+    Reduce `x` to `2^k (1+f)` and calculate `r = log(1+f) - f + f*f/2`
+    as in log.c, then combine and scale in extra precision:
+       `log2(x) = (f - f*f/2 + r)/log(2) + k`
+    */
     pub const fn log2(mut x: f64) -> f64 {
         let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
@@ -1274,6 +1246,9 @@ pub mod log {
         val_lo + val_hi
     }
 
+    /**
+    Compute the base `b` logarithm of `v`.
+    */
     pub const fn log(v: f64, b: f64) -> f64 {
         log2(v) / log2(b)
     }
@@ -1340,3 +1315,43 @@ pub mod log {
 }
 
 pub use self::log::*;
+
+#[inline(never)]
+#[cold]
+const fn cold_path() {}
+
+#[inline]
+const fn from_parts(negative: bool, exponent: u32, significand: u64) -> f64 {
+    let sign = if negative { 1u64 } else { 0 };
+    f64::from_bits(
+        (sign << (BITS - 1))
+            | (((exponent & EXP_SAT) as u64) << SIG_BITS)
+            | (significand & SIG_MASK),
+    )
+}
+
+#[inline]
+const fn get_high_word(x: f64) -> u32 {
+    (x.to_bits() >> 32) as u32
+}
+
+#[inline]
+const fn with_set_high_word(f: f64, hi: u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0x00000000_ffffffff;
+    tmp |= (hi as u64) << 32;
+    f64::from_bits(tmp)
+}
+
+#[inline]
+const fn with_set_low_word(f: f64, lo: u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0xffffffff_00000000;
+    tmp |= lo as u64;
+    f64::from_bits(tmp)
+}
+
+#[inline]
+const fn ex(v: f64) -> u32 {
+    ((v.to_bits() >> SIG_BITS) as u32) & EXP_SAT
+}


### PR DESCRIPTION
For #303 

This PR adds the fundamental `emit::metric::bucket_midpoint` function that can be used to produce exponential histograms of input data. It also adds well-known properties for tacking exponential histograms onto other metric samples.

I've ended up interning the relevant parts of `libm` I needed to implement `bucket_midpoint` in a portable and `no_std` compatible way.