### PR TITLE
Add tests to ensure unsampled traceparent propagates via ctxt

### DIFF
--- a/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_optional_non_ref.stderr
@@ -11,14 +11,3 @@ help: the trait `emit::__private::Optional<'_>` is not implemented for `Option<{
   | impl<'a, T: ?Sized> Optional<'a> for Option<&'a T> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for that trait implementation, expected `&_`, found `{integer}`
-
-error[E0282]: type annotations needed for `&_`
- --> src/compile_fail/std/emit_props_optional_non_ref.rs:2:29
-  |
-2 |     emit::emit!("template", #[emit::optional] some: Some(1));
-  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-help: consider giving this closure parameter an explicit type, where the placeholders `_` are specified
-  |
-2 |     emit::emit!("template", #[emit::optional] some: Some(1): &_);
-  |                                                            ++++


### PR DESCRIPTION
This PR just adds some tests for propagating traceparent sampling via the usual method with `Ctxt`. It's important that sampling decisions follow context across threads, without users needing to change the way propagation is done. This does seem to be the case, which is good.