### PR TITLE
Properly escape {} chars when formatting templates

### DIFF
--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -317,17 +317,26 @@ impl<T: Channel> Sender<T> {
 }
 
 /**
-Test barriers for deterministic ordering in tests.
+Deterministic ordering in tests via barriers.
 */
 #[cfg(all(not(target_arch = "wasm32"), test))]
 #[derive(Default, Clone)]
-pub struct TestBarriers {
+struct TestBarriers {
+    // NOTE: These use `tokio`'s barrier type since we always have `tokio` in tests
+    // but could be rewritten to some generic `futures` type
+    pre_take: Option<Arc<::tokio::sync::Barrier>>,
     post_take: Option<Arc<::tokio::sync::Barrier>>,
     post_process: Option<Arc<::tokio::sync::Barrier>>,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), test))]
 impl TestBarriers {
+    async fn wait_pre_take(&self) {
+        if let Some(ref barrier) = self.pre_take {
+            barrier.wait().await;
+        }
+    }
+
     async fn wait_post_take(&self) {
         if let Some(ref barrier) = self.post_take {
             barrier.wait().await;
@@ -368,17 +377,6 @@ impl<T> Drop for Receiver<T> {
 
 impl<T: Channel> Receiver<T> {
     /**
-    Configure test barriers for deterministic ordering in tests.
-
-    This method is only available when building with tests.
-    */
-    #[cfg(all(not(target_arch = "wasm32"), test))]
-    pub fn with_test_barriers(mut self, barriers: TestBarriers) -> Self {
-        self.test_barriers = barriers;
-        self
-    }
-
-    /**
     Run the receiver asynchronously.
 
     The returned future will resolve once the [`Sender`] is dropped.
@@ -399,6 +397,10 @@ impl<T: Channel> Receiver<T> {
         let mut next_batch = Batch::new();
 
         loop {
+            // Post-take barrier: wait here after batch is taken
+            #[cfg(all(not(target_arch = "wasm32"), test))]
+            self.test_barriers.wait_pre_take().await;
+
             // Run inside the lock
             let (mut current_batch, is_open) = {
                 let mut state = self.shared.state.lock().unwrap();

--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -397,7 +397,7 @@ impl<T: Channel> Receiver<T> {
         let mut next_batch = Batch::new();
 
         loop {
-            // Post-take barrier: wait here after batch is taken
+            // Pre-take barrier: wait here before batch is taken
             #[cfg(all(not(target_arch = "wasm32"), test))]
             self.test_barriers.wait_pre_take().await;
 

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -161,6 +161,10 @@ mod tests {
 
     use crate::TestBarriers;
 
+    fn barrier() -> Arc<Barrier> {
+        Arc::new(Barrier::new(2))
+    }
+
     #[tokio::test]
     async fn async_send_recv_flush() {
         let received = Arc::new(Mutex::new(0));
@@ -197,33 +201,31 @@ mod tests {
     #[tokio::test]
     async fn send_full_capacity() {
         let received = Arc::new(Mutex::new(Vec::new()));
-        let post_process_barrier = Arc::new(Barrier::new(2));
+        let post_process_barrier = barrier();
 
-        let (sender, receiver) = crate::bounded::<Vec<i32>>(5);
+        let (sender, mut receiver) = crate::bounded::<Vec<i32>>(5);
 
         // Send more messages than capacity
         for i in 0..10 {
             sender.send(i);
         }
 
+        receiver.test_barriers = TestBarriers {
+            post_process: Some(post_process_barrier.clone()),
+            ..Default::default()
+        };
+
         // Spawn receiver after sending, with barrier after processing
-        let _ = spawn(
-            "test_receiver",
-            receiver.with_test_barriers(TestBarriers {
-                post_process: Some(post_process_barrier.clone()),
-                ..Default::default()
-            }),
-            {
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+            move |batch| {
                 let received = received.clone();
-                move |batch| {
-                    let received = received.clone();
-                    async move {
-                        received.lock().unwrap().extend(batch);
-                        Ok(())
-                    }
+                async move {
+                    received.lock().unwrap().extend(batch);
+                    Ok(())
                 }
-            },
-        )
+            }
+        })
         .unwrap();
 
         // Wait at barrier for receiver to finish processing
@@ -424,32 +426,30 @@ mod tests {
         // Channel to signal when receiver has completed a batch
         let (receiver_processed_tx, mut receiver_processed_rx) = broadcast::channel::<()>(100);
         let received = Arc::new(Mutex::new(Vec::new()));
-        let post_process_barrier = Arc::new(Barrier::new(2));
+        let post_process_barrier = barrier();
 
-        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+        let (sender, mut receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn(
-            "test_receiver",
-            receiver.with_test_barriers(TestBarriers {
-                post_process: Some(post_process_barrier.clone()),
-                ..Default::default()
-            }),
-            {
+        receiver.test_barriers = TestBarriers {
+            post_process: Some(post_process_barrier.clone()),
+            ..Default::default()
+        };
+
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+
+            move |batch| {
                 let received = received.clone();
+                let receiver_processed_tx = receiver_processed_tx.clone();
 
-                move |batch| {
-                    let received = received.clone();
-                    let receiver_processed_tx = receiver_processed_tx.clone();
+                async move {
+                    received.lock().unwrap().extend(batch);
+                    receiver_processed_tx.send(()).unwrap();
 
-                    async move {
-                        received.lock().unwrap().extend(batch);
-                        receiver_processed_tx.send(()).unwrap();
-
-                        Ok(())
-                    }
+                    Ok(())
                 }
-            },
-        )
+            }
+        })
         .unwrap();
 
         // Send messages and drop sender
@@ -470,36 +470,38 @@ mod tests {
 
     #[tokio::test]
     async fn try_send_behavior() {
-        let post_process_barrier = Arc::new(Barrier::new(2));
+        let pre_take_barrier = barrier();
+        let post_process_barrier = barrier();
 
-        let (sender, receiver) = crate::bounded::<Vec<i32>>(3);
-        let _ = spawn(
-            "test_receiver",
-            receiver.with_test_barriers(TestBarriers {
-                post_process: Some(post_process_barrier.clone()),
-                ..Default::default()
-            }),
-            |batch| async move {
-                let _ = batch;
-                Ok(())
-            },
-        )
+        let (sender, mut receiver) = crate::bounded::<Vec<i32>>(3);
+
+        receiver.test_barriers = TestBarriers {
+            pre_take: Some(pre_take_barrier.clone()),
+            post_process: Some(post_process_barrier.clone()),
+            ..Default::default()
+        };
+
+        let _ = spawn("test_receiver", receiver, |batch| async move {
+            let _ = batch;
+            Ok(())
+        })
         .unwrap();
 
-        // Successful sends
-        assert!(sender.try_send(1).is_ok());
-        assert!(sender.try_send(2).is_ok());
-        assert!(sender.try_send(3).is_ok());
+        // Up to capacity should succeed
+        sender.try_send(1).unwrap();
+        sender.try_send(2).unwrap();
+        sender.try_send(3).unwrap();
 
         // Should fail when at capacity
         let result = sender.try_send(4);
         assert!(result.is_err());
 
         // Wait at barrier for receiver to finish processing
+        pre_take_barrier.wait().await;
         post_process_barrier.wait().await;
 
         // Should succeed after processing
-        assert!(sender.try_send(4).is_ok());
+        sender.try_send(4).unwrap();
     }
 
     #[tokio::test]
@@ -521,19 +523,16 @@ mod tests {
     #[tokio::test]
     async fn when_empty_callback() {
         let callback_fired = Arc::new(Mutex::new(false));
-        let post_take_barrier = Arc::new(Barrier::new(2));
+        let post_take_barrier = barrier();
 
-        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+        let (sender, mut receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn(
-            "test_receiver",
-            receiver.with_test_barriers(TestBarriers {
-                post_take: Some(post_take_barrier.clone()),
-                ..Default::default()
-            }),
-            |_batch| async move { Ok(()) },
-        )
-        .unwrap();
+        receiver.test_barriers = TestBarriers {
+            post_take: Some(post_take_barrier.clone()),
+            ..Default::default()
+        };
+
+        let _ = spawn("test_receiver", receiver, |_batch| async move { Ok(()) }).unwrap();
 
         // Send a message
         sender.send(1);
@@ -558,19 +557,16 @@ mod tests {
         // Channel to signal when receiver has completed a batch
         let (when_flushed_tx, mut when_flushed_rx) = broadcast::channel::<()>(100);
         let callback_fired = Arc::new(Mutex::new(false));
-        let post_process_barrier = Arc::new(Barrier::new(2));
+        let post_process_barrier = barrier();
 
-        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+        let (sender, mut receiver) = crate::bounded::<Vec<i32>>(10);
 
-        let _ = spawn(
-            "test_receiver",
-            receiver.with_test_barriers(TestBarriers {
-                post_process: Some(post_process_barrier.clone()),
-                ..Default::default()
-            }),
-            |_batch| async move { Ok(()) },
-        )
-        .unwrap();
+        receiver.test_barriers = TestBarriers {
+            post_process: Some(post_process_barrier.clone()),
+            ..Default::default()
+        };
+
+        let _ = spawn("test_receiver", receiver, |_batch| async move { Ok(()) }).unwrap();
 
         // Send a message
         sender.send(1);

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -523,11 +523,13 @@ mod tests {
     #[tokio::test]
     async fn when_empty_callback() {
         let callback_fired = Arc::new(Mutex::new(false));
+        let pre_take_barrier = barrier();
         let post_take_barrier = barrier();
 
         let (sender, mut receiver) = crate::bounded::<Vec<i32>>(10);
 
         receiver.test_barriers = TestBarriers {
+            pre_take: Some(pre_take_barrier.clone()),
             post_take: Some(post_take_barrier.clone()),
             ..Default::default()
         };
@@ -537,15 +539,19 @@ mod tests {
         // Send a message
         sender.send(1);
 
-        let callback_fired_clone = callback_fired.clone();
-        sender.when_empty(move || {
-            *callback_fired_clone.lock().unwrap() = true;
+        sender.when_empty({
+            let callback_fired = callback_fired.clone();
+
+            move || {
+                *callback_fired.lock().unwrap() = true;
+            }
         });
 
         // Callback shouldn't fire yet (batch not taken)
         assert!(!*callback_fired.lock().unwrap());
 
-        // Wait at barrier for batch to be taken
+        // Wait at barrier for batch to be taken and processed
+        pre_take_barrier.wait().await;
         post_take_barrier.wait().await;
 
         // Callback should have fired

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -59,6 +59,8 @@ impl Path<'static> {
     /**
     Create a path from a raw value without checking its validity.
 
+    It is only valid to call this method with a `path` that constitutes a valid path. That is, a path where [`is_valid_path`] returns `true`.
+
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
     pub const fn new_raw(path: &'static str) -> Self {
@@ -83,6 +85,8 @@ impl<'a> Path<'a> {
 
     The [`Path::new_raw`] method should be preferred where possible.
 
+    It is only valid to call this method with a `path` that constitutes a valid path. That is, a path where [`is_valid_path`] returns `true`.
+
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
     pub const fn new_ref_raw(path: &'a str) -> Self {
@@ -104,6 +108,8 @@ impl<'a> Path<'a> {
 
     /**
     Create a path from a raw [`Str`] value without checking its validity.
+
+    It is only valid to call this method with a `path` that constitutes a valid path. That is, a path where [`is_valid_path`] returns `true`.
 
     This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
     */
@@ -373,6 +379,8 @@ mod alloc_support {
         /**
         Create a path from an owned raw value without checking its validity.
 
+        It is only valid to call this method with a `path` that constitutes a valid path. That is, a path where [`is_valid_path`] returns `true`.
+
         This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
         */
         pub fn new_owned_raw(path: impl Into<Box<str>>) -> Self {
@@ -396,6 +404,8 @@ mod alloc_support {
         Create a path from a potentially owned raw value without checking its validity.
 
         If the value is `Cow::Borrowed` then this method will defer to [`Path::new_ref_raw`]. If the value is `Cow::Owned` then this method will defer to [`Path::new_owned_raw`].
+
+        It is only valid to call this method with a `path` that constitutes a valid path. That is, a path where [`is_valid_path`] returns `true`.
 
         This method is not unsafe. There are no memory safety properties tied to the validity of paths. Code that uses path segments may panic or produce unexpected results if given an invalid path.
         */

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -570,27 +570,21 @@ impl<'a, P: Props> fmt::Debug for Render<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use fmt::Write as _;
 
-        f.write_char('"')?;
-        write!(WriteEscaped(&mut *f), "{}", self)?;
-        f.write_char('"')
-    }
-}
+        struct EscapeDebug<W>(W);
 
-struct WriteEscaped<W>(W);
+        impl<W: fmt::Write> fmt::Write for EscapeDebug<W> {
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                for c in s.escape_debug() {
+                    self.0.write_char(c)?;
+                }
 
-impl<W: fmt::Write> WriteEscaped<W> {
-    pub fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
-        self.0.write_fmt(args)
-    }
-}
-
-impl<W: fmt::Write> fmt::Write for WriteEscaped<W> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.escape_debug() {
-            self.0.write_char(c)?;
+                Ok(())
+            }
         }
 
-        Ok(())
+        f.write_char('"')?;
+        write!(EscapeDebug(&mut *f), "{}", self)?;
+        f.write_char('"')
     }
 }
 
@@ -1179,14 +1173,21 @@ mod tests {
 
     #[test]
     fn render() {
-        for (case, display, render_empty, render_interpolated) in [
-            (Template::literal("text"), "text", "text", "text"),
+        for (case, debug, display, render_empty, render_interpolated) in [
+            (
+                Template::literal("text"),
+                "\"text\"",
+                "text",
+                "text",
+                "text",
+            ),
             (
                 Template::new({
                     const PARTS: &'static [Part<'static>] = &[Part::hole("greet")];
 
                     PARTS
                 }),
+                "\"{greet}\"",
                 "{greet}",
                 "{greet}",
                 "user",
@@ -1198,9 +1199,25 @@ mod tests {
 
                     PARTS
                 }),
+                "\"{{user:{greet}}}\"",
                 "{{user:{greet}}}",
                 "{user:{greet}}",
                 "{user:user}",
+            ),
+            (
+                Template::new({
+                    const PARTS: &'static [Part<'static>] = &[
+                        Part::text("user is \""),
+                        Part::hole("greet"),
+                        Part::text("\""),
+                    ];
+
+                    PARTS
+                }),
+                "\"user is \\\"{greet}\\\"\"",
+                "user is \"{greet}\"",
+                "user is \"{greet}\"",
+                "user is \"user\"",
             ),
             (
                 Template::new({
@@ -1209,6 +1226,7 @@ mod tests {
 
                     PARTS
                 }),
+                "\"{}\"",
                 "{}",
                 "{}",
                 "{}",
@@ -1220,6 +1238,7 @@ mod tests {
 
                     PARTS
                 }),
+                "\"Hello, {greet}!\"",
                 "Hello, {greet}!",
                 "Hello, {greet}!",
                 "Hello, user!",
@@ -1231,11 +1250,14 @@ mod tests {
 
                     PARTS
                 }),
+                "\"Hello{}!\"",
                 "Hello{}!",
                 "Hello{}!",
                 "Hello{}!",
             ),
         ] {
+            assert_eq!(debug, format!("{case:?}"), "{case:?}");
+            assert_eq!(debug, format!("{:?}", case.to_string()), "{case:?}");
             assert_eq!(display, case.to_string(), "{case:?}");
             assert_eq!(render_empty, case.render(Empty).to_string(), "{case:?}");
             assert_eq!(

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -61,13 +61,13 @@ impl<'a> TemplateKind<'a> {
 
 impl<'a> fmt::Debug for Template<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.render(Empty), f)
+        fmt::Debug::fmt(&self.render(Empty).with_escaping(true), f)
     }
 }
 
 impl<'a> fmt::Display for Template<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.render(Empty), f)
+        fmt::Display::fmt(&self.render(Empty).with_escaping(true), f)
     }
 }
 
@@ -149,6 +149,7 @@ impl<'a> Template<'a> {
     pub fn render<'b, P>(&'b self, props: P) -> Render<'b, P> {
         Render {
             tpl: self.by_ref(),
+            escape: false,
             props,
         }
     }
@@ -197,7 +198,16 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
             let bp = &b[bi];
 
             match (&ap.0, &bp.0) {
-                (PartKind::Text { value: ref a }, PartKind::Text { value: ref b }) => {
+                (
+                    PartKind::Text {
+                        value: ref a,
+                        needs_escaping: _,
+                    },
+                    PartKind::Text {
+                        value: ref b,
+                        needs_escaping: _,
+                    },
+                ) => {
                     let a = a.get();
                     let b = b.get();
 
@@ -244,7 +254,11 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
 
         // If there's any data left then it would have to be empty text
         for part in a[ai..].iter().chain(b[bi..].iter()) {
-            let PartKind::Text { ref value } = part.0 else {
+            let PartKind::Text {
+                ref value,
+                needs_escaping: _,
+            } = part.0
+            else {
                 return false;
             };
 
@@ -267,6 +281,7 @@ The template can be converted to text either using the [`fmt::Display`] implemen
 */
 pub struct Render<'a, P> {
     tpl: Template<'a>,
+    escape: bool,
     props: P,
 }
 
@@ -277,8 +292,19 @@ impl<'a, P> Render<'a, P> {
     pub fn with_props<U>(self, props: U) -> Render<'a, U> {
         Render {
             tpl: self.tpl,
+            escape: self.escape,
             props,
         }
+    }
+
+    /**
+    Whether to escape `{` and `}` in text fragments as `{{` and `}}`.
+
+    Rendering will not escape by default.
+    */
+    pub fn with_escaping(mut self, escape: bool) -> Self {
+        self.escape = escape;
+        self
     }
 
     /**
@@ -297,7 +323,7 @@ impl<'a, P: Props> Render<'a, P> {
     */
     pub fn write(&self, mut writer: impl Write) -> fmt::Result {
         for part in self.tpl.0.parts() {
-            part.write(&mut writer, &self.props)?;
+            part.write(self.escape, &mut writer, &self.props)?;
         }
 
         Ok(())
@@ -469,7 +495,11 @@ impl<'a> Part<'a> {
     This method allows creating parts from potentially owned or borrowed string values.
     */
     pub const fn text_str(text: Str<'a>) -> Self {
-        Part(PartKind::Text { value: text })
+        Part(PartKind::Text {
+            // Assume the input needs to be escaped when formatting
+            needs_escaping: true,
+            value: text,
+        })
     }
 
     /**
@@ -489,7 +519,10 @@ impl<'a> Part<'a> {
     */
     pub const fn as_text(&'_ self) -> Option<&'_ Str<'a>> {
         match self.0 {
-            PartKind::Text { ref value, .. } => Some(value),
+            PartKind::Text {
+                ref value,
+                needs_escaping: _,
+            } => Some(value),
             _ => None,
         }
     }
@@ -501,7 +534,10 @@ impl<'a> Part<'a> {
     */
     pub const fn label(&'_ self) -> Option<&'_ Str<'a>> {
         match self.0 {
-            PartKind::Hole { ref label, .. } => Some(label),
+            PartKind::Hole {
+                ref label,
+                formatter: _,
+            } => Some(label),
             _ => None,
         }
     }
@@ -523,8 +559,12 @@ impl<'a> Part<'a> {
     */
     pub fn by_ref<'b>(&'b self) -> Part<'b> {
         match self.0 {
-            PartKind::Text { ref value } => Part(PartKind::Text {
+            PartKind::Text {
+                ref value,
+                needs_escaping,
+            } => Part(PartKind::Text {
                 value: value.by_ref(),
+                needs_escaping,
             }),
             PartKind::Hole {
                 ref label,
@@ -553,9 +593,35 @@ impl<'a> Part<'a> {
         self
     }
 
-    fn write(&self, mut writer: impl Write, props: impl Props) -> fmt::Result {
+    /**
+    Mark whether the part should check for, and escape any `{` or `}` characters when formatting.
+
+    It is only valid call this function with `false` if the part is known not to contain any `{` or `}`.
+    */
+    pub const fn with_escaping(mut self, escape: bool) -> Self {
+        if let PartKind::Text {
+            needs_escaping: ref mut slot,
+            ..
+        } = self.0
+        {
+            *slot = escape;
+        }
+
+        self
+    }
+
+    fn write(&self, escape: bool, mut writer: impl Write, props: impl Props) -> fmt::Result {
         match self.0 {
-            PartKind::Text { ref value, .. } => writer.write_text(value.get()),
+            PartKind::Text {
+                ref value,
+                needs_escaping,
+            } => {
+                if escape && needs_escaping {
+                    escape_text(writer, value.get())
+                } else {
+                    writer.write_text(value.get())
+                }
+            }
             PartKind::Hole {
                 ref label,
                 ref formatter,
@@ -575,6 +641,32 @@ impl<'a> Part<'a> {
             }
         }
     }
+}
+
+/**
+Write `text` to `writer`, escaping any `{` or `}` characters.
+*/
+fn escape_text(mut writer: impl Write, text: &str) -> fmt::Result {
+    let mut from = 0;
+    let mut to = 0;
+
+    let raw = text.as_bytes();
+
+    while to < text.len() {
+        let b = raw[to];
+
+        if let b'{' | b'}' = b {
+            writer.write_text(&text[from..to])?;
+            writer.write_text(&text[to..to + 1])?;
+            from = to;
+        }
+
+        to += 1;
+    }
+
+    writer.write_text(&text[from..])?;
+
+    Ok(())
 }
 
 // Work-around for const-fn in traits
@@ -659,6 +751,7 @@ impl Formatter {
 enum PartKind<'a> {
     Text {
         value: Str<'a>,
+        needs_escaping: bool,
     },
     Hole {
         label: Str<'a>,
@@ -712,6 +805,7 @@ mod alloc_support {
         pub fn text_owned(text: impl Into<Box<str>>) -> Self {
             Part(PartKind::Text {
                 value: Str::new_owned(text),
+                needs_escaping: true,
             })
         }
 
@@ -729,8 +823,12 @@ mod alloc_support {
     impl<'a> Part<'a> {
         fn to_owned(&self) -> Part<'static> {
             match self.0 {
-                PartKind::Text { ref value, .. } => Part(PartKind::Text {
+                PartKind::Text {
+                    ref value,
+                    needs_escaping,
+                } => Part(PartKind::Text {
                     value: value.to_owned(),
+                    needs_escaping,
                 }),
                 PartKind::Hole {
                     ref label,
@@ -760,6 +858,7 @@ impl<'k> sval_ref::ValueRef<'k> for Template<'k> {
         if let Some(v) = self.as_literal() {
             sval_ref::stream_ref(stream, v)
         } else {
+            // NOTE: This could borrow
             sval::stream_display(stream, self)
         }
     }
@@ -787,6 +886,7 @@ impl<'k, P: Props> sval_ref::ValueRef<'k> for Render<'k, P> {
         if let Some(v) = self.as_literal() {
             sval_ref::stream_ref(stream, v)
         } else {
+            // NOTE: These could be improved to borrow in more cases
             sval::stream_display(stream, self)
         }
     }
@@ -812,31 +912,52 @@ mod tests {
 
     #[test]
     fn eq() {
-        let a = [
-            Part::text("a"),
-            Part::text("b"),
-            Part::hole("c"),
-            Part::text(""),
-            Part::text("de"),
-        ];
-        let a = Template::new_ref(&a);
+        for (a, b, expected) in [
+            (&[Part::text("")] as &[_], &[Part::text("")] as &[_], true),
+            (&[Part::text("a")], &[Part::text("a")], true),
+            (
+                &[Part::text("a"), Part::text("b")],
+                &[Part::text("ab")],
+                true,
+            ),
+            (&[Part::hole("a")], &[Part::hole("a")], true),
+            (
+                &[Part::hole("a"), Part::hole("b")],
+                &[Part::hole("ab")],
+                false,
+            ),
+            (&[Part::text("a")], &[Part::text("b")], false),
+            (&[Part::hole("a")], &[Part::hole("b")], false),
+            (
+                &[
+                    Part::text("a"),
+                    Part::text("b"),
+                    Part::hole("c"),
+                    Part::text(""),
+                    Part::text("de"),
+                ],
+                &[
+                    Part::text(""),
+                    Part::text("ab"),
+                    Part::hole("c"),
+                    Part::text("de"),
+                    Part::text(""),
+                ],
+                true,
+            ),
+        ] {
+            let a = Template::new_ref(&a);
+            let b = Template::new_ref(&b);
 
-        let b = [
-            Part::text(""),
-            Part::text("ab"),
-            Part::hole("c"),
-            Part::text("de"),
-            Part::text(""),
-        ];
-        let b = Template::new_ref(&b);
-
-        assert_eq!(a, b);
+            assert_eq!(expected, a == b, "{a:?} == {b:?}");
+            assert_eq!(expected, b == a, "{b:?} == {a:?}");
+        }
     }
 
     #[test]
     fn render() {
-        for (case, raw, interpolated) in [
-            (Template::literal("text"), "text", "text"),
+        for (case, display, render_empty, render_interpolated) in [
+            (Template::literal("text"), "text", "text", "text"),
             (
                 Template::new({
                     const PARTS: &'static [Part<'static>] = &[Part::hole("greet")];
@@ -844,7 +965,30 @@ mod tests {
                     PARTS
                 }),
                 "{greet}",
+                "{greet}",
                 "user",
+            ),
+            (
+                Template::new({
+                    const PARTS: &'static [Part<'static>] =
+                        &[Part::text("{user:"), Part::hole("greet"), Part::text("}")];
+
+                    PARTS
+                }),
+                "{{user:{greet}}}",
+                "{user:{greet}}",
+                "{user:user}",
+            ),
+            (
+                Template::new({
+                    const PARTS: &'static [Part<'static>] =
+                        &[Part::text("{}").with_escaping(false)];
+
+                    PARTS
+                }),
+                "{}",
+                "{}",
+                "{}",
             ),
             (
                 Template::new({
@@ -853,6 +997,7 @@ mod tests {
 
                     PARTS
                 }),
+                "Hello, {greet}!",
                 "Hello, {greet}!",
                 "Hello, user!",
             ),
@@ -865,36 +1010,42 @@ mod tests {
                 }),
                 "Hello{}!",
                 "Hello{}!",
+                "Hello{}!",
             ),
         ] {
-            assert_eq!(raw, case.render(Empty).to_string());
-            assert_eq!(interpolated, case.render([("greet", "user")]).to_string());
+            assert_eq!(display, case.to_string(), "{case:?}");
+            assert_eq!(render_empty, case.render(Empty).to_string(), "{case:?}");
+            assert_eq!(
+                render_interpolated,
+                case.render([("greet", "user")]).to_string(),
+                "{case:?}"
+            );
         }
     }
 
     #[test]
     fn to_value() {
-        let tpl = Template::literal("text");
+        for (case, expected_display, expected_str) in [
+            (Template::literal("text"), "text", Some("text")),
+            (
+                Template::new({
+                    const PARTS: &'static [Part<'static>] =
+                        &[Part::text("Hello, "), Part::hole("greet"), Part::text("!")];
 
-        let value = Value::from_any(&tpl);
+                    PARTS
+                }),
+                "Hello, {greet}!",
+                None,
+            ),
+        ] {
+            let value = Value::from_any(&case);
 
-        assert_eq!("text", value.to_string());
+            assert_eq!(expected_display, value.to_string());
 
-        let s = value.cast::<Str>().unwrap();
+            let s = value.cast::<Str>().map(|s| s.to_string());
 
-        assert_eq!("text", s);
-
-        let tpl = Template::new({
-            const PARTS: &'static [Part<'static>] =
-                &[Part::text("Hello, "), Part::hole("greet"), Part::text("!")];
-
-            PARTS
-        });
-
-        let value = Value::from_any(&tpl);
-
-        assert_eq!("Hello, {greet}!", value.to_string());
-        assert!(value.cast::<Str>().is_none());
+            assert_eq!(expected_str, s.as_deref());
+        }
     }
 
     #[cfg(feature = "sval")]

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -42,9 +42,11 @@ Template equality is based on the equality of their renderings.
 Two templates can be equal if they'd render to the same outputs. That means they must have the same holes in the same positions, but their text tokens may be split differently, so long as they produce the same text.
 */
 #[derive(Clone)]
-pub struct Template<'a>(TemplateKind<'a>);
+pub struct Template<'a> {
+    kind: TemplateKind<'a>,
+}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum TemplateKind<'a> {
     Literal([Part<'a>; 1]),
     Parts(&'a [Part<'a>]),
@@ -86,14 +88,18 @@ impl Template<'static> {
     Create a template from a set of tokens.
     */
     pub const fn new(parts: &'static [Part<'static>]) -> Self {
-        Template(TemplateKind::Parts(parts))
+        Template {
+            kind: TemplateKind::Parts(parts),
+        }
     }
 
     /**
     Create a template from a string literal with no holes.
     */
     pub const fn literal(text: &'static str) -> Self {
-        Template(TemplateKind::Literal([Part::text(text)]))
+        Template {
+            kind: TemplateKind::Literal([Part::text(text)]),
+        }
     }
 }
 
@@ -104,7 +110,9 @@ impl<'a> Template<'a> {
     The [`Template::new`] method should be preferred where possible.
     */
     pub const fn new_ref(parts: &'a [Part<'a>]) -> Self {
-        Template(TemplateKind::Parts(parts))
+        Template {
+            kind: TemplateKind::Parts(parts),
+        }
     }
 
     /**
@@ -113,18 +121,26 @@ impl<'a> Template<'a> {
     The [`Template::literal`] method should be preferred where possible.
     */
     pub const fn literal_ref(text: &'a str) -> Self {
-        Template(TemplateKind::Literal([Part::text_ref(text)]))
+        Template {
+            kind: TemplateKind::Literal([Part::text_ref(text)]),
+        }
     }
 
     /**
     Get a new template, borrowing data from this one.
     */
     pub fn by_ref<'b>(&'b self) -> Template<'b> {
-        match self.0 {
-            TemplateKind::Literal([ref part]) => Template(TemplateKind::Literal([part.by_ref()])),
-            TemplateKind::Parts(parts) => Template(TemplateKind::Parts(parts)),
+        match self.kind {
+            TemplateKind::Literal([ref part]) => Template {
+                kind: TemplateKind::Literal([part.by_ref()]),
+            },
+            TemplateKind::Parts(parts) => Template {
+                kind: TemplateKind::Parts(parts),
+            },
             #[cfg(feature = "alloc")]
-            TemplateKind::Owned(ref parts) => Template(TemplateKind::Parts(parts)),
+            TemplateKind::Owned(ref parts) => Template {
+                kind: TemplateKind::Parts(parts),
+            },
         }
     }
 
@@ -134,7 +150,7 @@ impl<'a> Template<'a> {
     If the template only has a single token, and that token is text, then this method will return `Some`. Otherwise this method will return `None`.
     */
     pub fn as_literal(&'_ self) -> Option<&'_ Str<'a>> {
-        match self.0.parts() {
+        match self.kind.parts() {
             [part] => part.as_text(),
             _ => None,
         }
@@ -144,7 +160,7 @@ impl<'a> Template<'a> {
     Iterate over the parts of the template.
     */
     pub fn parts(&'_ self) -> Parts<'_, 'a> {
-        Parts(self.0.parts().iter())
+        Parts(self.kind.parts().iter())
     }
 
     /**
@@ -183,25 +199,36 @@ impl<'a> ToValue for Template<'a> {
 }
 
 impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
+    /**
+    Compare two templates for equality.
+
+    Templates are considered equal if they'd produce the same value when
+    formatted by `Display`. Note that the presence of formatters on holes
+    does not affect equality.
+    */
     fn eq(&self, other: &Template<'b>) -> bool {
         // Optimize for the case where both templates are just text literals
         if let (Some(a), Some(b)) = (self.as_literal(), other.as_literal()) {
             return a == b;
         }
 
+        // Index into parts of `a` and `b`
         let mut ai = 0;
-        let mut ati = 0;
         let mut bi = 0;
+
+        // Index into the current text fragment of `a` and `b`
+        let mut ati = 0;
         let mut bti = 0;
 
-        let a = self.0.parts();
-        let b = other.0.parts();
+        let a = self.kind.parts();
+        let b = other.kind.parts();
 
         while ai < a.len() && bi < b.len() {
             let ap = &a[ai];
             let bp = &b[bi];
 
             match (&ap.0, &bp.0) {
+                // Compare text fragments
                 (
                     PartKind::Text {
                         value: ref a,
@@ -212,6 +239,13 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
                         needs_escaping: _,
                     },
                 ) => {
+                    // Scan through the text fragments in `a` and `b`
+                    //
+                    // So long as the concatenated results are equal we consider
+                    // `a` and `b` to be equal. Usually, you'd expect two equal
+                    // templates to have the same exact text fragments, so this
+                    // will just compare them in their entirety in that case
+
                     let a = a.get();
                     let b = b.get();
 
@@ -242,7 +276,9 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
 
                     continue;
                 }
+                // Compare hole fragments
                 (PartKind::Hole { label: ref a, .. }, PartKind::Hole { label: ref b, .. }) => {
+                    // Holes are not partial, so must be exactly equal
                     if a != b {
                         return false;
                     }
@@ -252,11 +288,27 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
 
                     continue;
                 }
+                // Ignore empty fragments
+                (PartKind::Text { value: ref a, .. }, PartKind::Hole { .. })
+                    if a.get().is_empty() =>
+                {
+                    ai += 1;
+
+                    continue;
+                }
+                (PartKind::Hole { .. }, PartKind::Text { value: ref b, .. })
+                    if b.get().is_empty() =>
+                {
+                    bi += 1;
+
+                    continue;
+                }
+                // Any other mismatch means the templates aren't equal
                 _ => return false,
             }
         }
 
-        // If there's any data left then it would have to be empty text
+        // Any trailing parts after `a` or `b` is finished must be empty fragments
         for part in a[ai..].iter().chain(b[bi..].iter()) {
             let PartKind::Text {
                 ref value,
@@ -271,7 +323,7 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
             }
         }
 
-        // If all data was processed then the templates are equal
+        // If we get this far then the templates are equal
         true
     }
 }
@@ -281,12 +333,90 @@ impl<'a> Eq for Template<'a> {}
 impl<'a> Hash for Template<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         /*
-        Must be equivalent to `partial_eq`
+        The hash format used here emulates the same equality behavior as `partial_eq`.
+
+        Two templates hash to the same value if they format the same when escaping is applied.
+        That means hashing doesn't depend on the composition of text fragments if they have the
+        same concatenated value.
         */
 
-        let _ = state;
+        #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+        enum LastType {
+            Text,
+            Hole,
+        }
 
-        todo!();
+        fn hash_bytes(
+            state: &mut impl Hasher,
+            bytes_written_slot: &mut usize,
+            last_type_slot: &mut LastType,
+            bytes: &[u8],
+            last_type: LastType,
+        ) {
+            state.write(bytes);
+            *bytes_written_slot += bytes.len();
+            *last_type_slot = last_type;
+        }
+
+        fn hash_trailer(
+            state: &mut impl Hasher,
+            bytes_written_slot: &mut usize,
+            last_type: LastType,
+        ) {
+            last_type.hash(state);
+            bytes_written_slot.hash(state);
+            *bytes_written_slot = 0;
+        }
+
+        let mut last_type = LastType::Text;
+        let mut bytes_written = 0;
+
+        for part in self.kind.parts() {
+            match &part.0 {
+                // Text hashing defers writing the trailer until we hit the end of the template,
+                // or we hit a hole fragment
+                PartKind::Text {
+                    value,
+                    needs_escaping: _,
+                } => {
+                    let bytes = value.get().as_bytes();
+
+                    // Ignore empty fragments
+                    if bytes.len() > 0 {
+                        hash_bytes(
+                            state,
+                            &mut bytes_written,
+                            &mut last_type,
+                            bytes,
+                            LastType::Text,
+                        );
+                    }
+                }
+                // Hole fragments always write a trailer
+                PartKind::Hole {
+                    label,
+                    formatter: _,
+                } => {
+                    // NOTE: The redundant trailer here when templates start with a hole is fine
+                    if last_type == LastType::Text {
+                        hash_trailer(state, &mut bytes_written, last_type);
+                    }
+
+                    hash_bytes(
+                        state,
+                        &mut bytes_written,
+                        &mut last_type,
+                        label.get().as_bytes(),
+                        LastType::Hole,
+                    );
+                    hash_trailer(state, &mut bytes_written, last_type);
+                }
+            }
+        }
+
+        if last_type == LastType::Text {
+            hash_trailer(state, &mut bytes_written, last_type);
+        }
     }
 }
 
@@ -338,7 +468,7 @@ impl<'a, P: Props> Render<'a, P> {
     The [`Write`] is fed the tokens of the template along with properties matching the labels of its holes.
     */
     pub fn write(&self, mut writer: impl Write) -> fmt::Result {
-        for part in self.tpl.0.parts() {
+        for part in self.tpl.kind.parts() {
             part.write(self.escape, &mut writer, &self.props)?;
         }
 
@@ -467,8 +597,14 @@ impl<W: fmt::Write> fmt::Write for WriteEscaped<W> {
 /**
 An individual token in a [`Template`].
 */
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Part<'a>(PartKind<'a>);
+
+impl<'a> fmt::Display for Part<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.write(true, f, Empty)
+    }
+}
 
 impl Part<'static> {
     /**
@@ -610,17 +746,19 @@ impl<'a> Part<'a> {
     }
 
     /**
-    Mark whether the part should check for, and escape any `{` or `}` characters when formatting.
+    Mark whether the part should check for, and escape any `{` or `}` characters when formatting, without checking if escaping is actually necessary.
 
-    It is only valid call this function with `false` if the part is known not to contain any `{` or `}`.
+    It is only valid to call this method on a text part with `false` if the part does not contain any `{` or `}` characters.
+
+    This method is not unsafe. There are no memory safety properties tied to the validity of templates. Code that uses parts may panic or produce unexpected results if given an invalid template.
     */
-    pub const fn with_escaping(mut self, escape: bool) -> Self {
+    pub const fn with_needs_escaping_raw(mut self, needs_escaping: bool) -> Self {
         if let PartKind::Text {
             needs_escaping: ref mut slot,
             ..
         } = self.0
         {
-            *slot = escape;
+            *slot = needs_escaping;
         }
 
         self
@@ -724,6 +862,12 @@ pub struct Formatter {
     fmt: fn(Value, &mut fmt::Formatter) -> fmt::Result,
 }
 
+impl fmt::Debug for Formatter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Formatter").finish_non_exhaustive()
+    }
+}
+
 impl Formatter {
     /**
     Create a formatter from the given function.
@@ -763,7 +907,7 @@ impl Formatter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum PartKind<'a> {
     Text {
         value: Str<'a>,
@@ -788,7 +932,9 @@ mod alloc_support {
         pub fn new_owned(parts: impl Into<Box<[Part<'static>]>>) -> Self {
             let parts = parts.into();
 
-            Template(TemplateKind::Owned(parts))
+            Template {
+                kind: TemplateKind::Owned(parts),
+            }
         }
     }
 
@@ -799,7 +945,7 @@ mod alloc_support {
         If the template already contains owned data then this method will simply clone it.
         */
         pub fn to_owned(&self) -> Template<'static> {
-            match self.0 {
+            match self.kind {
                 TemplateKind::Owned(ref parts) => Template::new_owned(parts.clone()),
                 ref parts => {
                     let mut dst = Vec::new();
@@ -925,6 +1071,18 @@ mod tests {
         BuildHasherDefault::<DefaultHasher>::default().hash_one(h)
     }
 
+    fn parts_to_string(parts: &[Part]) -> String {
+        use std::fmt::Write as _;
+
+        let mut buf = String::new();
+
+        for part in parts {
+            write!(&mut buf, "{part}").unwrap();
+        }
+
+        buf
+    }
+
     #[test]
     fn literal() {
         let tpl = Template::literal("text");
@@ -936,6 +1094,7 @@ mod tests {
     fn eq() {
         for (a, b, expected) in [
             (&[Part::text("")] as &[_], &[Part::text("")] as &[_], true),
+            (&[Part::text("")] as &[_], &[] as &[_], true),
             (&[Part::text("a")], &[Part::text("a")], true),
             (
                 &[Part::text("a"), Part::text("b")],
@@ -950,6 +1109,10 @@ mod tests {
             ),
             (&[Part::text("a")], &[Part::text("b")], false),
             (&[Part::hole("a")], &[Part::hole("b")], false),
+            (&[Part::text("a")], &[Part::hole("a")], false),
+            (&[Part::text("{a}")], &[Part::hole("a")], false),
+            (&[Part::text(""), Part::hole("a")], &[Part::hole("a")], true),
+            (&[Part::hole("a"), Part::text("")], &[Part::hole("a")], true),
             (
                 &[
                     Part::text("a"),
@@ -974,13 +1137,36 @@ mod tests {
             let ah = hash(&a);
             let bh = hash(&b);
 
-            assert_eq!(a, a, "{a:?} == {a:?}");
-            assert_eq!(b, b, "{b:?} == {b:?}");
+            assert_eq!(a, a, "{:?} == {:?}", a.kind, a.kind);
+            assert_eq!(b, b, "{:?} == {:?}", b.kind, b.kind);
 
-            assert_eq!(expected, a == b, "{a:?} == {b:?}");
-            assert_eq!(expected, b == a, "{b:?} == {a:?}");
+            assert_eq!(expected, a == b, "{:?} == {:?}", a.kind, b.kind);
+            assert_eq!(expected, b == a, "{:?} == {:?}", b.kind, a.kind);
 
-            assert_eq!(expected, ah == bh, "{ah} == {bh}");
+            assert_eq!(expected, ah == bh, "h({:?}) == h({:?})", a.kind, b.kind);
+
+            assert_eq!(
+                expected,
+                a.to_string() == b.to_string(),
+                "{:?}.to_string() == {:?}.to_string()",
+                a.kind,
+                b.kind
+            );
+
+            assert_eq!(
+                a.to_string(),
+                parts_to_string(a.kind.parts()),
+                "{:?}.parts() == {:?}.parts()",
+                a.kind,
+                a.kind
+            );
+            assert_eq!(
+                b.to_string(),
+                parts_to_string(b.kind.parts()),
+                "{:?}.parts() == {:?}.parts()",
+                b.kind,
+                b.kind
+            );
         }
     }
 
@@ -1012,7 +1198,7 @@ mod tests {
             (
                 Template::new({
                     const PARTS: &'static [Part<'static>] =
-                        &[Part::text("{}").with_escaping(false)];
+                        &[Part::text("{}").with_needs_escaping_raw(false)];
 
                     PARTS
                 }),

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -16,7 +16,11 @@ Hello, Rust.
 `Template`s are conceptually similar to the standard library's `Arguments` type. The key difference between them is that templates are a runtime construct rather than a compile time one. You can construct a template programmatically, inspect its holes, and choose to render it in any way you like. The standard library's formatting APIs are optimized for producing strings. Templates are both a property capturing and a formatting tool.
 */
 
-use core::{cmp, fmt, slice};
+use core::{
+    cmp, fmt,
+    hash::{Hash, Hasher},
+    slice,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -273,6 +277,18 @@ impl<'a, 'b> PartialEq<Template<'b>> for Template<'a> {
 }
 
 impl<'a> Eq for Template<'a> {}
+
+impl<'a> Hash for Template<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        /*
+        Must be equivalent to `partial_eq`
+        */
+
+        let _ = state;
+
+        todo!();
+    }
+}
 
 /**
 The result of calling [`Template::render`].
@@ -903,6 +919,12 @@ impl<'k, P: Props> serde::Serialize for Render<'k, P> {
 mod tests {
     use super::*;
 
+    use std::hash::{BuildHasher, BuildHasherDefault, DefaultHasher};
+
+    fn hash(h: &(impl Hash + ?Sized)) -> u64 {
+        BuildHasherDefault::<DefaultHasher>::default().hash_one(h)
+    }
+
     #[test]
     fn literal() {
         let tpl = Template::literal("text");
@@ -949,8 +971,16 @@ mod tests {
             let a = Template::new_ref(&a);
             let b = Template::new_ref(&b);
 
+            let ah = hash(&a);
+            let bh = hash(&b);
+
+            assert_eq!(a, a, "{a:?} == {a:?}");
+            assert_eq!(b, b, "{b:?} == {b:?}");
+
             assert_eq!(expected, a == b, "{a:?} == {b:?}");
             assert_eq!(expected, b == a, "{b:?} == {a:?}");
+
+            assert_eq!(expected, ah == bh, "{ah} == {bh}");
         }
     }
 

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -748,7 +748,9 @@ impl<'a> Part<'a> {
     /**
     Mark whether the part should check for, and escape any `{` or `}` characters when formatting, without checking if escaping is actually necessary.
 
-    It is only valid to call this method on a text part with `false` if the part does not contain any `{` or `}` characters.
+    This method only applies to [`Part::text`]s. It's a no-op in other cases.
+
+    It is only valid to call this method on a text part with `false` if the text part does not contain any `{` or `}` characters.
 
     This method is not unsafe. There are no memory safety properties tied to the validity of templates. Code that uses parts may panic or produce unexpected results if given an invalid template.
     */
@@ -764,6 +766,11 @@ impl<'a> Part<'a> {
         self
     }
 
+    /**
+    Format the part into the given `writer`, filling any holes with values from `props`.
+
+    If `escape` is `true` then any text parts with `{` or `}` characters will be escaped as `{{` and `}}`.
+    */
     fn write(&self, escape: bool, mut writer: impl Write, props: impl Props) -> fmt::Result {
         match self.0 {
             PartKind::Text {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -37,4 +37,4 @@ version = "1.17.2"
 path = "../core"
 
 [dependencies.fv-template]
-version = "0.5.1"
+version = "0.6"

--- a/macros/src/template.rs
+++ b/macros/src/template.rs
@@ -135,14 +135,14 @@ struct TemplateVisitor<'a> {
 }
 
 impl<'a> fv_template::LiteralVisitor for TemplateVisitor<'a> {
-    fn visit_hole(&mut self, hole: &FieldValue) {
+    fn visit_hole(&mut self, hole: fv_template::Hole) {
         let Ok(ref mut parts) = self.parts else {
             return;
         };
 
         if let Err(e) = (|| {
-            let label = hole.key_name()?;
-            let hole = hole.key_expr()?;
+            let label = hole.get().key_name()?;
+            let hole = hole.get().key_expr()?;
 
             let field = self.props.get(&label).expect("missing prop");
 
@@ -165,13 +165,16 @@ impl<'a> fv_template::LiteralVisitor for TemplateVisitor<'a> {
         }
     }
 
-    fn visit_text(&mut self, text: &str) {
+    fn visit_text(&mut self, text: fv_template::Text) {
         let Ok(ref mut parts) = self.parts else {
             return;
         };
 
+        let needs_escaping = text.needs_escaping();
+        let text = text.get();
+
         self.literal.push_str(text);
 
-        parts.push(quote!(emit::template::Part::text(#text)));
+        parts.push(quote!(emit::template::Part::text(#text).with_escaping(#needs_escaping)));
     }
 }

--- a/macros/src/template.rs
+++ b/macros/src/template.rs
@@ -171,20 +171,15 @@ impl<'a> fv_template::LiteralVisitor for TemplateVisitor<'a> {
         };
 
         let needs_escaping = text.needs_escaping();
-
         let raw_text = text.get();
 
-        if needs_escaping {
-            // Roundtrip through `Part` to perform escaping
-            write!(
-                &mut self.literal,
-                "{}",
-                emit_core::template::Part::text_ref(text.get())
-            )
-            .expect("infallible write");
-        } else {
-            self.literal.push_str(&raw_text);
-        };
+        // Roundtrip through `Part` to perform escaping
+        write!(
+            &mut self.literal,
+            "{}",
+            emit_core::template::Part::text_ref(raw_text).with_needs_escaping_raw(needs_escaping)
+        )
+        .expect("infallible write");
 
         parts.push(
             quote!(emit::template::Part::text(#raw_text).with_needs_escaping_raw(#needs_escaping)),

--- a/macros/src/template.rs
+++ b/macros/src/template.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Write as _};
 
 use proc_macro2::TokenStream;
 
@@ -171,10 +171,23 @@ impl<'a> fv_template::LiteralVisitor for TemplateVisitor<'a> {
         };
 
         let needs_escaping = text.needs_escaping();
-        let text = text.get();
 
-        self.literal.push_str(text);
+        let raw_text = text.get();
 
-        parts.push(quote!(emit::template::Part::text(#text).with_escaping(#needs_escaping)));
+        if needs_escaping {
+            // Roundtrip through `Part` to perform escaping
+            write!(
+                &mut self.literal,
+                "{}",
+                emit_core::template::Part::text_ref(text.get())
+            )
+            .expect("infallible write");
+        } else {
+            self.literal.push_str(&raw_text);
+        };
+
+        parts.push(
+            quote!(emit::template::Part::text(#raw_text).with_needs_escaping_raw(#needs_escaping)),
+        );
     }
 }

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -328,6 +328,33 @@ fn span_guard_props() {
 }
 
 #[test]
+fn span_name_escape() {
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(
+                "{{test}}",
+                evt.props().pull::<&str, _>("span_name").unwrap()
+            );
+        },
+        |evt| {
+            assert_eq!(
+                "{{test}}",
+                evt.props().pull::<&str, _>("span_name").unwrap()
+            );
+
+            true
+        },
+    );
+
+    #[emit::span(rt: RT, "{{test}}")]
+    fn exec() {}
+
+    exec();
+
+    RT.emitter().blocking_flush(Duration::from_secs(1));
+}
+
+#[test]
 fn span_mdl() {
     static RT: StaticRuntime = static_runtime(
         |evt| {

--- a/test/ui/src/tpl.rs
+++ b/test/ui/src/tpl.rs
@@ -39,3 +39,14 @@ fn tpl_fmt() {
     assert_eq!("user", parts[1].label().unwrap());
     assert!(parts[1].formatter().is_some());
 }
+
+#[test]
+fn tpl_escape() {
+    let tpl = emit::tpl!("Hello, {{user}}");
+
+    assert_eq!("Hello, {{user}}", tpl.to_string());
+
+    let parts = tpl.parts().collect::<::std::vec::Vec<_>>();
+
+    assert_eq!("Hello, {user}", parts[0].as_text().unwrap());
+}


### PR DESCRIPTION
Closes #343 

This PR ensures a template like `{{"x":{x}}}` will properly format as `{{"x":{x}}}` in its `Display` and `Debug` implementation so that it can roundtrip as the original template. When rendering a template via the `.render()` method, no escaping will be performed by default, so if `x` is missing, you'll still get `{"x":{x}}`.

Before committing to this, I'd like to see if there's a better API that pushes unescaping onto the `Write` implementation, so consumers get more control over how escaping is done, and can ignore it if they want. Whether that turns out to be better depends on what it's like to wrap an escaping/non-escaping `Write`.