### PR TITLE
Add a few more details to the getting started page

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -83,6 +83,8 @@ features = ["serde"]
 
 ```rust
 # extern crate emit;
+# extern crate serde;
+# use serde::Serialize;
 #[derive(Serialize)]
 struct User<'a> {
     id: &'a str,

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -29,6 +29,8 @@ fn main() {
 }
 ```
 
+You can configure `emit` to write to [OpenTelemetry](https://docs.rs/emit_otlp/1.17.2/emit_otlp/index.html), [the console](https://docs.rs/emit_term/1.17.2/emit_term/index.html), [rolling files](https://docs.rs/emit_file/1.17.2/emit_file/index.html), or any custom emitter you create.
+
 Start peppering diagnostics through your application with `emit`'s macros.
 
 ## Logging events
@@ -56,6 +58,48 @@ let err = std::io::Error::new(
 emit::warn!("updating {user} cart failed: {err}");
 ```
 
+### Macro syntax
+
+`emit`'s syntax is compatible with `std::fmt` in simple cases, but much more capable. It uses field-value syntax to name properties captured from local variables:
+
+```rust
+# extern crate emit;
+emit::info!(
+    "{user} added {item} to their cart",
+    user: "user-123",
+    item: "product-123",
+);
+```
+
+### Structured data
+
+`emit` captures properties using their `Display` implementation by default with special handling for booleans and numbers. It uses attribute syntax to customize how properties are captured, such as using `Serialize` instead:
+
+```toml
+[dependencies.emit]
+version = "1.17.2"
+features = ["serde"]
+```
+
+```rust
+# extern crate emit;
+#[derive(Serialize)]
+struct User<'a> {
+    id: &'a str,
+    name: &'a str,
+}
+
+let user = User {
+    id: "user-123",
+    name: "Some User",
+};
+
+emit::info!(
+    "{#[emit::as_serde] user} added {item} to their cart",
+    item: "product-123",
+);
+```
+
 ## Tracing functions
 
 Add [`#[span]`](https://docs.rs/emit/1.17.2/emit/attr.span.html) to a significant function in your application to trace its execution:
@@ -69,6 +113,8 @@ async fn add_item(user: &str, item: &str) {
 ```
 
 Any diagnostics emitted within a traced function will be correlated with it. Any other traced functions it calls will form a trace hierarchy.
+
+`emit`'s tracing attributes use the same syntax and capturing rules as log events.
 
 ## Sampling metrics
 
@@ -103,7 +149,7 @@ To learn more about configuring `emit`, see the [Emitting events](./emitting-eve
 
 To learn more about using `emit`, see the [Producing events](./producing-events.md) section.
 
-To learn `emit`'s architecture in more detail, see the [Reference](./reference.md) section.
+To learn `emit`'s architecture and syntax in more detail, see the [Reference](./reference.md) section.
 
 You may also want to explore:
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -59,3 +59,37 @@ Resolve it by using a capturing attribute explicitly on that property so `emit` 
 ```rust,ignore
 emit::emit!("template {#[emit::as_display] x}");
 ```
+
+### `E0277` when capturing `Option`
+
+When capturing a property wrapped in an `Option` by default, you'll encounter this error:
+
+```rust,ignore
+let x = Some("some data");
+
+emit::emit!("template {x}");
+```
+
+```text
+error[E0277]: capturing requires `Option<&str>` implements `Display + Any` by default. If this value does implement `Display`, then dereference or annotate it with `#[emit::as_display]`. If it doesn't, then use one of the `#[emit::as_*]` attributes to capture this value using a trait it does implement.
+ --> src/compile_fail/std/emit_props_non_optional.rs:4:28
+  |
+4 |     emit::emit!("template {x}");
+  |                            ^ the trait `std::fmt::Display` is not implemented for `Option<&str>`
+```
+
+Resolve it by adding the `#[optional]` attribute on that property:
+
+```rust,ignore
+let x = Some("some data");
+
+emit::emit!("template {#[emit::optional] x}");
+```
+
+You may also need to add `.as_ref()`, to ensure the property is `Option<&T>`, not `&Option<T>`:
+
+```rust,ignore
+let x = Some(42);
+
+emit::emit!("template {#[emit::optional] x: x.as_ref()}");
+```

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -30,38 +30,32 @@ fn main() {
 
 This section documents some common compile errors you might encounter when using `emit`.
 
-### `E0597` when capturing properties
+### `E0597` or `E0521` when capturing properties
 
 When capturing a property that doesn't satisfy `'static` (such as `std::panic::Location<'a>`), you'll encounter this error by default:
 
-```rust,no_run
+```rust,ignore
 emit::emit!("template {x}");
 ```
 
 ```text
-error[E0597]: `short_lived` does not live long enough
- --> src/compile_fail/std/emit_props_non_static.rs:5:25
-  |
-4 |     let short_lived = String::from("x");
-  |         ----------- binding `short_lived` declared here
-5 |     let x = InternalRef(&short_lived);
-  |                         ^^^^^^^^^^^^ borrowed value does not live long enough
-6 |
-7 |     emit::emit!("template {x}");
-  |                            - argument requires that `short_lived` is borrowed for `'static`
-8 | }
-  | - `short_lived` dropped here while still borrowed
-  |
-note: requirement that the value outlives `'static` introduced here
- --> $WORKSPACE/src/macro_hooks.rs
-  |
-  |         Self: CaptureWithDefault,
-  |               ^^^^^^^^^^^^^^^^^^
-
+error[E0521]: borrowed data escapes outside of function
+  --> src/compile_fail/std/emit_props_non_static.rs:10:28
+   |
+ 9 | pub fn exec(x: &InternalRef<'_>) {
+   |             -
+   |             |
+   |             `x` is a reference that is only valid in the function body
+   |             has type `&InternalRef<'1>`
+10 |     emit::emit!("template {x}");
+   |                            ^
+   |                            |
+   |                            `x` escapes the function body here
+   |                            argument requires that `'1` must outlive `'static`
 ```
 
 Resolve it by using a capturing attribute explicitly on that property so `emit` won't try and downcast it:
 
-```rust,no_run
+```rust,ignore
 emit::emit!("template {#[emit::as_display] x}");
 ```

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -25,3 +25,43 @@ fn main() {
     internal_rt.blocking_flush(std::time::Duration::from_secs(5));
 }
 ```
+
+## Common errors
+
+This section documents some common compile errors you might encounter when using `emit`.
+
+### `E0597` when capturing properties
+
+When capturing a property that doesn't satisfy `'static` (such as `std::panic::Location<'a>`), you'll encounter this error by default:
+
+```rust,no_run
+emit::emit!("template {x}");
+```
+
+```text
+error[E0597]: `short_lived` does not live long enough
+ --> src/compile_fail/std/emit_props_non_static.rs:5:25
+  |
+4 |     let short_lived = String::from("x");
+  |         ----------- binding `short_lived` declared here
+5 |     let x = InternalRef(&short_lived);
+  |                         ^^^^^^^^^^^^ borrowed value does not live long enough
+6 |
+7 |     emit::emit!("template {x}");
+  |                            - argument requires that `short_lived` is borrowed for `'static`
+8 | }
+  | - `short_lived` dropped here while still borrowed
+  |
+note: requirement that the value outlives `'static` introduced here
+ --> $WORKSPACE/src/macro_hooks.rs
+  |
+  |         Self: CaptureWithDefault,
+  |               ^^^^^^^^^^^^^^^^^^
+
+```
+
+Resolve it by using a capturing attribute explicitly on that property so `emit` won't try and downcast it:
+
+```rust,no_run
+emit::emit!("template {#[emit::as_display] x}");
+```

--- a/test/ui/src/compile_fail/std/emit_props_non_optional.rs
+++ b/test/ui/src/compile_fail/std/emit_props_non_optional.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x = Some("some data");
+
+    emit::emit!("template {x}");
+}

--- a/test/ui/src/compile_fail/std/emit_props_non_optional.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_optional.stderr
@@ -1,0 +1,20 @@
+error[E0277]: capturing requires `Option<&str>` implements `Display + Any` by default. If this value does implement `Display`, then dereference or annotate it with `#[emit::as_display]`. If it doesn't, then use one of the `#[emit::as_*]` attributes to capture this value using a trait it does implement.
+ --> src/compile_fail/std/emit_props_non_optional.rs:4:28
+  |
+4 |     emit::emit!("template {x}");
+  |                            ^ the trait `std::fmt::Display` is not implemented for `Option<&str>`
+  |
+help: the trait `emit::__private::CaptureWithDefault` is implemented for `str`
+ --> $WORKSPACE/src/macro_hooks.rs
+  |
+  | impl CaptureWithDefault for str {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `Option<&str>` to implement `emit::__private::CaptureWithDefault`
+note: required by a bound in `emit::__private::__PrivateCaptureHook::__private_capture_as_default`
+ --> $WORKSPACE/src/macro_hooks.rs
+  |
+  |     fn __private_capture_as_default(&self) -> Option<Value<'_>>
+  |        ---------------------------- required by a bound in this associated function
+  |     where
+  |         Self: CaptureWithDefault,
+  |               ^^^^^^^^^^^^^^^^^^ required by this bound in `__PrivateCaptureHook::__private_capture_as_default`

--- a/test/ui/src/compile_fail/std/emit_props_non_static.rs
+++ b/test/ui/src/compile_fail/std/emit_props_non_static.rs
@@ -2,8 +2,11 @@ use std::fmt;
 
 fn main() {
     let short_lived = String::from("x");
-    let x = InternalRef(&short_lived);
 
+    exec(&InternalRef(&short_lived));
+}
+
+pub fn exec(x: &InternalRef<'_>) {
     emit::emit!("template {x}");
 }
 

--- a/test/ui/src/compile_fail/std/emit_props_non_static.rs
+++ b/test/ui/src/compile_fail/std/emit_props_non_static.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+fn main() {
+    let short_lived = String::from("x");
+    let x = InternalRef(&short_lived);
+
+    emit::emit!("template {x}");
+}
+
+struct InternalRef<'a>(&'a str);
+
+impl<'a> fmt::Display for InternalRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.0, f)
+    }
+}

--- a/test/ui/src/compile_fail/std/emit_props_non_static.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_static.stderr
@@ -1,18 +1,13 @@
-error[E0597]: `short_lived` does not live long enough
- --> src/compile_fail/std/emit_props_non_static.rs:5:25
-  |
-4 |     let short_lived = String::from("x");
-  |         ----------- binding `short_lived` declared here
-5 |     let x = InternalRef(&short_lived);
-  |                         ^^^^^^^^^^^^ borrowed value does not live long enough
-6 |
-7 |     emit::emit!("template {x}");
-  |                            - argument requires that `short_lived` is borrowed for `'static`
-8 | }
-  | - `short_lived` dropped here while still borrowed
-  |
-note: requirement that the value outlives `'static` introduced here
- --> $WORKSPACE/src/macro_hooks.rs
-  |
-  |         Self: CaptureWithDefault,
-  |               ^^^^^^^^^^^^^^^^^^
+error[E0521]: borrowed data escapes outside of function
+  --> src/compile_fail/std/emit_props_non_static.rs:10:28
+   |
+ 9 | pub fn exec(x: &InternalRef<'_>) {
+   |             -
+   |             |
+   |             `x` is a reference that is only valid in the function body
+   |             has type `&InternalRef<'1>`
+10 |     emit::emit!("template {x}");
+   |                            ^
+   |                            |
+   |                            `x` escapes the function body here
+   |                            argument requires that `'1` must outlive `'static`

--- a/test/ui/src/compile_fail/std/emit_props_non_static.stderr
+++ b/test/ui/src/compile_fail/std/emit_props_non_static.stderr
@@ -1,0 +1,18 @@
+error[E0597]: `short_lived` does not live long enough
+ --> src/compile_fail/std/emit_props_non_static.rs:5:25
+  |
+4 |     let short_lived = String::from("x");
+  |         ----------- binding `short_lived` declared here
+5 |     let x = InternalRef(&short_lived);
+  |                         ^^^^^^^^^^^^ borrowed value does not live long enough
+6 |
+7 |     emit::emit!("template {x}");
+  |                            - argument requires that `short_lived` is borrowed for `'static`
+8 | }
+  | - `short_lived` dropped here while still borrowed
+  |
+note: requirement that the value outlives `'static` introduced here
+ --> $WORKSPACE/src/macro_hooks.rs
+  |
+  |         Self: CaptureWithDefault,
+  |               ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR aims to improve our getting started section so it includes enough detail to cover the basics of `emit`'s API in a self-contained way.