### PR TITLE
Support mapping `emit`'s distributions to OTLP's exponential histograms

### DIFF
--- a/core/src/well_known.rs
+++ b/core/src/well_known.rs
@@ -38,8 +38,7 @@ Extensions to the data model are signaled by the well-known [`KEY_EVT_KIND`] pro
     - [`KEY_METRIC_VALUE`]: The sample itself.
     - [`KEY_METRIC_UNIT`]: The measurement unit the sample is in.
     - [`KEY_METRIC_DESCRIPTION`]: A description of the underlying data source.
-    - [`KEY_DIST_BUCKET_MIDPOINTS`]: The midpoint values of buckets in a distribution.
-    - [`KEY_DIST_BUCKET_COUNTS`]: The count of values in a bucket in a distribution.
+    - [`KEY_DIST_BUCKET_POINTS`]: The bucket midpoint/count pairs in a distribution.
     - [`KEY_DIST_BUCKET_SCALE`]: The scale of buckets in a distribution.
     - [`KEY_DIST_COUNT`]: The count of values in a distribution.
     - [`KEY_DIST_SUM`]: The sum of values in a distribution.
@@ -120,9 +119,7 @@ pub const KEY_METRIC_UNIT: &'static str = "metric_unit";
 pub const KEY_METRIC_DESCRIPTION: &'static str = "metric_description";
 
 /** The midpoint values of buckets in a distribution. */
-pub const KEY_DIST_BUCKET_MIDPOINTS: &'static str = "dist_bucket_midpoints";
-/** The count of values in a bucket in a distribution. */
-pub const KEY_DIST_BUCKET_COUNTS: &'static str = "dist_bucket_counts";
+pub const KEY_DIST_BUCKET_POINTS: &'static str = "dist_bucket_midpoints";
 /** The scale of buckets in a distribution. */
 pub const KEY_DIST_BUCKET_SCALE: &'static str = "dist_bucket_scale";
 /** The count of values in a distribution. */

--- a/emitter/otlp/src/data/metrics.rs
+++ b/emitter/otlp/src/data/metrics.rs
@@ -369,6 +369,50 @@ impl<'a, A> DataPointBuilder for RawPointSet<'a, A> {
     }
 }
 
+/*
+Building an exponential histogram:
+
+1. Walk the `dist_bucket_counts`, collecting them into a `Vec`
+2. Walk the `dist_bucket_midpoints`, zipping with counts, mapping into bucket indexes
+3. Compute the offset to use, convert indexes into dense buckets
+*/
+
+#[derive(Debug, PartialEq, Eq)]
+enum Index {
+    ZeroBucket,
+    PositiveBucket(i32),
+    NegativeBucket(i32),
+}
+
+fn bucket_index(value: f64, scale: i32) -> Option<Index> {
+    let positive = value == 0.0 || value.is_sign_positive();
+    let value = value.abs();
+
+    if value <= zero_threshold(scale) {
+        return Some(Index::ZeroBucket);
+    }
+
+    let gamma = 2.0f64.powf(2.0f64.powi(-scale));
+    let index = value.log(gamma).ceil();
+
+    let index = (index as i64).try_into().ok()?;
+
+    if positive {
+        Some(Index::PositiveBucket(index))
+    } else {
+        Some(Index::NegativeBucket(index))
+    }
+}
+
+#[inline]
+fn zero_threshold(scale: i32) -> f64 {
+    let gamma = 2.0f64.powf(2.0f64.powi(-scale));
+
+    // Pick a zero threshold that allows 100 buckets
+    // between `gamma` (a value close to 1) and 0
+    gamma.powi(-101)
+}
+
 #[derive(Default)]
 pub(crate) struct MetricsRequestEncoder;
 
@@ -752,5 +796,27 @@ mod tests {
                 }
             },
         );
+    }
+
+    #[test]
+    fn compute_bucket_indexes() {
+        for (value, scale, expected) in [
+            (0.0f64, 3, Some(Index::ZeroBucket)),
+            (-0.0f64, 3, Some(Index::ZeroBucket)),
+            (f64::EPSILON, 3, Some(Index::ZeroBucket)),
+            (-f64::EPSILON, 3, Some(Index::ZeroBucket)),
+            (zero_threshold(3), 3, Some(Index::ZeroBucket)),
+            (-zero_threshold(3), 3, Some(Index::ZeroBucket)),
+            (50f64, 3, Some(Index::PositiveBucket(46))),
+            (51f64, 3, Some(Index::PositiveBucket(46))),
+            (-50f64, 3, Some(Index::NegativeBucket(46))),
+            (-51f64, 3, Some(Index::NegativeBucket(46))),
+        ] {
+            let actual = bucket_index(value, scale);
+            assert_eq!(
+                expected, actual,
+                "expected bucket_index({value}, {scale}) to be {expected:?} but got {actual:?}"
+            );
+        }
     }
 }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1248,7 +1248,7 @@ pub mod dist {
     The implementation here uses a portable implementation of `powf` and `log` that is consistent across platforms.
     You may also consider using a native port of it for performance reasons.
     */
-    pub const fn bucket_midpoint(value: f64, scale: i32) -> f64 {
+    pub const fn midpoint(value: f64, scale: i32) -> f64 {
         let sign = if value == 0.0 || value.is_sign_positive() {
             1.0
         } else {
@@ -1265,6 +1265,247 @@ pub mod dist {
         sign * lower.midpoint(upper)
     }
 
+    #[cfg(feature = "sval")]
+    mod visit {
+        use core::{fmt, ops::ControlFlow};
+
+        use crate::Value;
+
+        /**
+        An error encountered attempting to visit bucket midpoint/count pairs.
+        */
+        #[derive(Debug)]
+        pub struct VisitBucketPointsError {}
+
+        impl fmt::Display for VisitBucketPointsError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "the input was not a valid sequence of bucket midpoint/count pairs"
+                )
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl std::error::Error for VisitBucketPointsError {}
+
+        /**
+        Visit the bucket midpoint/count pairs in a value.
+        */
+        pub fn visit_bucket_points(
+            buckets: Value,
+            for_each: impl FnMut(f64, u64) -> ControlFlow<()>,
+        ) -> Result<(), VisitBucketPointsError> {
+            struct Stream<F> {
+                depth: usize,
+                next_midpoint: Option<f64>,
+                next_count: Option<u64>,
+                next: F,
+                done: bool,
+            }
+
+            impl<F> Stream<F> {
+                fn push(
+                    &mut self,
+                    midpoint: impl FnOnce() -> Option<f64>,
+                    count: impl FnOnce() -> Option<u64>,
+                ) -> sval::Result {
+                    if self.depth == 2 {
+                        if self.next_midpoint.is_none() {
+                            self.next_midpoint = midpoint();
+
+                            return Ok(());
+                        }
+
+                        if self.next_count.is_none() {
+                            self.next_count = count();
+
+                            return Ok(());
+                        }
+                    }
+
+                    sval::error()
+                }
+
+                fn take(&mut self) -> Option<sval::Result<(f64, u64)>> {
+                    if self.depth == 2 {
+                        let (next_midpoint, next_count) =
+                            (self.next_midpoint.take(), self.next_count.take());
+
+                        Some((|| {
+                            sval::Result::Ok((
+                                next_midpoint.ok_or_else(|| sval::Error::new())?,
+                                next_count.ok_or_else(|| sval::Error::new())?,
+                            ))
+                        })())
+                    } else {
+                        None
+                    }
+                }
+            }
+
+            impl<'sval, F: FnMut(f64, u64) -> ControlFlow<()>> sval::Stream<'sval> for Stream<F> {
+                fn null(&mut self) -> sval::Result {
+                    sval::error()
+                }
+
+                fn bool(&mut self, _: bool) -> sval::Result {
+                    sval::error()
+                }
+
+                fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+                    sval::error()
+                }
+
+                fn text_fragment_computed(&mut self, _: &str) -> sval::Result {
+                    sval::error()
+                }
+
+                fn text_end(&mut self) -> sval::Result {
+                    sval::error()
+                }
+
+                fn i64(&mut self, value: i64) -> sval::Result {
+                    self.push(|| Some(value as f64), || value.try_into().ok())
+                }
+
+                fn u64(&mut self, value: u64) -> sval::Result {
+                    self.push(|| Some(value as f64), || value.try_into().ok())
+                }
+
+                fn f64(&mut self, value: f64) -> sval::Result {
+                    self.push(|| Some(value), || Some(value as u64))
+                }
+
+                fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+                    self.depth += 1;
+
+                    if self.depth > 2 {
+                        sval::error()
+                    } else {
+                        Ok(())
+                    }
+                }
+
+                fn seq_value_begin(&mut self) -> sval::Result {
+                    Ok(())
+                }
+
+                fn seq_value_end(&mut self) -> sval::Result {
+                    Ok(())
+                }
+
+                fn seq_end(&mut self) -> sval::Result {
+                    if let Some(next) = self.take() {
+                        let (midpoint, count) = next?;
+
+                        if let ControlFlow::Break(()) = (self.next)(midpoint, count) {
+                            self.done = true;
+                            return sval::error();
+                        };
+                    }
+
+                    self.depth -= 1;
+
+                    Ok(())
+                }
+
+                fn map_begin(&mut self, _: Option<usize>) -> sval::Result {
+                    sval::error()
+                }
+            }
+
+            let mut stream = Stream {
+                depth: 0,
+                next_midpoint: None,
+                next_count: None,
+                next: for_each,
+                done: false,
+            };
+
+            let r = sval::stream(&mut stream, &buckets);
+
+            if r.is_ok() || stream.done {
+                Ok(())
+            } else {
+                Err(VisitBucketPointsError {})
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn visit_bucket_points_valid() {
+                let value = [(1.0, 1), (2.0, 2), (3.0, 3)];
+
+                let mut actual = Vec::new();
+
+                let r = visit_bucket_points(Value::from_sval(&value), |midpoint, count| {
+                    actual.push((midpoint, count));
+
+                    ControlFlow::Continue(())
+                });
+
+                assert!(r.is_ok());
+
+                assert_eq!(&value, &*actual);
+            }
+
+            #[test]
+            fn visit_bucket_points_empty() {
+                assert!(
+                    visit_bucket_points(Value::from_any(&[] as &[f64; 0]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_ok()
+                );
+            }
+
+            #[test]
+            fn visit_bucket_points_invalid() {
+                assert!(
+                    visit_bucket_points(Value::from(0.0), |_, _| ControlFlow::Continue(()))
+                        .is_err()
+                );
+                assert!(
+                    visit_bucket_points(Value::from_any(&[1.0, 2.0, 3.0]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_err()
+                );
+                assert!(
+                    visit_bucket_points(Value::from_sval(&[[(1.0, 42)]]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_err()
+                );
+                assert!(
+                    visit_bucket_points(Value::from_sval(&[(1.0, 42, 1.0)]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_err()
+                );
+                assert!(
+                    visit_bucket_points(Value::from_sval(&[(true, 42)]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_err()
+                );
+                assert!(
+                    visit_bucket_points(Value::from_sval(&[("text", 42)]), |_, _| {
+                        ControlFlow::Continue(())
+                    })
+                    .is_err()
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "sval")]
+    pub use self::visit::*;
+
     #[cfg(test)]
     mod tests {
         use core::f64::consts::PI;
@@ -1272,7 +1513,7 @@ pub mod dist {
         use super::*;
 
         #[test]
-        fn compute_bucket_midpoints() {
+        fn compute_midpoints() {
             let cases = [
                 0.0f64,
                 PI,
@@ -1369,13 +1610,17 @@ pub mod dist {
                 ),
             ] {
                 for (case, expected) in cases.iter().copied().zip(expected.iter().copied()) {
-                    let actual = bucket_midpoint(case, scale);
+                    let actual = midpoint(case, scale);
 
                     if expected.is_nan() && actual.is_nan() {
                         continue;
                     }
 
-                    assert_eq!(expected.to_bits(), actual.to_bits(), "expected bucket_midpoint({case}, {scale}) to be {expected}, but got {actual}");
+                    assert_eq!(
+                        expected.to_bits(),
+                        actual.to_bits(),
+                        "expected midpoint({case}, {scale}) to be {expected}, but got {actual}"
+                    );
                 }
             }
         }


### PR DESCRIPTION
This PR finishes off `emit`'s distribution data model and wires it up to `emit_otlp` as an exponential histogram. Most of the details are still to figure out here, so will update once it's all finalized.