### PR TITLE
Improve compiler errors when captured values are missing

### DIFF
--- a/macros/src/capture.rs
+++ b/macros/src/capture.rs
@@ -97,8 +97,8 @@ pub(crate) fn value_with_hook(
     };
 
     quote_spanned!(expr.span()=> #[allow(unused_imports)] {
-        use emit::__private::{__PrivateCaptureHook as _, __PrivateOptionalCaptureHook as _, __PrivateOptionalMapHook as _, __PrivateInterpolatedHook as _, __PrivateKeyExternalHook as _};
-        (#expr).__private_optional_capture_some().__private_optional_map_some(|v| v.#fn_name()).__private_key_external() #interpolated_expr #captured_expr
+        use emit::__private::{__PrivateCaptureHook as _, __PrivateOptionalCaptureHook as _, __PrivateOptionalHook as _, __PrivateInterpolatedHook as _, __PrivateKeyExternalHook as _};
+        (#expr).#fn_name().__private_key_external() #interpolated_expr #captured_expr
     })
 }
 

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -456,21 +456,8 @@ impl<'a, T: ?Sized> Optional<'a> for Option<&'a T> {
     }
 }
 
-pub trait __PrivateOptionalMapHook<'a> {
-    fn __private_optional_map_some<
-        F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>,
-        U: 'a,
-    >(
-        self,
-        map: F,
-    ) -> Option<U>
-    where
-        Self: Optional<'a>;
-
-    fn __private_optional_map_option_ref<
-        F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>,
-        U: 'a,
-    >(
+pub trait __PrivateOptionalHook<'a> {
+    fn __private_optional<F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>, U: 'a>(
         self,
         map: F,
     ) -> Option<U>
@@ -478,21 +465,8 @@ pub trait __PrivateOptionalMapHook<'a> {
         Self: Optional<'a>;
 }
 
-impl<'a, T> __PrivateOptionalMapHook<'a> for T {
-    fn __private_optional_map_some<F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>, U>(
-        self,
-        map: F,
-    ) -> Option<U>
-    where
-        Self: Optional<'a>,
-    {
-        self.into_option().and_then(map)
-    }
-
-    fn __private_optional_map_option_ref<
-        F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>,
-        U,
-    >(
+impl<'a, T> __PrivateOptionalHook<'a> for T {
+    fn __private_optional<F: FnOnce(&'a <Self as Optional<'a>>::Value) -> Option<U>, U>(
         self,
         map: F,
     ) -> Option<U>

--- a/test/ui/src/compile_fail/std/emit_props_missing.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_missing.stderr
@@ -3,14 +3,3 @@ error[E0425]: cannot find value `x` in this scope
   |
 2 |     emit::emit!("template", x);
   |                             ^ not found in this scope
-
-error[E0282]: type annotations needed
- --> src/compile_fail/std/emit_props_missing.rs:2:29
-  |
-2 |     emit::emit!("template", x);
-  |                             ^
-  |
-help: consider giving this closure parameter an explicit type
-  |
-2 |     emit::emit!("template", x: /* Type */);
-  |                              ++++++++++++

--- a/test/ui/src/compile_fail/std/emit_props_missing_interpolated.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_missing_interpolated.stderr
@@ -3,14 +3,3 @@ error[E0425]: cannot find value `x` in this scope
   |
 2 |     emit::emit!("template {x}");
   |                            ^ not found in this scope
-
-error[E0282]: type annotations needed
- --> src/compile_fail/std/emit_props_missing_interpolated.rs:2:28
-  |
-2 |     emit::emit!("template {x}");
-  |                            ^
-  |
-help: consider giving this closure parameter an explicit type
-  |
-2 |     emit::emit!("template {x: /* Type */}");
-  |                             ++++++++++++

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -321,6 +321,17 @@ fn props_optional_ref() {
 }
 
 #[test]
+fn props_optional_multi_attr() {
+    let props = emit::props! {
+        #[emit::optional] #[emit::as_debug] some: Some(&1),
+        #[emit::as_debug] #[emit::optional] none: None::<&i32>,
+    };
+
+    assert!(props.get("some").is_some());
+    assert!(props.get("none").is_none());
+}
+
+#[test]
 fn props_as_debug() {
     #[derive(Debug)]
     struct Data;


### PR DESCRIPTION
This PR fixes up a regression in compiler errors when an event is trying to capture a missing property.

Instead of unconditionally generating a closure call for capturing, we only emit it when the `#[emit::optional]` attribute is present.