### PR TITLE
Rename metric::dist to metric::exp

### DIFF
--- a/book/src/producing-events/metrics/distributions.md
+++ b/book/src/producing-events/metrics/distributions.md
@@ -150,7 +150,7 @@ struct MyDistribution {
     scale: i32,
     max_buckets: usize,
     total: u64,
-    buckets: BTreeMap<emit::metric::dist::Point, u64>,
+    buckets: BTreeMap<emit::metric::exp::Point, u64>,
 }
 
 impl MyDistribution {
@@ -165,7 +165,7 @@ impl MyDistribution {
         }
     }
 
-    pub fn buckets(&self) -> &BTreeMap<emit::metric::dist::Point, u64> {
+    pub fn buckets(&self) -> &BTreeMap<emit::metric::exp::Point, u64> {
         &self.buckets
     }
 
@@ -180,7 +180,7 @@ impl MyDistribution {
     pub fn observe(&mut self, value: f64) {
         *self
             .buckets
-            .entry(emit::metric::dist::midpoint(value, self.scale))
+            .entry(emit::metric::exp::midpoint(value, self.scale))
             .or_default() += 1;
 
         self.total += 1;
@@ -194,7 +194,7 @@ impl MyDistribution {
 
             for (value, count) in &self.buckets {
                 *resampled
-                    .entry(emit::metric::dist::midpoint(value.get(), self.scale))
+                    .entry(emit::metric::exp::midpoint(value.get(), self.scale))
                     .or_default() += *count;
             }
 
@@ -213,10 +213,10 @@ An exponential histogram in `MyDistribution` can then be converted into a metric
 #     scale: i32,
 #     max_buckets: usize,
 #     total: u64,
-#     buckets: std::collections::BTreeMap<emit::metric::dist::Point, u64>,
+#     buckets: std::collections::BTreeMap<emit::metric::exp::Point, u64>,
 # }
 # impl MyDistribution {
-#     pub fn buckets(&self) -> &std::collections::BTreeMap<emit::metric::dist::Point, u64> { &self.buckets }
+#     pub fn buckets(&self) -> &std::collections::BTreeMap<emit::metric::exp::Point, u64> { &self.buckets }
 #     pub fn total(&self) -> u64 { self.total }
 #     pub fn scale(&self) -> i32 { self.scale }
 # }

--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -88,7 +88,7 @@ fn main() {
 use std::{cell::RefCell, collections::BTreeMap, fmt, io::Write, iter, str, time::Duration};
 
 use emit::{
-    metric::dist::Point,
+    metric::exp::Point,
     well_known::{
         KEY_DIST_EXP_BUCKETS, KEY_DIST_EXP_SCALE, KEY_ERR, KEY_EVT_KIND, KEY_LVL, KEY_SPAN_ID,
         KEY_TRACE_ID,

--- a/examples/common_patterns/metric_distribution.rs
+++ b/examples/common_patterns/metric_distribution.rs
@@ -3,7 +3,7 @@ This example demonstrates attaching a distribution to a metric sample.
 
 Distributions give you an idea of what the individual values that made up your sample look like
 without actually storing all of them. Values that are close together are bucketed together by
-a single `emit::metric::dist::midpoint`. The `scale` parameter decides how big these buckets are.
+a single `emit::metric::exp::midpoint`. The `scale` parameter decides how big these buckets are.
 Bigger buckets take up less space, because there are fewer of them, but are less accurate than
 smaller buckets. There's no single right `scale` to use, it depends on the shape of your input data.
 
@@ -25,14 +25,14 @@ use std::{
 struct MyDistribution {
     scale: i32,
     total: u64,
-    buckets: BTreeMap<emit::metric::dist::Point, u64>,
+    buckets: BTreeMap<emit::metric::exp::Point, u64>,
 }
 
 impl MyDistribution {
     fn observe(&mut self, value: f64) {
         *self
             .buckets
-            .entry(emit::metric::dist::midpoint(value, self.scale))
+            .entry(emit::metric::exp::midpoint(value, self.scale))
             .or_default() += 1;
         self.total += 1;
     }

--- a/examples/common_patterns/metric_distribution_resampling.rs
+++ b/examples/common_patterns/metric_distribution_resampling.rs
@@ -18,14 +18,14 @@ struct MyDistribution {
     scale: i32,
     total: u64,
     max_buckets: usize,
-    buckets: BTreeMap<emit::metric::dist::Point, u64>,
+    buckets: BTreeMap<emit::metric::exp::Point, u64>,
 }
 
 impl MyDistribution {
     fn observe(&mut self, value: f64) {
         *self
             .buckets
-            .entry(emit::metric::dist::midpoint(value, self.scale))
+            .entry(emit::metric::exp::midpoint(value, self.scale))
             .or_default() += 1;
         self.total += 1;
 
@@ -38,7 +38,7 @@ impl MyDistribution {
 
             for (value, count) in &self.buckets {
                 *resampled
-                    .entry(emit::metric::dist::midpoint(value.get(), self.scale))
+                    .entry(emit::metric::exp::midpoint(value.get(), self.scale))
                     .or_default() += *count;
             }
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1207,9 +1207,9 @@ pub mod sampler {
     }
 }
 
-pub mod dist {
+pub mod exp {
     /*!
-    Functions for working with metric distributions.
+    Functions for working with exponential histograms.
     */
 
     use crate::{


### PR DESCRIPTION
This PR renames the unreleased `metric::dist` module to `metric::exp`, to leave room for other bucketing schemes in the future.