### PR TITLE
Batcher test improvements

### DIFF
--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -47,7 +47,3 @@ version = "0.3"
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dev-dependencies.tokio]
 version = "1"
 features = ["sync", "macros", "io-util", "rt", "time"]
-
-[dev-dependencies]
-quickcheck = "1"
-quickcheck_macros = "1"

--- a/batcher/Cargo.toml
+++ b/batcher/Cargo.toml
@@ -47,3 +47,7 @@ version = "0.3"
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dev-dependencies.tokio]
 version = "1"
 features = ["sync", "macros", "io-util", "rt", "time"]
+
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -158,7 +158,7 @@ pub fn bounded<T: Channel>(max_capacity: usize) -> (Sender<T>, Receiver<T>) {
             capacity: Capacity::new(),
             shared,
             #[cfg(all(not(target_arch = "wasm32"), test))]
-            test_barriers: TestBarriers::new(),
+            test_barriers: TestBarriers::default(),
         },
     )
 }
@@ -321,78 +321,22 @@ impl<T: Channel> Sender<T> {
 
 /**
 Test barriers for deterministic ordering in tests.
-
-Use these barriers to force specific synchronization points between sender and receiver in tests,
-avoiding reliance on non-deterministic delays.
 */
 #[cfg(all(not(target_arch = "wasm32"), test))]
 #[derive(Default, Clone)]
-pub struct TestBarriers {
-    pre_fetch: Option<Arc<Barrier>>,
+struct TestBarriers {
     post_take: Option<Arc<Barrier>>,
     post_process: Option<Arc<Barrier>>,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), test))]
 impl TestBarriers {
-    /**
-    Create a new empty TestBarriers instance.
-    */
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /**
-    Configure the pre-fetch barrier.
-
-    This barrier is triggered before the receiver checks for the next batch.
-    */
-    pub fn with_pre_fetch(mut self, barrier: Arc<Barrier>) -> Self {
-        self.pre_fetch = Some(barrier);
-        self
-    }
-
-    /**
-    Configure the post-take barrier.
-
-    This barrier is triggered after the receiver takes a batch but before processing.
-    */
-    pub fn with_post_take(mut self, barrier: Arc<Barrier>) -> Self {
-        self.post_take = Some(barrier);
-        self
-    }
-
-    /**
-    Configure the post-process barrier.
-
-    This barrier is triggered after the receiver finishes processing a batch.
-    */
-    pub fn with_post_process(mut self, barrier: Arc<Barrier>) -> Self {
-        self.post_process = Some(barrier);
-        self
-    }
-
-    /**
-    Wait at the pre-fetch barrier if configured.
-    */
-    pub async fn wait_pre_fetch(&self) {
-        if let Some(ref barrier) = self.pre_fetch {
-            barrier.wait().await;
-        }
-    }
-
-    /**
-    Wait at the post-take barrier if configured.
-    */
     pub async fn wait_post_take(&self) {
         if let Some(ref barrier) = self.post_take {
             barrier.wait().await;
         }
     }
 
-    /**
-    Wait at the post-process barrier if configured.
-    */
     pub async fn wait_post_process(&self) {
         if let Some(ref barrier) = self.post_process {
             barrier.wait().await;
@@ -432,7 +376,7 @@ impl<T: Channel> Receiver<T> {
     This method is only available when building with tests.
     */
     #[cfg(all(not(target_arch = "wasm32"), test))]
-    pub fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
+    fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
         self.test_barriers = barriers;
         self
     }
@@ -458,10 +402,6 @@ impl<T: Channel> Receiver<T> {
         let mut next_batch = Batch::new();
 
         loop {
-            // Pre-fetch barrier: wait here before checking for batches
-            #[cfg(all(not(target_arch = "wasm32"), test))]
-            self.test_barriers.wait_pre_fetch().await;
-
             // Run inside the lock
             let (mut current_batch, is_open) = {
                 let mut state = self.shared.state.lock().unwrap();

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
     time::Duration,
 };
 
-#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+#[cfg(all(not(target_arch = "wasm32"), test))]
 use ::tokio::sync::Barrier;
 
 mod internal_metrics;
@@ -157,7 +157,7 @@ pub fn bounded<T: Channel>(max_capacity: usize) -> (Sender<T>, Receiver<T>) {
             retry_delay: Delay::new(Duration::from_millis(700), Duration::from_secs(10)),
             capacity: Capacity::new(),
             shared,
-            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            #[cfg(all(not(target_arch = "wasm32"), test))]
             test_barriers: TestBarriers::new(),
         },
     )
@@ -325,7 +325,7 @@ Test barriers for deterministic ordering in tests.
 Use these barriers to force specific synchronization points between sender and receiver in tests,
 avoiding reliance on non-deterministic delays.
 */
-#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+#[cfg(all(not(target_arch = "wasm32"), test))]
 #[derive(Default, Clone)]
 pub struct TestBarriers {
     pre_fetch: Option<Arc<Barrier>>,
@@ -333,7 +333,7 @@ pub struct TestBarriers {
     post_process: Option<Arc<Barrier>>,
 }
 
-#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+#[cfg(all(not(target_arch = "wasm32"), test))]
 impl TestBarriers {
     /**
     Create a new empty TestBarriers instance.
@@ -411,7 +411,7 @@ pub struct Receiver<T> {
     retry_delay: Delay,
     capacity: Capacity,
     shared: Arc<Shared<T>>,
-    #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+    #[cfg(all(not(target_arch = "wasm32"), test))]
     test_barriers: TestBarriers,
 }
 
@@ -429,9 +429,9 @@ impl<T: Channel> Receiver<T> {
     /**
     Configure test barriers for deterministic ordering in tests.
 
-    This method is only available when building with tests or the `test_utils` feature.
+    This method is only available when building with tests.
     */
-    #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+    #[cfg(all(not(target_arch = "wasm32"), test))]
     pub fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
         self.test_barriers = barriers;
         self
@@ -459,7 +459,7 @@ impl<T: Channel> Receiver<T> {
 
         loop {
             // Pre-fetch barrier: wait here before checking for batches
-            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            #[cfg(all(not(target_arch = "wasm32"), test))]
             self.test_barriers.wait_pre_fetch().await;
 
             // Run inside the lock
@@ -500,7 +500,7 @@ impl<T: Channel> Receiver<T> {
             current_batch.watchers.notify_on_take();
 
             // Post-take barrier: wait here after batch is taken
-            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            #[cfg(all(not(target_arch = "wasm32"), test))]
             self.test_barriers.wait_post_take().await;
 
             if current_batch.channel.len() > 0 {
@@ -562,7 +562,7 @@ impl<T: Channel> Receiver<T> {
                 current_batch.watchers.notify_on_flush();
 
                 // Post-process barrier: wait here after batch is processed
-                #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+                #[cfg(all(not(target_arch = "wasm32"), test))]
                 self.test_barriers.wait_post_process().await;
             }
             // If the batch was empty then notify any watchers (there was nothing to flush)
@@ -571,7 +571,7 @@ impl<T: Channel> Receiver<T> {
                 current_batch.watchers.notify_on_flush();
 
                 // Post-process barrier: wait here after empty batch
-                #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+                #[cfg(all(not(target_arch = "wasm32"), test))]
                 self.test_barriers.wait_post_process().await;
 
                 // If the channel is closed then exit the loop and return; this will

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -31,6 +31,9 @@ use std::{
     time::Duration,
 };
 
+#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+use ::tokio::sync::Barrier;
+
 mod internal_metrics;
 
 /**
@@ -154,6 +157,8 @@ pub fn bounded<T: Channel>(max_capacity: usize) -> (Sender<T>, Receiver<T>) {
             retry_delay: Delay::new(Duration::from_millis(700), Duration::from_secs(10)),
             capacity: Capacity::new(),
             shared,
+            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            test_barriers: TestBarriers::new(),
         },
     )
 }
@@ -315,6 +320,87 @@ impl<T: Channel> Sender<T> {
 }
 
 /**
+Test barriers for deterministic ordering in tests.
+
+Use these barriers to force specific synchronization points between sender and receiver in tests,
+avoiding reliance on non-deterministic delays.
+*/
+#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+#[derive(Default, Clone)]
+pub struct TestBarriers {
+    pre_fetch: Option<Arc<Barrier>>,
+    post_take: Option<Arc<Barrier>>,
+    post_process: Option<Arc<Barrier>>,
+}
+
+#[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+impl TestBarriers {
+    /**
+    Create a new empty TestBarriers instance.
+    */
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /**
+    Configure the pre-fetch barrier.
+
+    This barrier is triggered before the receiver checks for the next batch.
+    */
+    pub fn with_pre_fetch(mut self, barrier: Arc<Barrier>) -> Self {
+        self.pre_fetch = Some(barrier);
+        self
+    }
+
+    /**
+    Configure the post-take barrier.
+
+    This barrier is triggered after the receiver takes a batch but before processing.
+    */
+    pub fn with_post_take(mut self, barrier: Arc<Barrier>) -> Self {
+        self.post_take = Some(barrier);
+        self
+    }
+
+    /**
+    Configure the post-process barrier.
+
+    This barrier is triggered after the receiver finishes processing a batch.
+    */
+    pub fn with_post_process(mut self, barrier: Arc<Barrier>) -> Self {
+        self.post_process = Some(barrier);
+        self
+    }
+
+    /**
+    Wait at the pre-fetch barrier if configured.
+    */
+    pub async fn wait_pre_fetch(&self) {
+        if let Some(ref barrier) = self.pre_fetch {
+            barrier.wait().await;
+        }
+    }
+
+    /**
+    Wait at the post-take barrier if configured.
+    */
+    pub async fn wait_post_take(&self) {
+        if let Some(ref barrier) = self.post_take {
+            barrier.wait().await;
+        }
+    }
+
+    /**
+    Wait at the post-process barrier if configured.
+    */
+    pub async fn wait_post_process(&self) {
+        if let Some(ref barrier) = self.post_process {
+            barrier.wait().await;
+        }
+    }
+}
+
+/**
 The receiving half of a channel.
 
 Use [`Receiver::exec`], [`crate::tokio::spawn`], or [`crate::sync::spawn`] to run the receiver as a background worker.
@@ -325,6 +411,8 @@ pub struct Receiver<T> {
     retry_delay: Delay,
     capacity: Capacity,
     shared: Arc<Shared<T>>,
+    #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+    test_barriers: TestBarriers,
 }
 
 impl<T> Drop for Receiver<T> {
@@ -338,6 +426,17 @@ impl<T> Drop for Receiver<T> {
 }
 
 impl<T: Channel> Receiver<T> {
+    /**
+    Configure test barriers for deterministic ordering in tests.
+
+    This method is only available when building with tests or the `test_utils` feature.
+    */
+    #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+    pub fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
+        self.test_barriers = barriers;
+        self
+    }
+
     /**
     Run the receiver asynchronously.
 
@@ -359,6 +458,10 @@ impl<T: Channel> Receiver<T> {
         let mut next_batch = Batch::new();
 
         loop {
+            // Pre-fetch barrier: wait here before checking for batches
+            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            self.test_barriers.wait_pre_fetch().await;
+
             // Run inside the lock
             let (mut current_batch, is_open) = {
                 let mut state = self.shared.state.lock().unwrap();
@@ -395,6 +498,10 @@ impl<T: Channel> Receiver<T> {
 
             // Run outside of the lock
             current_batch.watchers.notify_on_take();
+
+            // Post-take barrier: wait here after batch is taken
+            #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+            self.test_barriers.wait_post_take().await;
 
             if current_batch.channel.len() > 0 {
                 self.retry.reset();
@@ -453,11 +560,19 @@ impl<T: Channel> Receiver<T> {
 
                 // After the batch has been emitted, notify any watchers
                 current_batch.watchers.notify_on_flush();
+
+                // Post-process barrier: wait here after batch is processed
+                #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+                self.test_barriers.wait_post_process().await;
             }
             // If the batch was empty then notify any watchers (there was nothing to flush)
             // and wait before checking again
             else {
                 current_batch.watchers.notify_on_flush();
+
+                // Post-process barrier: wait here after empty batch
+                #[cfg(all(not(target_arch = "wasm32"), any(feature = "test_utils", test)))]
+                self.test_barriers.wait_post_process().await;
 
                 // If the channel is closed then exit the loop and return; this will
                 // drop the receiver

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -31,9 +31,6 @@ use std::{
     time::Duration,
 };
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
-use ::tokio::sync::Barrier;
-
 mod internal_metrics;
 
 /**
@@ -325,8 +322,8 @@ Test barriers for deterministic ordering in tests.
 #[cfg(all(not(target_arch = "wasm32"), test))]
 #[derive(Default, Clone)]
 pub struct TestBarriers {
-    post_take: Option<Arc<Barrier>>,
-    post_process: Option<Arc<Barrier>>,
+    post_take: Option<Arc<::tokio::sync::Barrier>>,
+    post_process: Option<Arc<::tokio::sync::Barrier>>,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), test))]

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -324,20 +324,20 @@ Test barriers for deterministic ordering in tests.
 */
 #[cfg(all(not(target_arch = "wasm32"), test))]
 #[derive(Default, Clone)]
-struct TestBarriers {
+pub struct TestBarriers {
     post_take: Option<Arc<Barrier>>,
     post_process: Option<Arc<Barrier>>,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), test))]
 impl TestBarriers {
-    pub async fn wait_post_take(&self) {
+    async fn wait_post_take(&self) {
         if let Some(ref barrier) = self.post_take {
             barrier.wait().await;
         }
     }
 
-    pub async fn wait_post_process(&self) {
+    async fn wait_post_process(&self) {
         if let Some(ref barrier) = self.post_process {
             barrier.wait().await;
         }
@@ -376,7 +376,7 @@ impl<T: Channel> Receiver<T> {
     This method is only available when building with tests.
     */
     #[cfg(all(not(target_arch = "wasm32"), test))]
-    fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
+    pub fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
         self.test_barriers = barriers;
         self
     }

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -479,6 +479,28 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: try_send returns an error when the channel is closed.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel
+    /// 2. Drop the receiver to close the channel from the receiver side
+    /// 3. Attempt try_send - should fail with a non-retryable error
+    fn try_send_on_closed_channel() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        // Drop the receiver to close the channel
+        drop(receiver);
+
+        // try_send should fail with a non-retryable error
+        let result = sender.try_send(1);
+        assert!(result.is_err());
+
+        // Verify the error is non-retryable (no messages to retry)
+        let err = result.err().unwrap();
+        assert!(err.into_retryable().is_none());
+    }
+
+    #[test]
     /// **Property**: Flush on an empty channel with zero timeout succeeds immediately.
     ///
     /// **Sequence of events**:

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -292,15 +292,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Basic send and receive functionality works correctly.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn a receiver thread that waits for processing commands
-    /// 3. Send 10 messages to the channel
-    /// 4. Allow receiver to process up to 2 batches (messages may be batched together)
-    /// 5. Wait until all 10 messages have been processed
-    /// 6. Drop sender and join receiver thread
     fn send_recv() {
         let received = Arc::new(Mutex::new(0));
 
@@ -338,14 +329,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Channel truncates oldest messages when capacity is exceeded.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Send 10 messages (exceeding capacity, causing truncation)
-    /// 3. Spawn receiver after all sends complete
-    /// 4. Process the single batch that remains
-    /// 5. Verify only the last 5 messages (5-9) were received, first 5 (0-4) were truncated
     fn send_full_capacity() {
         let received = Arc::new(Mutex::new(Vec::new()));
 
@@ -383,15 +366,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Blocking send waits for capacity and all messages are eventually processed.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Spawn sender thread and receiver thread
-    /// 3. Send 10 messages using blocking_send (blocks when at capacity)
-    /// 4. Receiver processes messages in up to 10 batches
-    /// 5. Wait until all 10 messages are processed
-    /// 6. All messages succeed because blocking_send waits for capacity
     fn blocking_send_full_capacity() {
         let received = Arc::new(Mutex::new(0));
 
@@ -432,15 +406,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Blocking send times out when channel remains at capacity.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Spawn sender thread and receiver thread
-    /// 3. Send 10 messages with 1ms timeout (will timeout when channel is full)
-    /// 4. Receiver processes only the first batch (5 messages)
-    /// 5. Remaining sends timeout because receiver doesn't process more batches
-    /// 6. Sender thread exits after timeout, receiver is abandoned
     fn blocking_send_full_capacity_timeout() {
         let received = Arc::new(Mutex::new(Vec::new()));
 
@@ -479,12 +444,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: try_send returns an error when the channel is closed.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel
-    /// 2. Drop the receiver to close the channel from the receiver side
-    /// 3. Attempt try_send - should fail with a non-retryable error
     fn try_send_on_closed_channel() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
@@ -501,14 +460,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Flush on an empty channel with zero timeout succeeds immediately.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver thread
-    /// 3. Call blocking_flush with zero timeout on empty channel
-    /// 4. Flush returns true immediately (nothing to wait for)
-    /// 5. Drop sender and join receiver thread
     fn flush_empty() {
         let (sender, receiver) = crate::bounded(10);
 
@@ -523,17 +474,6 @@ mod tests {
     }
 
     #[test]
-    /// **Property**: Flush waits for all active batches to complete processing.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver thread
-    /// 3. Send 3 messages to start first batch
-    /// 4. Wait for receiver to pick up the batch (is_in_batch flag)
-    /// 5. Send 3 more messages (second batch, while first is being processed)
-    /// 6. Call blocking_flush in a scoped thread
-    /// 7. Process both batches in the receiver
-    /// 8. Flush completes when all batches are done and channel is empty
     fn flush_active() {
         let (sender, receiver) = crate::bounded(10);
 

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -229,9 +229,9 @@ fn block_on<R>(fut: impl Future<Output = R>) -> R {
 mod tests {
     use super::*;
 
-    use crate::Receiver;
-
     use std::{sync::mpsc, thread};
+
+    use crate::Receiver;
 
     enum SenderCommand<T> {
         BlockingSend(T, Duration),

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -292,6 +292,15 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Basic send and receive functionality works correctly.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn a receiver thread that waits for processing commands
+    /// 3. Send 10 messages to the channel
+    /// 4. Allow receiver to process up to 2 batches (messages may be batched together)
+    /// 5. Wait until all 10 messages have been processed
+    /// 6. Drop sender and join receiver thread
     fn send_recv() {
         let received = Arc::new(Mutex::new(0));
 
@@ -329,6 +338,14 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Channel truncates oldest messages when capacity is exceeded.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Send 10 messages (exceeding capacity, causing truncation)
+    /// 3. Spawn receiver after all sends complete
+    /// 4. Process the single batch that remains
+    /// 5. Verify only the last 5 messages (5-9) were received, first 5 (0-4) were truncated
     fn send_full_capacity() {
         let received = Arc::new(Mutex::new(Vec::new()));
 
@@ -366,6 +383,15 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Blocking send waits for capacity and all messages are eventually processed.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Spawn sender thread and receiver thread
+    /// 3. Send 10 messages using blocking_send (blocks when at capacity)
+    /// 4. Receiver processes messages in up to 10 batches
+    /// 5. Wait until all 10 messages are processed
+    /// 6. All messages succeed because blocking_send waits for capacity
     fn blocking_send_full_capacity() {
         let received = Arc::new(Mutex::new(0));
 
@@ -406,6 +432,15 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Blocking send times out when channel remains at capacity.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Spawn sender thread and receiver thread
+    /// 3. Send 10 messages with 1ms timeout (will timeout when channel is full)
+    /// 4. Receiver processes only the first batch (5 messages)
+    /// 5. Remaining sends timeout because receiver doesn't process more batches
+    /// 6. Sender thread exits after timeout, receiver is abandoned
     fn blocking_send_full_capacity_timeout() {
         let received = Arc::new(Mutex::new(Vec::new()));
 
@@ -444,6 +479,14 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Flush on an empty channel with zero timeout succeeds immediately.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver thread
+    /// 3. Call blocking_flush with zero timeout on empty channel
+    /// 4. Flush returns true immediately (nothing to wait for)
+    /// 5. Drop sender and join receiver thread
     fn flush_empty() {
         let (sender, receiver) = crate::bounded(10);
 
@@ -458,6 +501,17 @@ mod tests {
     }
 
     #[test]
+    /// **Property**: Flush waits for all active batches to complete processing.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver thread
+    /// 3. Send 3 messages to start first batch
+    /// 4. Wait for receiver to pick up the batch (is_in_batch flag)
+    /// 5. Send 3 more messages (second batch, while first is being processed)
+    /// 6. Call blocking_flush in a scoped thread
+    /// 7. Process both batches in the receiver
+    /// 8. Flush completes when all batches are done and channel is empty
     fn flush_active() {
         let (sender, receiver) = crate::bounded(10);
 

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -157,7 +157,7 @@ mod tests {
     use super::*;
 
     use std::sync::{Arc, Mutex};
-    use tokio::sync::{Barrier, Semaphore};
+    use tokio::sync::{broadcast, Barrier, Semaphore};
 
     use crate::TestBarriers;
 
@@ -266,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn async_send_timeout() {
         // Channel to signal when receiver has taken a batch
-        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
+        let (receiver_ready_tx, mut receiver_ready_rx) = broadcast::channel::<()>(100);
         // Semaphore with 0 permits - blocks forever (until cancelled)
         let blocker = Arc::new(Semaphore::new(0));
 
@@ -332,7 +332,7 @@ mod tests {
     async fn flush_active() {
         let batch_count = Arc::new(Mutex::new(0));
         // Channel to signal when receiver has taken first batch
-        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
+        let (receiver_ready_tx, mut receiver_ready_rx) = broadcast::channel::<()>(100);
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
@@ -375,6 +375,8 @@ mod tests {
 
     #[tokio::test]
     async fn retry_on_batch_failure() {
+        // Channel to signal when receiver has completed a batch
+        let (receiver_processed_tx, mut receiver_processed_rx) = broadcast::channel::<()>(100);
         let attempt_count = Arc::new(Mutex::new(0));
         let received = Arc::new(Mutex::new(false));
 
@@ -386,6 +388,8 @@ mod tests {
             move |batch| {
                 let attempt_count = attempt_count.clone();
                 let received = received.clone();
+                let receiver_processed_tx = receiver_processed_tx.clone();
+
                 async move {
                     let mut count = attempt_count.lock().unwrap();
                     *count += 1;
@@ -397,6 +401,7 @@ mod tests {
                             batch,
                         ))
                     } else {
+                        receiver_processed_tx.send(()).unwrap();
                         *received.lock().unwrap() = true;
                         Ok(())
                     }
@@ -407,20 +412,10 @@ mod tests {
 
         sender.send(42);
 
-        // Retry loop: return early when count == 2, panic after 3 seconds
-        let start = Instant::now();
-        loop {
-            let received = *received.lock().unwrap();
-            if received {
-                break;
-            }
+        // Wait for receiver to process the batch
+        receiver_processed_rx.recv().await.ok();
 
-            if start.elapsed() >= Duration::from_secs(3) {
-                panic!("Timeout waiting for retries");
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
+        assert!(*received.lock().unwrap());
     }
 
     #[tokio::test]
@@ -549,6 +544,8 @@ mod tests {
 
     #[tokio::test]
     async fn when_flushed_callback() {
+        // Channel to signal when receiver has completed a batch
+        let (when_flushed_tx, mut when_flushed_rx) = broadcast::channel::<()>(100);
         let callback_fired = Arc::new(Mutex::new(false));
         let post_process_barrier = Arc::new(Barrier::new(2));
 
@@ -569,6 +566,7 @@ mod tests {
 
         let callback_fired_clone = callback_fired.clone();
         sender.when_flushed(move || {
+            when_flushed_tx.send(()).unwrap();
             *callback_fired_clone.lock().unwrap() = true;
         });
 
@@ -577,6 +575,8 @@ mod tests {
 
         // Wait at barrier for batch to be processed
         post_process_barrier.wait().await;
+
+        when_flushed_rx.recv().await.ok();
 
         // Callback should have fired
         assert!(*callback_fired.lock().unwrap());

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -370,7 +370,7 @@ mod tests {
         assert!(flushed);
 
         // Both batches should have been processed
-        assert!(*batch_count.lock().unwrap() >= 1);
+        assert_eq!(2, *batch_count.lock().unwrap());
     }
 
     #[tokio::test]
@@ -407,13 +407,20 @@ mod tests {
 
         sender.send(42);
 
-        // Wait for retries to complete (700ms delay between retries, need 3 attempts)
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        // Retry loop: return early when count == 2, panic after 3 seconds
+        let start = Instant::now();
+        loop {
+            let received = *received.lock().unwrap();
+            if received {
+                break;
+            }
 
-        // Should have 3 attempts: 1 initial + 2 retries
-        let count = *attempt_count.lock().unwrap();
-        assert!(count >= 2, "Should have at least 2 attempts, got {}", count);
-        assert!(*received.lock().unwrap());
+            if start.elapsed() >= Duration::from_secs(3) {
+                panic!("Timeout waiting for retries");
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 
     #[tokio::test]

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -157,6 +157,7 @@ mod tests {
     use super::*;
 
     use std::sync::{Arc, Mutex};
+    use ::tokio::sync::Barrier;
 
     #[tokio::test]
     async fn async_send_recv_flush() {
@@ -193,7 +194,11 @@ mod tests {
 
     #[tokio::test]
     async fn send_full_capacity() {
+        use crate::TestBarriers;
+        use std::sync::Arc;
+
         let received = Arc::new(Mutex::new(Vec::new()));
+        let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
 
@@ -202,8 +207,10 @@ mod tests {
             sender.send(i);
         }
 
-        // Spawn receiver after sending
-        let _ = spawn("test_receiver", receiver, {
+        // Spawn receiver after sending, with barrier after processing
+        let _ = spawn("test_receiver", receiver.with_test_barriers(
+            TestBarriers::new().with_post_process(post_process_barrier.clone())
+        ), {
             let received = received.clone();
             move |batch| {
                 let received = received.clone();
@@ -215,8 +222,8 @@ mod tests {
         })
         .unwrap();
 
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait at barrier for receiver to finish processing
+        post_process_barrier.wait().await;
 
         // Only last 5 messages should remain (0-4 were truncated)
         assert_eq!(vec![5, 6, 7, 8, 9], *received.lock().unwrap());
@@ -247,8 +254,8 @@ mod tests {
                 .unwrap();
         }
 
-        // Wait for all to be processed
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Use flush to wait for all messages to be processed
+        flush(&sender, Duration::from_secs(1)).await;
 
         // All 10 messages should be processed
         assert_eq!(10, *received.lock().unwrap());
@@ -256,25 +263,33 @@ mod tests {
 
     #[tokio::test]
     async fn async_send_timeout() {
+        use std::sync::Arc;
+
         let received = Arc::new(Mutex::new(Vec::new()));
-        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel(100);
+        // Channel to signal when receiver has taken a batch
+        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
+        // Channel to signal receiver to continue processing
+        let (_continue_processing_tx, continue_processing_rx) = tokio::sync::broadcast::channel::<()>(100);
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
 
-        // Spawn receiver task that blocks before processing
+        // Spawn receiver task that waits for signal before processing
         let received_clone = received.clone();
-        let receiver_ready_tx_clone = receiver_ready_tx.clone();
+        let continue_processing_rx_clone = continue_processing_rx.resubscribe();
         let receiver_task = tokio::task::spawn(async move {
             exec(receiver, {
                 let received = received_clone.clone();
+                let receiver_ready_tx = receiver_ready_tx.clone();
+                let continue_processing_rx = continue_processing_rx_clone;
                 move |batch| {
                     let received = received.clone();
-                    let receiver_ready_tx = receiver_ready_tx_clone.clone();
+                    let receiver_ready_tx = receiver_ready_tx.clone();
+                    let mut continue_processing_rx = continue_processing_rx.resubscribe();
                     async move {
-                        // Signal that we've received a batch and block before processing
+                        // Signal that we've received a batch
                         let _ = receiver_ready_tx.send(());
-                        // Wait for test to fill the channel again
-                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        // Wait for test to signal us to continue
+                        let _ = continue_processing_rx.recv().await;
                         received.lock().unwrap().extend(batch);
                         Ok(())
                     }
@@ -321,18 +336,24 @@ mod tests {
 
     #[tokio::test]
     async fn flush_active() {
+        use std::sync::Arc;
+
         let batch_count = Arc::new(Mutex::new(0));
+        // Channel to signal when receiver has taken first batch
+        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
         let _ = spawn("test_receiver", receiver, {
             let batch_count = batch_count.clone();
+            let receiver_ready_tx = receiver_ready_tx.clone();
             move |_batch| {
                 let batch_count = batch_count.clone();
+                let receiver_ready_tx = receiver_ready_tx.clone();
                 async move {
                     *batch_count.lock().unwrap() += 1;
-                    // Small delay to simulate processing
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    // Signal that we've taken a batch
+                    let _ = receiver_ready_tx.send(());
                     Ok(())
                 }
             }
@@ -345,7 +366,7 @@ mod tests {
         }
 
         // Wait for receiver to pick up the batch
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        receiver_ready_rx.recv().await.ok();
 
         // Send more messages (second batch)
         for i in 3..6 {
@@ -405,11 +426,17 @@ mod tests {
 
     #[tokio::test]
     async fn processes_remaining_after_drop() {
+        use crate::TestBarriers;
+        use std::sync::Arc;
+
         let received = Arc::new(Mutex::new(Vec::new()));
+        let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver, {
+        let _ = spawn("test_receiver", receiver.with_test_barriers(
+            TestBarriers::new().with_post_process(post_process_barrier.clone())
+        ), {
             let received = received.clone();
             move |batch| {
                 let received = received.clone();
@@ -427,8 +454,8 @@ mod tests {
         }
         drop(sender);
 
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait at barrier for receiver to finish processing
+        post_process_barrier.wait().await;
 
         // All messages should still be processed
         assert_eq!(vec![0, 1, 2, 3, 4], *received.lock().unwrap());
@@ -436,8 +463,15 @@ mod tests {
 
     #[tokio::test]
     async fn try_send_behavior() {
+        use crate::TestBarriers;
+        use std::sync::Arc;
+
+        let post_process_barrier = Arc::new(Barrier::new(2));
+
         let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
-        let _ = spawn("test_receiver", receiver, |batch| async move {
+        let _ = spawn("test_receiver", receiver.with_test_barriers(
+            TestBarriers::new().with_post_process(post_process_barrier.clone())
+        ), |batch| async move {
             let _ = batch;
             Ok(())
         })
@@ -452,8 +486,8 @@ mod tests {
         let result = sender.try_send(4);
         assert!(result.is_err());
 
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait at barrier for receiver to finish processing
+        post_process_barrier.wait().await;
 
         // Should succeed after processing
         assert!(sender.try_send(4).is_ok());
@@ -461,11 +495,17 @@ mod tests {
 
     #[tokio::test]
     async fn when_empty_callback() {
+        use crate::TestBarriers;
+        use std::sync::Arc;
+
         let callback_fired = Arc::new(Mutex::new(false));
+        let post_take_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver, |_batch| async move {
+        let _ = spawn("test_receiver", receiver.with_test_barriers(
+            TestBarriers::new().with_post_take(post_take_barrier.clone())
+        ), |_batch| async move {
             Ok(())
         })
         .unwrap();
@@ -481,8 +521,8 @@ mod tests {
         // Callback shouldn't fire yet (batch not taken)
         assert!(!*callback_fired.lock().unwrap());
 
-        // Wait for batch to be taken
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait at barrier for batch to be taken
+        post_take_barrier.wait().await;
 
         // Callback should have fired
         assert!(*callback_fired.lock().unwrap());
@@ -490,13 +530,17 @@ mod tests {
 
     #[tokio::test]
     async fn when_flushed_callback() {
+        use crate::TestBarriers;
+        use std::sync::Arc;
+
         let callback_fired = Arc::new(Mutex::new(false));
+        let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver, |_batch| async move {
-            // Simulate some processing time
-            tokio::time::sleep(Duration::from_millis(10)).await;
+        let _ = spawn("test_receiver", receiver.with_test_barriers(
+            TestBarriers::new().with_post_process(post_process_barrier.clone())
+        ), |_batch| async move {
             Ok(())
         })
         .unwrap();
@@ -512,8 +556,8 @@ mod tests {
         // Callback shouldn't fire yet (batch not processed)
         assert!(!*callback_fired.lock().unwrap());
 
-        // Wait for batch to be processed
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait at barrier for batch to be processed
+        post_process_barrier.wait().await;
 
         // Callback should have fired
         assert!(*callback_fired.lock().unwrap());

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -566,6 +566,28 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: try_send returns an error when the channel is closed.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel
+    /// 2. Drop the receiver to close the channel from the receiver side
+    /// 3. Attempt try_send - should fail with a non-retryable error
+    async fn try_send_on_closed_channel() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        // Drop the receiver to close the channel
+        drop(receiver);
+
+        // try_send should fail with a non-retryable error
+        let result = sender.try_send(1);
+        assert!(result.is_err());
+
+        // Verify the error is non-retryable (no messages to retry)
+        let err = result.err().unwrap();
+        assert!(err.into_retryable().is_none());
+    }
+
+    #[tokio::test]
     /// **Property**: when_empty callback fires when the channel becomes empty (batch is taken).
     ///
     /// **Sequence of events**:

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -190,4 +190,577 @@ mod tests {
 
         assert_eq!(100, *received.lock().unwrap());
     }
+
+    #[tokio::test]
+    async fn send_full_capacity() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
+
+        // Send more messages than capacity
+        for i in 0..10 {
+            sender.send(i);
+        }
+
+        // Spawn receiver after sending
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+            move |batch| {
+                let received = received.clone();
+                async move {
+                    received.lock().unwrap().extend(batch);
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Only last 5 messages should remain (0-4 were truncated)
+        assert_eq!(vec![5, 6, 7, 8, 9], *received.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn async_send_full_capacity() {
+        let received = Arc::new(Mutex::new(0));
+
+        let (sender, receiver) = crate::bounded::<Vec<()>>(5);
+
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+            move |batch| {
+                let received = received.clone();
+                async move {
+                    *received.lock().unwrap() += batch.len();
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Send more messages than capacity using async send
+        for _ in 0..10 {
+            send(&sender, (), Duration::from_secs(1))
+                .await
+                .unwrap();
+        }
+
+        // Wait for all to be processed
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // All 10 messages should be processed
+        assert_eq!(10, *received.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn async_send_timeout() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel(100);
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
+
+        // Spawn receiver task that blocks before processing
+        let received_clone = received.clone();
+        let receiver_ready_tx_clone = receiver_ready_tx.clone();
+        let receiver_task = tokio::task::spawn(async move {
+            exec(receiver, {
+                let received = received_clone.clone();
+                move |batch| {
+                    let received = received.clone();
+                    let receiver_ready_tx = receiver_ready_tx_clone.clone();
+                    async move {
+                        // Signal that we've received a batch and block before processing
+                        let _ = receiver_ready_tx.send(());
+                        // Wait for test to fill the channel again
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
+                }
+            })
+            .await
+        });
+
+        // Fill the channel initially
+        for i in 0..5 {
+            sender.send(i);
+        }
+
+        // Wait for receiver to pick up the batch and signal
+        receiver_ready_rx.recv().await.ok();
+
+        // Now the channel is empty (receiver has it), fill it again
+        for i in 0..5 {
+            sender.send(i);
+        }
+
+        // Try to send with short timeout - should fail because channel is full
+        let result = send(&sender, 99, Duration::from_millis(10)).await;
+        assert!(result.is_err());
+
+        // Clean up - abort the receiver task
+        receiver_task.abort();
+        let _ = receiver_task.await;
+    }
+
+    #[tokio::test]
+    async fn flush_empty() {
+        let (sender, receiver) = crate::bounded::<Vec<()>>(10);
+
+        let _ = spawn("test_receiver", receiver, |batch| async move {
+            let _ = batch;
+            Ok(())
+        })
+        .unwrap();
+
+        // Flush with zero timeout on empty channel should succeed immediately
+        assert!(flush(&sender, Duration::ZERO).await);
+    }
+
+    #[tokio::test]
+    async fn flush_active() {
+        let batch_count = Arc::new(Mutex::new(0));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, {
+            let batch_count = batch_count.clone();
+            move |_batch| {
+                let batch_count = batch_count.clone();
+                async move {
+                    *batch_count.lock().unwrap() += 1;
+                    // Small delay to simulate processing
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Send initial batch
+        for i in 0..3 {
+            sender.send(i);
+        }
+
+        // Wait for receiver to pick up the batch
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Send more messages (second batch)
+        for i in 3..6 {
+            sender.send(i);
+        }
+
+        // Flush should wait for both batches to complete
+        let flushed = flush(&sender, Duration::from_secs(1)).await;
+        assert!(flushed);
+
+        // Both batches should have been processed
+        assert!(*batch_count.lock().unwrap() >= 1);
+    }
+
+    #[tokio::test]
+    async fn retry_on_batch_failure() {
+        let attempt_count = Arc::new(Mutex::new(0));
+        let received = Arc::new(Mutex::new(false));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, {
+            let attempt_count = attempt_count.clone();
+            let received = received.clone();
+            move |batch| {
+                let attempt_count = attempt_count.clone();
+                let received = received.clone();
+                async move {
+                    let mut count = attempt_count.lock().unwrap();
+                    *count += 1;
+
+                    // Fail first two attempts, succeed on third
+                    if *count < 3 {
+                        Err(BatchError::retry(
+                            std::io::Error::new(std::io::ErrorKind::Other, "temporary failure"),
+                            batch,
+                        ))
+                    } else {
+                        *received.lock().unwrap() = true;
+                        Ok(())
+                    }
+                }
+            }
+        })
+        .unwrap();
+
+        sender.send(42);
+
+        // Wait for retries to complete (700ms delay between retries, need 3 attempts)
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Should have 3 attempts: 1 initial + 2 retries
+        let count = *attempt_count.lock().unwrap();
+        assert!(count >= 2, "Should have at least 2 attempts, got {}", count);
+        assert!(*received.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn processes_remaining_after_drop() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+            move |batch| {
+                let received = received.clone();
+                async move {
+                    received.lock().unwrap().extend(batch);
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Send messages and drop sender
+        for i in 0..5 {
+            sender.send(i);
+        }
+        drop(sender);
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // All messages should still be processed
+        assert_eq!(vec![0, 1, 2, 3, 4], *received.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn try_send_behavior() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
+        let _ = spawn("test_receiver", receiver, |batch| async move {
+            let _ = batch;
+            Ok(())
+        })
+        .unwrap();
+
+        // Successful sends
+        assert!(sender.try_send(1).is_ok());
+        assert!(sender.try_send(2).is_ok());
+        assert!(sender.try_send(3).is_ok());
+
+        // Should fail when at capacity
+        let result = sender.try_send(4);
+        assert!(result.is_err());
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Should succeed after processing
+        assert!(sender.try_send(4).is_ok());
+    }
+
+    #[tokio::test]
+    async fn when_empty_callback() {
+        let callback_fired = Arc::new(Mutex::new(false));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, |_batch| async move {
+            Ok(())
+        })
+        .unwrap();
+
+        // Send a message
+        sender.send(1);
+
+        let callback_fired_clone = callback_fired.clone();
+        sender.when_empty(move || {
+            *callback_fired_clone.lock().unwrap() = true;
+        });
+
+        // Callback shouldn't fire yet (batch not taken)
+        assert!(!*callback_fired.lock().unwrap());
+
+        // Wait for batch to be taken
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Callback should have fired
+        assert!(*callback_fired.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn when_flushed_callback() {
+        let callback_fired = Arc::new(Mutex::new(false));
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, |_batch| async move {
+            // Simulate some processing time
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            Ok(())
+        })
+        .unwrap();
+
+        // Send a message
+        sender.send(1);
+
+        let callback_fired_clone = callback_fired.clone();
+        sender.when_flushed(move || {
+            *callback_fired_clone.lock().unwrap() = true;
+        });
+
+        // Callback shouldn't fire yet (batch not processed)
+        assert!(!*callback_fired.lock().unwrap());
+
+        // Wait for batch to be processed
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Callback should have fired
+        assert!(*callback_fired.lock().unwrap());
+    }
+}
+
+#[cfg(test)]
+mod quickcheck_tests {
+    use crate::tokio::{flush, spawn};
+    use crate::bounded;
+
+    use quickcheck_macros::quickcheck;
+    use std::sync::{Arc, Mutex};
+    use tokio::time::{sleep, Duration};
+
+    #[quickcheck]
+    fn prop_all_messages_received(messages: Vec<i32>) {
+        if messages.is_empty() || messages.len() > 1000 {
+            return;
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let received = Arc::new(Mutex::new(Vec::new()));
+            let (sender, receiver) = bounded::<Vec<i32>>(1024);
+
+            let _ = spawn("test_receiver", receiver, {
+                let received = received.clone();
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
+                }
+            })
+            .unwrap();
+
+            // Send all messages
+            for msg in &messages {
+                sender.send(*msg);
+            }
+
+            // Wait for processing
+            flush(&sender, Duration::from_secs(1)).await;
+            sleep(Duration::from_millis(50)).await;
+
+            // Verify all messages were received (order may vary due to batching)
+            let mut received_vec = received.lock().unwrap().clone();
+            received_vec.sort();
+            let mut expected = messages.clone();
+            expected.sort();
+
+            assert_eq!(expected, received_vec);
+        });
+    }
+
+    #[quickcheck]
+    fn prop_truncation_keeps_most_recent(capacity: usize, extra_messages: usize) {
+        // Constrain to reasonable values - ensure we have meaningful test data
+        let capacity = (capacity % 50) + 1; // 1-50
+        let extra_messages = (extra_messages % 100) + 1; // 1-100
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let received = Arc::new(Mutex::new(Vec::new()));
+            let (sender, receiver) = bounded::<Vec<usize>>(capacity);
+
+            // Send more messages than capacity BEFORE spawning receiver
+            // This ensures truncation happens in the channel buffer
+            for i in 0..(capacity + extra_messages) {
+                sender.send(i);
+            }
+
+            // Spawn receiver after sending - it will only see the most recent messages
+            let _ = spawn("test_receiver", receiver, {
+                let received = received.clone();
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
+                }
+            })
+            .unwrap();
+
+            // Wait for processing
+            sleep(Duration::from_millis(200)).await;
+
+            let received_vec = received.lock().unwrap();
+
+            // After truncation, we should have at most capacity messages
+            // The actual count depends on how many messages were sent after the last truncation
+            assert!(
+                received_vec.len() <= capacity,
+                "Should receive at most capacity messages, got {}",
+                received_vec.len()
+            );
+
+            // All received messages should be >= extra_messages (the most recent ones after truncation)
+            // This verifies that older messages were dropped
+            for &msg in received_vec.iter() {
+                assert!(
+                    msg >= extra_messages,
+                    "All messages should be the most recent ones (>= {}), got {}",
+                    extra_messages,
+                    msg
+                );
+            }
+        });
+    }
+
+    #[quickcheck]
+    fn prop_batch_sizes_are_consistent(message_count: usize, capacity: usize) {
+        // Constrain values - ensure message_count <= capacity to avoid truncation
+        let capacity = (capacity % 100) + 1; // 1-100
+        let message_count = (message_count % capacity) + 1; // 1-capacity
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
+
+            let _ = spawn("test_receiver", receiver, {
+                let batch_sizes = batch_sizes.clone();
+                move |batch| {
+                    let batch_sizes = batch_sizes.clone();
+                    async move {
+                        batch_sizes.lock().unwrap().push(batch.len());
+                        Ok(())
+                    }
+                }
+            })
+            .unwrap();
+
+            // Send messages (within capacity, so no truncation)
+            for _ in 0..message_count {
+                sender.send(42i32);
+            }
+
+            sleep(Duration::from_millis(200)).await;
+
+            let batch_sizes = batch_sizes.lock().unwrap();
+
+            // Total messages processed should equal sent messages
+            let total_processed: usize = batch_sizes.iter().sum();
+            assert_eq!(total_processed, message_count, "All messages should be processed");
+
+            // No batch should exceed capacity
+            for &size in batch_sizes.iter() {
+                assert!(size <= capacity, "Batch size should not exceed capacity");
+            }
+        });
+    }
+
+    #[quickcheck]
+    fn prop_flush_guarantees_completion(message_count: usize, capacity: usize) {
+        // Constrain values - ensure message_count <= capacity to avoid truncation
+        let capacity = (capacity % 100) + 1; // 1-100
+        let message_count = (message_count % capacity) + 1; // 1-capacity
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let received = Arc::new(Mutex::new(0usize));
+            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
+
+            let _ = spawn("test_receiver", receiver, {
+                let received = received.clone();
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        *received.lock().unwrap() += batch.len();
+                        // Add variable delay to simulate real processing
+                        sleep(Duration::from_millis((batch.len() % 10) as u64)).await;
+                        Ok(())
+                    }
+                }
+            })
+            .unwrap();
+
+            // Send messages (within capacity, so no truncation)
+            for _ in 0..message_count {
+                sender.send(42i32);
+            }
+
+            // Flush should wait for all to complete
+            let flushed = flush(&sender, Duration::from_secs(5)).await;
+            assert!(flushed, "Flush should complete within timeout");
+
+            // All messages should be processed
+            assert_eq!(*received.lock().unwrap(), message_count);
+        });
+    }
+
+    #[quickcheck]
+    fn prop_drop_sender_preserves_messages(message_count: usize, capacity: usize) {
+        // Constrain values - ensure message_count <= capacity to avoid truncation
+        let capacity = (capacity % 100) + 1; // 1-100
+        let message_count = (message_count % capacity) + 1; // 1-capacity
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let received = Arc::new(Mutex::new(Vec::new()));
+            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
+
+            let _ = spawn("test_receiver", receiver, {
+                let received = received.clone();
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
+                }
+            })
+            .unwrap();
+
+            // Send messages (within capacity, so no truncation)
+            for i in 0..message_count {
+                sender.send(i as i32);
+            }
+
+            // Drop sender immediately
+            drop(sender);
+
+            // Wait for processing
+            sleep(Duration::from_millis(200)).await;
+
+            // All messages should still be processed
+            let received_vec = received.lock().unwrap();
+            assert_eq!(received_vec.len(), message_count);
+        });
+    }
 }

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -160,6 +160,14 @@ mod tests {
     use ::tokio::sync::Barrier;
 
     #[tokio::test]
+    /// **Property**: Async send and flush work correctly for high-volume message processing.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver task that counts processed messages
+    /// 3. Send 100 messages using async send (blocks when at capacity)
+    /// 4. Call flush to wait for all messages to be processed
+    /// 5. Verify all 100 messages were received and counted
     async fn async_send_recv_flush() {
         let received = Arc::new(Mutex::new(0));
 
@@ -193,6 +201,15 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Channel truncates oldest messages when capacity is exceeded (tokio variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Send 10 messages (exceeding capacity, causing truncation of 0-4)
+    /// 3. Spawn receiver with post_process barrier for synchronization
+    /// 4. Receiver processes the remaining batch
+    /// 5. Wait at barrier for processing to complete
+    /// 6. Verify only messages 5-9 were received (first 5 truncated)
     async fn send_full_capacity() {
         use crate::TestBarriers;
         use std::sync::Arc;
@@ -230,6 +247,14 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Async send with blocking ensures all messages are processed even when exceeding capacity.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Spawn receiver task
+    /// 3. Send 10 messages using async send (blocks when full, waits for capacity)
+    /// 4. Call flush to wait for all processing to complete
+    /// 5. Verify all 10 messages were processed (no truncation because async_send waits)
     async fn async_send_full_capacity() {
         let received = Arc::new(Mutex::new(0));
 
@@ -262,35 +287,39 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Async send times out when channel remains at capacity.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Spawn receiver that takes first batch then blocks indefinitely (using Semaphore(0))
+    /// 3. Fill channel with 5 messages
+    /// 4. Wait for receiver to take the batch and block
+    /// 5. Fill channel again with 5 messages (now at capacity)
+    /// 6. Attempt async send with 10ms timeout - should fail (channel full, receiver blocked)
+    /// 7. Abort receiver task to clean up
     async fn async_send_timeout() {
-        use std::sync::Arc;
+        use tokio::sync::Semaphore;
 
-        let received = Arc::new(Mutex::new(Vec::new()));
         // Channel to signal when receiver has taken a batch
         let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
-        // Channel to signal receiver to continue processing
-        let (_continue_processing_tx, continue_processing_rx) = tokio::sync::broadcast::channel::<()>(100);
+        // Semaphore with 0 permits - blocks forever (until cancelled)
+        let blocker = Arc::new(Semaphore::new(0));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
 
-        // Spawn receiver task that waits for signal before processing
-        let received_clone = received.clone();
-        let continue_processing_rx_clone = continue_processing_rx.resubscribe();
+        // Spawn receiver task that blocks after taking first batch
         let receiver_task = tokio::task::spawn(async move {
             exec(receiver, {
-                let received = received_clone.clone();
                 let receiver_ready_tx = receiver_ready_tx.clone();
-                let continue_processing_rx = continue_processing_rx_clone;
-                move |batch| {
-                    let received = received.clone();
+                let blocker = blocker.clone();
+                move |_batch| {
                     let receiver_ready_tx = receiver_ready_tx.clone();
-                    let mut continue_processing_rx = continue_processing_rx.resubscribe();
+                    let blocker = blocker.clone();
                     async move {
                         // Signal that we've received a batch
                         let _ = receiver_ready_tx.send(());
-                        // Wait for test to signal us to continue
-                        let _ = continue_processing_rx.recv().await;
-                        received.lock().unwrap().extend(batch);
+                        // Block forever - acquire will never complete (until task is cancelled)
+                        let _ = blocker.acquire().await;
                         Ok(())
                     }
                 }
@@ -321,6 +350,13 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Flush on an empty channel with zero timeout succeeds immediately (tokio variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver task
+    /// 3. Call flush with zero timeout on empty channel
+    /// 4. Flush returns true immediately (nothing to wait for)
     async fn flush_empty() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(10);
 
@@ -335,6 +371,16 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Flush waits for all active and in-flight batches to complete (tokio variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver that signals when it takes a batch
+    /// 3. Send 3 messages to start first batch
+    /// 4. Wait for receiver to pick up first batch
+    /// 5. Send 3 more messages (second batch, queued while first is processing)
+    /// 6. Call flush - should wait for both batches to complete
+    /// 7. Verify flush succeeded and at least one batch was processed
     async fn flush_active() {
         use std::sync::Arc;
 
@@ -382,6 +428,14 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Batch processing retries on temporary failures until success or max retries.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver that fails twice then succeeds on third attempt
+    /// 3. Send a single message
+    /// 4. Wait for retry logic to complete (3 attempts with 700ms backoff)
+    /// 5. Verify at least 2 attempts were made and message was eventually received
     async fn retry_on_batch_failure() {
         let attempt_count = Arc::new(Mutex::new(0));
         let received = Arc::new(Mutex::new(false));
@@ -425,6 +479,15 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: Receiver processes all remaining messages after sender is dropped.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver with post_process barrier for synchronization
+    /// 3. Send 5 messages to the channel
+    /// 4. Drop the sender (signals channel is closed)
+    /// 5. Wait at barrier for receiver to finish processing
+    /// 6. Verify all 5 messages were processed despite sender being dropped
     async fn processes_remaining_after_drop() {
         use crate::TestBarriers;
         use std::sync::Arc;
@@ -462,6 +525,15 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: try_send succeeds when under capacity and fails immediately when at capacity.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 3
+    /// 2. Spawn receiver with post_process barrier for synchronization
+    /// 3. Send 3 messages using try_send (should all succeed)
+    /// 4. Attempt 4th try_send - should fail immediately (at capacity)
+    /// 5. Wait at barrier for receiver to process the batch
+    /// 6. Attempt try_send again - should succeed (capacity freed)
     async fn try_send_behavior() {
         use crate::TestBarriers;
         use std::sync::Arc;
@@ -494,6 +566,16 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: when_empty callback fires when the channel becomes empty (batch is taken).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver with post_take barrier for synchronization
+    /// 3. Send a single message
+    /// 4. Register when_empty callback
+    /// 5. Verify callback hasn't fired yet (batch not taken)
+    /// 6. Wait at barrier for receiver to take the batch
+    /// 7. Verify callback fired after batch was taken (channel empty)
     async fn when_empty_callback() {
         use crate::TestBarriers;
         use std::sync::Arc;
@@ -529,6 +611,16 @@ mod tests {
     }
 
     #[tokio::test]
+    /// **Property**: when_flushed callback fires when a batch is fully processed.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 10
+    /// 2. Spawn receiver with post_process barrier for synchronization
+    /// 3. Send a single message
+    /// 4. Register when_flushed callback
+    /// 5. Verify callback hasn't fired yet (batch not processed)
+    /// 6. Wait at barrier for receiver to finish processing
+    /// 7. Verify callback fired after batch was flushed
     async fn when_flushed_callback() {
         use crate::TestBarriers;
         use std::sync::Arc;
@@ -573,6 +665,15 @@ mod quickcheck_tests {
     use std::sync::{Arc, Mutex};
     use tokio::time::{sleep, Duration};
 
+     /// **Property**: All sent messages are eventually received (property-based test).
+    ///
+    /// **Sequence of events**:
+    /// 1. Generate random vector of messages (1-1000 messages)
+    /// 2. Create a bounded channel with capacity 1024
+    /// 3. Spawn receiver that collects all received messages
+    /// 4. Send all messages to the channel
+    /// 5. Flush to wait for all processing to complete
+    /// 6. Verify all messages were received (sorted comparison, order may vary)
     #[quickcheck]
     fn prop_all_messages_received(messages: Vec<i32>) {
         if messages.is_empty() || messages.len() > 1000 {
@@ -618,6 +719,15 @@ mod quickcheck_tests {
         });
     }
 
+    /// **Property**: Channel truncation keeps only the most recent messages (property-based test).
+    ///
+    /// **Sequence of events**:
+    /// 1. Generate random capacity (1-50) and extra_messages (1-100)
+    /// 2. Create a bounded channel with the generated capacity
+    /// 3. Send (capacity + extra_messages) messages BEFORE spawning receiver
+    /// 4. Spawn receiver after truncation has occurred
+    /// 5. Wait for processing to complete
+    /// 6. Verify: received count <= capacity, all messages are the most recent ones
     #[quickcheck]
     fn prop_truncation_keeps_most_recent(capacity: usize, extra_messages: usize) {
         // Constrain to reasonable values - ensure we have meaningful test data
@@ -677,6 +787,15 @@ mod quickcheck_tests {
         });
     }
 
+    /// **Property**: Batch sizes are consistent - total processed equals sent, no batch exceeds capacity (property-based test).
+    ///
+    /// **Sequence of events**:
+    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
+    /// 2. Create a bounded channel with the generated capacity
+    /// 3. Spawn receiver that records batch sizes
+    /// 4. Send message_count messages (within capacity, no truncation)
+    /// 5. Wait for processing to complete
+    /// 6. Verify: sum of batch sizes equals message_count, no batch exceeds capacity
     #[quickcheck]
     fn prop_batch_sizes_are_consistent(message_count: usize, capacity: usize) {
         // Constrain values - ensure message_count <= capacity to avoid truncation
@@ -723,6 +842,15 @@ mod quickcheck_tests {
         });
     }
 
+    /// **Property**: Flush guarantees all messages are processed before returning (property-based test).
+    ///
+    /// **Sequence of events**:
+    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
+    /// 2. Create a bounded channel with the generated capacity
+    /// 3. Spawn receiver with variable processing delay
+    /// 4. Send message_count messages (within capacity, no truncation)
+    /// 5. Call flush with 5s timeout - should wait for all processing
+    /// 6. Verify: flush succeeded and all messages were processed
     #[quickcheck]
     fn prop_flush_guarantees_completion(message_count: usize, capacity: usize) {
         // Constrain values - ensure message_count <= capacity to avoid truncation
@@ -765,6 +893,16 @@ mod quickcheck_tests {
         });
     }
 
+    /// **Property**: Dropping sender doesn't lose messages - receiver still processes all buffered messages (property-based test).
+    ///
+    /// **Sequence of events**:
+    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
+    /// 2. Create a bounded channel with the generated capacity
+    /// 3. Spawn receiver that collects all received messages
+    /// 4. Send message_count messages (within capacity, no truncation)
+    /// 5. Drop sender immediately (signals channel is closed)
+    /// 6. Wait for processing to complete
+    /// 7. Verify: all messages were processed despite sender being dropped
     #[quickcheck]
     fn prop_drop_sender_preserves_messages(message_count: usize, capacity: usize) {
         // Constrain values - ensure message_count <= capacity to avoid truncation

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -156,8 +156,10 @@ async fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duratio
 mod tests {
     use super::*;
 
-    use ::tokio::sync::Barrier;
     use std::sync::{Arc, Mutex};
+    use tokio::sync::{Barrier, Semaphore};
+
+    use crate::TestBarriers;
 
     #[tokio::test]
     /// **Property**: Async send and flush work correctly for high-volume message processing.
@@ -211,9 +213,6 @@ mod tests {
     /// 5. Wait at barrier for processing to complete
     /// 6. Verify only messages 5-9 were received (first 5 truncated)
     async fn send_full_capacity() {
-        use crate::TestBarriers;
-        use std::sync::Arc;
-
         let received = Arc::new(Mutex::new(Vec::new()));
         let post_process_barrier = Arc::new(Barrier::new(2));
 
@@ -300,8 +299,6 @@ mod tests {
     /// 6. Attempt async send with 10ms timeout - should fail (channel full, receiver blocked)
     /// 7. Abort receiver task to clean up
     async fn async_send_timeout() {
-        use tokio::sync::Semaphore;
-
         // Channel to signal when receiver has taken a batch
         let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
         // Semaphore with 0 permits - blocks forever (until cancelled)
@@ -384,8 +381,6 @@ mod tests {
     /// 6. Call flush - should wait for both batches to complete
     /// 7. Verify flush succeeded and at least one batch was processed
     async fn flush_active() {
-        use std::sync::Arc;
-
         let batch_count = Arc::new(Mutex::new(0));
         // Channel to signal when receiver has taken first batch
         let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
@@ -491,9 +486,6 @@ mod tests {
     /// 5. Wait at barrier for receiver to finish processing
     /// 6. Verify all 5 messages were processed despite sender being dropped
     async fn processes_remaining_after_drop() {
-        use crate::TestBarriers;
-        use std::sync::Arc;
-
         let received = Arc::new(Mutex::new(Vec::new()));
         let post_process_barrier = Arc::new(Barrier::new(2));
 
@@ -541,9 +533,6 @@ mod tests {
     /// 5. Wait at barrier for receiver to process the batch
     /// 6. Attempt try_send again - should succeed (capacity freed)
     async fn try_send_behavior() {
-        use crate::TestBarriers;
-        use std::sync::Arc;
-
         let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
@@ -609,9 +598,6 @@ mod tests {
     /// 6. Wait at barrier for receiver to take the batch
     /// 7. Verify callback fired after batch was taken (channel empty)
     async fn when_empty_callback() {
-        use crate::TestBarriers;
-        use std::sync::Arc;
-
         let callback_fired = Arc::new(Mutex::new(false));
         let post_take_barrier = Arc::new(Barrier::new(2));
 
@@ -655,9 +641,6 @@ mod tests {
     /// 6. Wait at barrier for receiver to finish processing
     /// 7. Verify callback fired after batch was flushed
     async fn when_flushed_callback() {
-        use crate::TestBarriers;
-        use std::sync::Arc;
-
         let callback_fired = Arc::new(Mutex::new(false));
         let post_process_barrier = Arc::new(Barrier::new(2));
 

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -162,14 +162,6 @@ mod tests {
     use crate::TestBarriers;
 
     #[tokio::test]
-    /// **Property**: Async send and flush work correctly for high-volume message processing.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver task that counts processed messages
-    /// 3. Send 100 messages using async send (blocks when at capacity)
-    /// 4. Call flush to wait for all messages to be processed
-    /// 5. Verify all 100 messages were received and counted
     async fn async_send_recv_flush() {
         let received = Arc::new(Mutex::new(0));
 
@@ -203,15 +195,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Channel truncates oldest messages when capacity is exceeded (tokio variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Send 10 messages (exceeding capacity, causing truncation of 0-4)
-    /// 3. Spawn receiver with post_process barrier for synchronization
-    /// 4. Receiver processes the remaining batch
-    /// 5. Wait at barrier for processing to complete
-    /// 6. Verify only messages 5-9 were received (first 5 truncated)
     async fn send_full_capacity() {
         let received = Arc::new(Mutex::new(Vec::new()));
         let post_process_barrier = Arc::new(Barrier::new(2));
@@ -226,9 +209,10 @@ mod tests {
         // Spawn receiver after sending, with barrier after processing
         let _ = spawn(
             "test_receiver",
-            receiver.with_test_barriers(
-                TestBarriers::new().with_post_process(post_process_barrier.clone()),
-            ),
+            receiver.with_test_barriers(TestBarriers {
+                post_process: Some(post_process_barrier.clone()),
+                ..Default::default()
+            }),
             {
                 let received = received.clone();
                 move |batch| {
@@ -250,14 +234,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Async send with blocking ensures all messages are processed even when exceeding capacity.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Spawn receiver task
-    /// 3. Send 10 messages using async send (blocks when full, waits for capacity)
-    /// 4. Call flush to wait for all processing to complete
-    /// 5. Verify all 10 messages were processed (no truncation because async_send waits)
     async fn async_send_full_capacity() {
         let received = Arc::new(Mutex::new(0));
 
@@ -288,16 +264,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Async send times out when channel remains at capacity.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Spawn receiver that takes first batch then blocks indefinitely (using Semaphore(0))
-    /// 3. Fill channel with 5 messages
-    /// 4. Wait for receiver to take the batch and block
-    /// 5. Fill channel again with 5 messages (now at capacity)
-    /// 6. Attempt async send with 10ms timeout - should fail (channel full, receiver blocked)
-    /// 7. Abort receiver task to clean up
     async fn async_send_timeout() {
         // Channel to signal when receiver has taken a batch
         let (receiver_ready_tx, mut receiver_ready_rx) = tokio::sync::broadcast::channel::<()>(100);
@@ -349,13 +315,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Flush on an empty channel with zero timeout succeeds immediately (tokio variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver task
-    /// 3. Call flush with zero timeout on empty channel
-    /// 4. Flush returns true immediately (nothing to wait for)
     async fn flush_empty() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(10);
 
@@ -370,16 +329,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Flush waits for all active and in-flight batches to complete (tokio variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver that signals when it takes a batch
-    /// 3. Send 3 messages to start first batch
-    /// 4. Wait for receiver to pick up first batch
-    /// 5. Send 3 more messages (second batch, queued while first is processing)
-    /// 6. Call flush - should wait for both batches to complete
-    /// 7. Verify flush succeeded and at least one batch was processed
     async fn flush_active() {
         let batch_count = Arc::new(Mutex::new(0));
         // Channel to signal when receiver has taken first batch
@@ -425,14 +374,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Batch processing retries on temporary failures until success or max retries.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver that fails twice then succeeds on third attempt
-    /// 3. Send a single message
-    /// 4. Wait for retry logic to complete (3 attempts with 700ms backoff)
-    /// 5. Verify at least 2 attempts were made and message was eventually received
     async fn retry_on_batch_failure() {
         let attempt_count = Arc::new(Mutex::new(0));
         let received = Arc::new(Mutex::new(false));
@@ -476,15 +417,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: Receiver processes all remaining messages after sender is dropped.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver with post_process barrier for synchronization
-    /// 3. Send 5 messages to the channel
-    /// 4. Drop the sender (signals channel is closed)
-    /// 5. Wait at barrier for receiver to finish processing
-    /// 6. Verify all 5 messages were processed despite sender being dropped
     async fn processes_remaining_after_drop() {
         let received = Arc::new(Mutex::new(Vec::new()));
         let post_process_barrier = Arc::new(Barrier::new(2));
@@ -493,9 +425,10 @@ mod tests {
 
         let _ = spawn(
             "test_receiver",
-            receiver.with_test_barriers(
-                TestBarriers::new().with_post_process(post_process_barrier.clone()),
-            ),
+            receiver.with_test_barriers(TestBarriers {
+                post_process: Some(post_process_barrier.clone()),
+                ..Default::default()
+            }),
             {
                 let received = received.clone();
                 move |batch| {
@@ -523,24 +456,16 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: try_send succeeds when under capacity and fails immediately when at capacity.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 3
-    /// 2. Spawn receiver with post_process barrier for synchronization
-    /// 3. Send 3 messages using try_send (should all succeed)
-    /// 4. Attempt 4th try_send - should fail immediately (at capacity)
-    /// 5. Wait at barrier for receiver to process the batch
-    /// 6. Attempt try_send again - should succeed (capacity freed)
     async fn try_send_behavior() {
         let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
         let _ = spawn(
             "test_receiver",
-            receiver.with_test_barriers(
-                TestBarriers::new().with_post_process(post_process_barrier.clone()),
-            ),
+            receiver.with_test_barriers(TestBarriers {
+                post_process: Some(post_process_barrier.clone()),
+                ..Default::default()
+            }),
             |batch| async move {
                 let _ = batch;
                 Ok(())
@@ -565,12 +490,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: try_send returns an error when the channel is closed.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel
-    /// 2. Drop the receiver to close the channel from the receiver side
-    /// 3. Attempt try_send - should fail with a non-retryable error
     async fn try_send_on_closed_channel() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
@@ -587,16 +506,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: when_empty callback fires when the channel becomes empty (batch is taken).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver with post_take barrier for synchronization
-    /// 3. Send a single message
-    /// 4. Register when_empty callback
-    /// 5. Verify callback hasn't fired yet (batch not taken)
-    /// 6. Wait at barrier for receiver to take the batch
-    /// 7. Verify callback fired after batch was taken (channel empty)
     async fn when_empty_callback() {
         let callback_fired = Arc::new(Mutex::new(false));
         let post_take_barrier = Arc::new(Barrier::new(2));
@@ -605,8 +514,10 @@ mod tests {
 
         let _ = spawn(
             "test_receiver",
-            receiver
-                .with_test_barriers(TestBarriers::new().with_post_take(post_take_barrier.clone())),
+            receiver.with_test_barriers(TestBarriers {
+                post_take: Some(post_take_barrier.clone()),
+                ..Default::default()
+            }),
             |_batch| async move { Ok(()) },
         )
         .unwrap();
@@ -630,16 +541,6 @@ mod tests {
     }
 
     #[tokio::test]
-    /// **Property**: when_flushed callback fires when a batch is fully processed.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 10
-    /// 2. Spawn receiver with post_process barrier for synchronization
-    /// 3. Send a single message
-    /// 4. Register when_flushed callback
-    /// 5. Verify callback hasn't fired yet (batch not processed)
-    /// 6. Wait at barrier for receiver to finish processing
-    /// 7. Verify callback fired after batch was flushed
     async fn when_flushed_callback() {
         let callback_fired = Arc::new(Mutex::new(false));
         let post_process_barrier = Arc::new(Barrier::new(2));
@@ -648,9 +549,10 @@ mod tests {
 
         let _ = spawn(
             "test_receiver",
-            receiver.with_test_barriers(
-                TestBarriers::new().with_post_process(post_process_barrier.clone()),
-            ),
+            receiver.with_test_barriers(TestBarriers {
+                post_process: Some(post_process_barrier.clone()),
+                ..Default::default()
+            }),
             |_batch| async move { Ok(()) },
         )
         .unwrap();

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -156,8 +156,8 @@ async fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duratio
 mod tests {
     use super::*;
 
-    use std::sync::{Arc, Mutex};
     use ::tokio::sync::Barrier;
+    use std::sync::{Arc, Mutex};
 
     #[tokio::test]
     /// **Property**: Async send and flush work correctly for high-volume message processing.
@@ -225,18 +225,22 @@ mod tests {
         }
 
         // Spawn receiver after sending, with barrier after processing
-        let _ = spawn("test_receiver", receiver.with_test_barriers(
-            TestBarriers::new().with_post_process(post_process_barrier.clone())
-        ), {
-            let received = received.clone();
-            move |batch| {
+        let _ = spawn(
+            "test_receiver",
+            receiver.with_test_barriers(
+                TestBarriers::new().with_post_process(post_process_barrier.clone()),
+            ),
+            {
                 let received = received.clone();
-                async move {
-                    received.lock().unwrap().extend(batch);
-                    Ok(())
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
                 }
-            }
-        })
+            },
+        )
         .unwrap();
 
         // Wait at barrier for receiver to finish processing
@@ -274,9 +278,7 @@ mod tests {
 
         // Send more messages than capacity using async send
         for _ in 0..10 {
-            send(&sender, (), Duration::from_secs(1))
-                .await
-                .unwrap();
+            send(&sender, (), Duration::from_secs(1)).await.unwrap();
         }
 
         // Use flush to wait for all messages to be processed
@@ -497,18 +499,22 @@ mod tests {
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver.with_test_barriers(
-            TestBarriers::new().with_post_process(post_process_barrier.clone())
-        ), {
-            let received = received.clone();
-            move |batch| {
+        let _ = spawn(
+            "test_receiver",
+            receiver.with_test_barriers(
+                TestBarriers::new().with_post_process(post_process_barrier.clone()),
+            ),
+            {
                 let received = received.clone();
-                async move {
-                    received.lock().unwrap().extend(batch);
-                    Ok(())
+                move |batch| {
+                    let received = received.clone();
+                    async move {
+                        received.lock().unwrap().extend(batch);
+                        Ok(())
+                    }
                 }
-            }
-        })
+            },
+        )
         .unwrap();
 
         // Send messages and drop sender
@@ -541,12 +547,16 @@ mod tests {
         let post_process_barrier = Arc::new(Barrier::new(2));
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
-        let _ = spawn("test_receiver", receiver.with_test_barriers(
-            TestBarriers::new().with_post_process(post_process_barrier.clone())
-        ), |batch| async move {
-            let _ = batch;
-            Ok(())
-        })
+        let _ = spawn(
+            "test_receiver",
+            receiver.with_test_barriers(
+                TestBarriers::new().with_post_process(post_process_barrier.clone()),
+            ),
+            |batch| async move {
+                let _ = batch;
+                Ok(())
+            },
+        )
         .unwrap();
 
         // Successful sends
@@ -607,11 +617,12 @@ mod tests {
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver.with_test_barriers(
-            TestBarriers::new().with_post_take(post_take_barrier.clone())
-        ), |_batch| async move {
-            Ok(())
-        })
+        let _ = spawn(
+            "test_receiver",
+            receiver
+                .with_test_barriers(TestBarriers::new().with_post_take(post_take_barrier.clone())),
+            |_batch| async move { Ok(()) },
+        )
         .unwrap();
 
         // Send a message
@@ -652,11 +663,13 @@ mod tests {
 
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn("test_receiver", receiver.with_test_barriers(
-            TestBarriers::new().with_post_process(post_process_barrier.clone())
-        ), |_batch| async move {
-            Ok(())
-        })
+        let _ = spawn(
+            "test_receiver",
+            receiver.with_test_barriers(
+                TestBarriers::new().with_post_process(post_process_barrier.clone()),
+            ),
+            |_batch| async move { Ok(()) },
+        )
         .unwrap();
 
         // Send a message
@@ -675,296 +688,5 @@ mod tests {
 
         // Callback should have fired
         assert!(*callback_fired.lock().unwrap());
-    }
-}
-
-#[cfg(test)]
-mod quickcheck_tests {
-    use crate::tokio::{flush, spawn};
-    use crate::bounded;
-
-    use quickcheck_macros::quickcheck;
-    use std::sync::{Arc, Mutex};
-    use tokio::time::{sleep, Duration};
-
-     /// **Property**: All sent messages are eventually received (property-based test).
-    ///
-    /// **Sequence of events**:
-    /// 1. Generate random vector of messages (1-1000 messages)
-    /// 2. Create a bounded channel with capacity 1024
-    /// 3. Spawn receiver that collects all received messages
-    /// 4. Send all messages to the channel
-    /// 5. Flush to wait for all processing to complete
-    /// 6. Verify all messages were received (sorted comparison, order may vary)
-    #[quickcheck]
-    fn prop_all_messages_received(messages: Vec<i32>) {
-        if messages.is_empty() || messages.len() > 1000 {
-            return;
-        }
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let received = Arc::new(Mutex::new(Vec::new()));
-            let (sender, receiver) = bounded::<Vec<i32>>(1024);
-
-            let _ = spawn("test_receiver", receiver, {
-                let received = received.clone();
-                move |batch| {
-                    let received = received.clone();
-                    async move {
-                        received.lock().unwrap().extend(batch);
-                        Ok(())
-                    }
-                }
-            })
-            .unwrap();
-
-            // Send all messages
-            for msg in &messages {
-                sender.send(*msg);
-            }
-
-            // Wait for processing
-            flush(&sender, Duration::from_secs(1)).await;
-            sleep(Duration::from_millis(50)).await;
-
-            // Verify all messages were received (order may vary due to batching)
-            let mut received_vec = received.lock().unwrap().clone();
-            received_vec.sort();
-            let mut expected = messages.clone();
-            expected.sort();
-
-            assert_eq!(expected, received_vec);
-        });
-    }
-
-    /// **Property**: Channel truncation keeps only the most recent messages (property-based test).
-    ///
-    /// **Sequence of events**:
-    /// 1. Generate random capacity (1-50) and extra_messages (1-100)
-    /// 2. Create a bounded channel with the generated capacity
-    /// 3. Send (capacity + extra_messages) messages BEFORE spawning receiver
-    /// 4. Spawn receiver after truncation has occurred
-    /// 5. Wait for processing to complete
-    /// 6. Verify: received count <= capacity, all messages are the most recent ones
-    #[quickcheck]
-    fn prop_truncation_keeps_most_recent(capacity: usize, extra_messages: usize) {
-        // Constrain to reasonable values - ensure we have meaningful test data
-        let capacity = (capacity % 50) + 1; // 1-50
-        let extra_messages = (extra_messages % 100) + 1; // 1-100
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let received = Arc::new(Mutex::new(Vec::new()));
-            let (sender, receiver) = bounded::<Vec<usize>>(capacity);
-
-            // Send more messages than capacity BEFORE spawning receiver
-            // This ensures truncation happens in the channel buffer
-            for i in 0..(capacity + extra_messages) {
-                sender.send(i);
-            }
-
-            // Spawn receiver after sending - it will only see the most recent messages
-            let _ = spawn("test_receiver", receiver, {
-                let received = received.clone();
-                move |batch| {
-                    let received = received.clone();
-                    async move {
-                        received.lock().unwrap().extend(batch);
-                        Ok(())
-                    }
-                }
-            })
-            .unwrap();
-
-            // Wait for processing
-            sleep(Duration::from_millis(200)).await;
-
-            let received_vec = received.lock().unwrap();
-
-            // After truncation, we should have at most capacity messages
-            // The actual count depends on how many messages were sent after the last truncation
-            assert!(
-                received_vec.len() <= capacity,
-                "Should receive at most capacity messages, got {}",
-                received_vec.len()
-            );
-
-            // All received messages should be >= extra_messages (the most recent ones after truncation)
-            // This verifies that older messages were dropped
-            for &msg in received_vec.iter() {
-                assert!(
-                    msg >= extra_messages,
-                    "All messages should be the most recent ones (>= {}), got {}",
-                    extra_messages,
-                    msg
-                );
-            }
-        });
-    }
-
-    /// **Property**: Batch sizes are consistent - total processed equals sent, no batch exceeds capacity (property-based test).
-    ///
-    /// **Sequence of events**:
-    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
-    /// 2. Create a bounded channel with the generated capacity
-    /// 3. Spawn receiver that records batch sizes
-    /// 4. Send message_count messages (within capacity, no truncation)
-    /// 5. Wait for processing to complete
-    /// 6. Verify: sum of batch sizes equals message_count, no batch exceeds capacity
-    #[quickcheck]
-    fn prop_batch_sizes_are_consistent(message_count: usize, capacity: usize) {
-        // Constrain values - ensure message_count <= capacity to avoid truncation
-        let capacity = (capacity % 100) + 1; // 1-100
-        let message_count = (message_count % capacity) + 1; // 1-capacity
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let batch_sizes = Arc::new(Mutex::new(Vec::new()));
-            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
-
-            let _ = spawn("test_receiver", receiver, {
-                let batch_sizes = batch_sizes.clone();
-                move |batch| {
-                    let batch_sizes = batch_sizes.clone();
-                    async move {
-                        batch_sizes.lock().unwrap().push(batch.len());
-                        Ok(())
-                    }
-                }
-            })
-            .unwrap();
-
-            // Send messages (within capacity, so no truncation)
-            for _ in 0..message_count {
-                sender.send(42i32);
-            }
-
-            sleep(Duration::from_millis(200)).await;
-
-            let batch_sizes = batch_sizes.lock().unwrap();
-
-            // Total messages processed should equal sent messages
-            let total_processed: usize = batch_sizes.iter().sum();
-            assert_eq!(total_processed, message_count, "All messages should be processed");
-
-            // No batch should exceed capacity
-            for &size in batch_sizes.iter() {
-                assert!(size <= capacity, "Batch size should not exceed capacity");
-            }
-        });
-    }
-
-    /// **Property**: Flush guarantees all messages are processed before returning (property-based test).
-    ///
-    /// **Sequence of events**:
-    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
-    /// 2. Create a bounded channel with the generated capacity
-    /// 3. Spawn receiver with variable processing delay
-    /// 4. Send message_count messages (within capacity, no truncation)
-    /// 5. Call flush with 5s timeout - should wait for all processing
-    /// 6. Verify: flush succeeded and all messages were processed
-    #[quickcheck]
-    fn prop_flush_guarantees_completion(message_count: usize, capacity: usize) {
-        // Constrain values - ensure message_count <= capacity to avoid truncation
-        let capacity = (capacity % 100) + 1; // 1-100
-        let message_count = (message_count % capacity) + 1; // 1-capacity
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let received = Arc::new(Mutex::new(0usize));
-            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
-
-            let _ = spawn("test_receiver", receiver, {
-                let received = received.clone();
-                move |batch| {
-                    let received = received.clone();
-                    async move {
-                        *received.lock().unwrap() += batch.len();
-                        // Add variable delay to simulate real processing
-                        sleep(Duration::from_millis((batch.len() % 10) as u64)).await;
-                        Ok(())
-                    }
-                }
-            })
-            .unwrap();
-
-            // Send messages (within capacity, so no truncation)
-            for _ in 0..message_count {
-                sender.send(42i32);
-            }
-
-            // Flush should wait for all to complete
-            let flushed = flush(&sender, Duration::from_secs(5)).await;
-            assert!(flushed, "Flush should complete within timeout");
-
-            // All messages should be processed
-            assert_eq!(*received.lock().unwrap(), message_count);
-        });
-    }
-
-    /// **Property**: Dropping sender doesn't lose messages - receiver still processes all buffered messages (property-based test).
-    ///
-    /// **Sequence of events**:
-    /// 1. Generate random capacity (1-100) and message_count (1-capacity)
-    /// 2. Create a bounded channel with the generated capacity
-    /// 3. Spawn receiver that collects all received messages
-    /// 4. Send message_count messages (within capacity, no truncation)
-    /// 5. Drop sender immediately (signals channel is closed)
-    /// 6. Wait for processing to complete
-    /// 7. Verify: all messages were processed despite sender being dropped
-    #[quickcheck]
-    fn prop_drop_sender_preserves_messages(message_count: usize, capacity: usize) {
-        // Constrain values - ensure message_count <= capacity to avoid truncation
-        let capacity = (capacity % 100) + 1; // 1-100
-        let message_count = (message_count % capacity) + 1; // 1-capacity
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let received = Arc::new(Mutex::new(Vec::new()));
-            let (sender, receiver) = bounded::<Vec<i32>>(capacity);
-
-            let _ = spawn("test_receiver", receiver, {
-                let received = received.clone();
-                move |batch| {
-                    let received = received.clone();
-                    async move {
-                        received.lock().unwrap().extend(batch);
-                        Ok(())
-                    }
-                }
-            })
-            .unwrap();
-
-            // Send messages (within capacity, so no truncation)
-            for i in 0..message_count {
-                sender.send(i as i32);
-            }
-
-            // Drop sender immediately
-            drop(sender);
-
-            // Wait for processing
-            sleep(Duration::from_millis(200)).await;
-
-            // All messages should still be processed
-            let received_vec = received.lock().unwrap();
-            assert_eq!(received_vec.len(), message_count);
-        });
     }
 }

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -292,6 +292,13 @@ mod tests {
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
+    /// **Property**: Spawn handle resolves when sender is dropped (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 1024
+    /// 2. Spawn receiver in a JavaScript promise
+    /// 3. Drop the sender (signals channel is closed)
+    /// 4. Join the handle - should complete when receiver exits
     async fn promise_resolves_on_sender_drop() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -309,6 +316,14 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    /// **Property**: Receiver processes all messages in batches (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 1024
+    /// 2. Spawn receiver that records batch size
+    /// 3. Send 100 messages (JavaScript single-threaded, all processed together)
+    /// 4. Drop sender and join handle
+    /// 5. Verify all 100 messages were processed in a single batch
     async fn spawn_processes_batches() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -342,6 +357,14 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    /// **Property**: Async send waits for capacity and ensures messages are processed (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 2
+    /// 2. Spawn receiver that counts processed messages
+    /// 3. Send 3 messages using async send (blocks when at capacity)
+    /// 4. After 3 sends with capacity 2, exactly 2 messages should be processed
+    /// 5. Drop sender and join handle
     async fn send_waits_for_processing() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(2);
 
@@ -374,6 +397,15 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    /// **Property**: Flush waits for all messages to be processed (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 1024
+    /// 2. Spawn receiver that counts processed messages
+    /// 3. Send 100 messages
+    /// 4. Verify no messages processed yet
+    /// 5. Call flush with 10ms timeout - should wait for all processing
+    /// 6. Verify flush succeeded and all 100 messages were processed
     async fn flush_waits_for_completion() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -411,6 +443,15 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    /// **Property**: Flush times out when processing takes longer than the timeout (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 1024
+    /// 2. Spawn receiver that takes 50ms to process each batch
+    /// 3. Send 100 messages
+    /// 4. Verify no messages processed yet
+    /// 5. Call flush with 1ms timeout - should timeout before processing completes
+    /// 6. Verify flush returned false (timed out)
     async fn flush_times_out() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -448,6 +489,14 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    /// **Property**: Receiver errors are handled gracefully without crashing (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 1024
+    /// 2. Spawn receiver that always returns an error (no_retry)
+    /// 3. Send a message
+    /// 4. Drop sender and join handle
+    /// 5. Verify the system doesn't crash despite the failing receiver
     async fn failing_receiver_does_not_cause_havoc() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(1024);
 

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -287,6 +287,7 @@ extern "C" {
 mod tests {
     use super::*;
 
+    use futures::channel::oneshot;
     use std::sync::{Arc, Mutex};
     use wasm_bindgen_test::*;
 
@@ -575,5 +576,81 @@ mod tests {
 
         // Only last 5 messages should remain (0-4 were truncated)
         assert_eq!(vec![5, 6, 7, 8, 9], *received.lock().unwrap());
+    }
+
+    #[wasm_bindgen_test]
+    /// **Property**: Park future completes when timeout fires.
+    ///
+    /// This test verifies that Park properly wakes when the timeout expires.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a Park future with a 10ms delay
+    /// 2. Await it (should complete in ~10ms)
+    /// 3. Verify the test completes (timeout fired and woke the future)
+    async fn park_completes_on_timeout() {
+        let start = js_sys::Date::new_0().get_time();
+
+        // Park for 10ms
+        Park::new(Duration::from_millis(10)).await;
+
+        let elapsed = js_sys::Date::new_0().get_time() - start;
+
+        // Should have waited at least 10ms (allow some tolerance)
+        assert!(elapsed >= 10.0, "Expected at least 10ms, got {}", elapsed);
+        // Should not have waited too long (would indicate a hang)
+        assert!(
+            elapsed < 100.0,
+            "Expected less than 100ms, got {} - future may have hung",
+            elapsed
+        );
+    }
+
+    #[wasm_bindgen_test]
+    /// **Property**: Park future doesn't hang when used with select and other future completes first.
+    ///
+    /// This test verifies that Park doesn't leak timeouts when dropped early.
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a oneshot channel and a Park future with 100ms delay
+    /// 2. Select between them
+    /// 3. Send on the oneshot (completes immediately)
+    /// 4. Verify select returns the oneshot result (not the timeout)
+    /// 5. Park is dropped, timeout should be cleared
+    async fn park_does_not_hang_when_dropped_early() {
+        let (tx, rx) = oneshot::channel::<()>();
+
+        // Send immediately (should complete before timeout)
+        let _ = tx.send(());
+
+        // Select between rx and Park
+        let result = futures::future::select(rx, Park::new(Duration::from_millis(100))).await;
+
+        // Should be the left side (oneshot completed first)
+        assert!(matches!(result, futures::future::Either::Left((Ok(()), _))));
+
+        // If we get here without hanging, Park was cleaned up properly
+    }
+
+    #[wasm_bindgen_test]
+    /// **Property**: Park with zero duration completes quickly.
+    ///
+    /// This test verifies that Park handles zero duration correctly (should use minimum 1ms).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a Park future with zero duration
+    /// 2. Await it
+    /// 3. Verify it completes quickly (should be at least 1ms due to setTimeout minimum)
+    async fn park_zero_duration() {
+        let start = js_sys::Date::new_0().get_time();
+
+        // Park for 0ms (should use minimum 1ms)
+        Park::new(Duration::ZERO).await;
+
+        let elapsed = js_sys::Date::new_0().get_time() - start;
+
+        // Should have waited at least 1ms (setTimeout minimum)
+        assert!(elapsed >= 1.0, "Expected at least 1ms, got {}", elapsed);
+        // Should not have waited too long
+        assert!(elapsed < 50.0, "Expected less than 50ms, got {}", elapsed);
     }
 }

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -292,13 +292,6 @@ mod tests {
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
-    /// **Property**: Spawn handle resolves when sender is dropped (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 1024
-    /// 2. Spawn receiver in a JavaScript promise
-    /// 3. Drop the sender (signals channel is closed)
-    /// 4. Join the handle - should complete when receiver exits
     async fn promise_resolves_on_sender_drop() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -316,14 +309,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Receiver processes all messages in batches (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 1024
-    /// 2. Spawn receiver that records batch size
-    /// 3. Send 100 messages (JavaScript single-threaded, all processed together)
-    /// 4. Drop sender and join handle
-    /// 5. Verify all 100 messages were processed in a single batch
     async fn spawn_processes_batches() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -357,14 +342,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Async send waits for capacity and ensures messages are processed (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 2
-    /// 2. Spawn receiver that counts processed messages
-    /// 3. Send 3 messages using async send (blocks when at capacity)
-    /// 4. After 3 sends with capacity 2, exactly 2 messages should be processed
-    /// 5. Drop sender and join handle
     async fn send_waits_for_processing() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(2);
 
@@ -397,15 +374,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Flush waits for all messages to be processed (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 1024
-    /// 2. Spawn receiver that counts processed messages
-    /// 3. Send 100 messages
-    /// 4. Verify no messages processed yet
-    /// 5. Call flush with 10ms timeout - should wait for all processing
-    /// 6. Verify flush succeeded and all 100 messages were processed
     async fn flush_waits_for_completion() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -443,15 +411,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Flush times out when processing takes longer than the timeout (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 1024
-    /// 2. Spawn receiver that takes 50ms to process each batch
-    /// 3. Send 100 messages
-    /// 4. Verify no messages processed yet
-    /// 5. Call flush with 1ms timeout - should timeout before processing completes
-    /// 6. Verify flush returned false (timed out)
     async fn flush_times_out() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(1024);
 
@@ -489,14 +448,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Receiver errors are handled gracefully without crashing (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 1024
-    /// 2. Spawn receiver that always returns an error (no_retry)
-    /// 3. Send a message
-    /// 4. Drop sender and join handle
-    /// 5. Verify the system doesn't crash despite the failing receiver
     async fn failing_receiver_does_not_cause_havoc() {
         let (sender, receiver) = crate::bounded::<Vec<()>>(1024);
 
@@ -516,12 +467,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: try_send returns an error when the channel is closed (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel
-    /// 2. Drop the receiver to close the channel from the receiver side
-    /// 3. Attempt try_send - should fail with a non-retryable error
     fn try_send_on_closed_channel() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
 
@@ -538,14 +483,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Channel truncates oldest messages when capacity is exceeded (WebAssembly variant).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a bounded channel with capacity 5
-    /// 2. Send 10 messages (exceeding capacity, causing truncation of 0-4)
-    /// 3. Spawn receiver to process the remaining batch
-    /// 4. Drop sender and join handle
-    /// 5. Verify only messages 5-9 were received (first 5 truncated)
     async fn truncation_keeps_most_recent() {
         let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
 
@@ -579,14 +516,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Park future completes when timeout fires.
-    ///
-    /// This test verifies that Park properly wakes when the timeout expires.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a Park future with a 10ms delay
-    /// 2. Await it (should complete in ~10ms)
-    /// 3. Verify the test completes (timeout fired and woke the future)
     async fn park_completes_on_timeout() {
         let start = js_sys::Date::new_0().get_time();
 
@@ -606,16 +535,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Park future doesn't hang when used with select and other future completes first.
-    ///
-    /// This test verifies that Park doesn't leak timeouts when dropped early.
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a oneshot channel and a Park future with 100ms delay
-    /// 2. Select between them
-    /// 3. Send on the oneshot (completes immediately)
-    /// 4. Verify select returns the oneshot result (not the timeout)
-    /// 5. Park is dropped, timeout should be cleared
     async fn park_does_not_hang_when_dropped_early() {
         let (tx, rx) = oneshot::channel::<()>();
 
@@ -632,14 +551,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    /// **Property**: Park with zero duration completes quickly.
-    ///
-    /// This test verifies that Park handles zero duration correctly (should use minimum 1ms).
-    ///
-    /// **Sequence of events**:
-    /// 1. Create a Park future with zero duration
-    /// 2. Await it
-    /// 3. Verify it completes quickly (should be at least 1ms due to setTimeout minimum)
     async fn park_zero_duration() {
         let start = js_sys::Date::new_0().get_time();
 

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -288,7 +288,6 @@ mod tests {
     use super::*;
 
     use std::sync::{Arc, Mutex};
-
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
@@ -513,5 +512,68 @@ mod tests {
 
         drop(sender);
         handle.join().await;
+    }
+
+    #[wasm_bindgen_test]
+    /// **Property**: try_send returns an error when the channel is closed (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel
+    /// 2. Drop the receiver to close the channel from the receiver side
+    /// 3. Attempt try_send - should fail with a non-retryable error
+    fn try_send_on_closed_channel() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        // Drop the receiver to close the channel
+        drop(receiver);
+
+        // try_send should fail with a non-retryable error
+        let result = sender.try_send(1);
+        assert!(result.is_err());
+
+        // Verify the error is non-retryable (no messages to retry)
+        let err = result.err().unwrap();
+        assert!(err.into_retryable().is_none());
+    }
+
+    #[wasm_bindgen_test]
+    /// **Property**: Channel truncates oldest messages when capacity is exceeded (WebAssembly variant).
+    ///
+    /// **Sequence of events**:
+    /// 1. Create a bounded channel with capacity 5
+    /// 2. Send 10 messages (exceeding capacity, causing truncation of 0-4)
+    /// 3. Spawn receiver to process the remaining batch
+    /// 4. Drop sender and join handle
+    /// 5. Verify only messages 5-9 were received (first 5 truncated)
+    async fn truncation_keeps_most_recent() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+
+        let handle = spawn(receiver, {
+            let received = received.clone();
+
+            move |batch| {
+                let received = received.clone();
+
+                async move {
+                    received.lock().unwrap().extend(batch);
+
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Send more messages than capacity
+        for i in 0..10 {
+            sender.send(i);
+        }
+
+        drop(sender);
+        handle.join().await;
+
+        // Only last 5 messages should remain (0-4 were truncated)
+        assert_eq!(vec![5, 6, 7, 8, 9], *received.lock().unwrap());
     }
 }


### PR DESCRIPTION
This PR just fills in some test gaps around `emit_batcher`, particularly its `tokio` and `web` implementations. I haven't found any actual issues in it, but will continue investigating and improving its tests over time.

-----

**AI Disclosure:** This work was assisted by agentic tooling, specifically Qwen 3.5 27B running locally. I've reviewed and further modified the result.