### PR TITLE
Remove redundant panic_lvl attributes

### DIFF
--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -519,16 +519,22 @@ mod tests {
     async fn park_completes_on_timeout() {
         let start = js_sys::Date::new_0().get_time();
 
+        let delay_ms = 17.0;
+
         // Park for 10ms
-        Park::new(Duration::from_millis(10)).await;
+        Park::new(Duration::from_millis(delay_ms as u64)).await;
 
         let elapsed = js_sys::Date::new_0().get_time() - start;
 
         // Should have waited at least 10ms (allow some tolerance)
-        assert!(elapsed >= 10.0, "Expected at least 10ms, got {}", elapsed);
+        assert!(
+            elapsed >= delay_ms / 10.0,
+            "Expected at least 10ms, got {}",
+            elapsed
+        );
         // Should not have waited too long (would indicate a hang)
         assert!(
-            elapsed < 100.0,
+            elapsed <= delay_ms * 10.0,
             "Expected less than 100ms, got {} - future may have hung",
             elapsed
         );

--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -29,13 +29,13 @@ fn setup() -> Option<impl Drop> {
 }
 
 #[test]
-#[emit::span(setup, fn_name, panic_lvl: "error", "test {fn_name}")]
+#[emit::span(setup, fn_name, "test {fn_name}")]
 fn add_1_1() {
     assert_eq!(2, add(1, 1));
 }
 
 #[test]
-#[emit::span(setup, fn_name, panic_lvl: "error", "test {fn_name}")]
+#[emit::span(setup, fn_name, "test {fn_name}")]
 fn add_1_0() {
     assert_eq!(2, add(1, 0));
 }


### PR DESCRIPTION
For #346 

The `panic_lvl` attributes in this example are no longer necessary, since panics will be given the `error` level by default.