### PR TITLE
Support catching panic payloads in `#[emit::span]`

### DIFF
--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -561,14 +561,7 @@ mod tests {
     async fn park_zero_duration() {
         let start = js_sys::Date::new_0().get_time();
 
-        // Park for 0ms (should use minimum 1ms)
+        // Just ensure we don't panic
         Park::new(Duration::ZERO).await;
-
-        let elapsed = js_sys::Date::new_0().get_time() - start;
-
-        // Should have waited at least 1ms (setTimeout minimum)
-        assert!(elapsed >= 1.0, "Expected at least 1ms, got {}", elapsed);
-        // Should not have waited too long
-        assert!(elapsed < 50.0, "Expected less than 50ms, got {}", elapsed);
     }
 }

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -200,6 +200,7 @@ impl Future for Park {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        // SAFETY: `self` does not use interior pinning
         let unpinned = unsafe { self.get_unchecked_mut() };
 
         if unpinned.state.borrow_mut().done {

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -30,6 +30,7 @@
         - [Reporting from sources](./producing-events/metrics/reporting-sources.md)
         - [Limitations](./producing-events/metrics/limitations.md)
     - [Quick debugging](./producing-events/quick-debugging.md)
+    - [In tests](./producing-events/testing.md)
 - [Filtering events](./filtering-events.md)
 - [Working with events](./working-with-events.md)
 - [Emitting events](./emitting-events.md)

--- a/book/src/producing-events/testing.md
+++ b/book/src/producing-events/testing.md
@@ -1,0 +1,76 @@
+# In tests
+
+`emit` can be configured in `#[test]` functions using the [`#[span]`](https://docs.rs/emit/1.17.2/emit/attr.span.html) attribute. There are several useful [control parameters](../reference/control-parameters.md) you can use to improve diagnostics in tests:
+
+- `setup`: Run some code at the start of the annotated function. We can use `setup` in tests to configure the `emit` runtime. When multiple tests share the same setup the first to execute will initialize the runtime.
+- `fn_name`: Include a property with the name of the annotated function. We can use `fn_name` to distinguish tests in the output.
+- `catch_unwind`: Wrap the annotated function in `catch_unwind`. We can use `catch_unwind` to make assertion failures appear on the resulting span.
+
+Here's a simple example of some `emit` testing infrastructure:
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+// This is the piece of code we're going to test
+pub fn add(a: i32, b: i32) -> i32 {
+    let r = a + b;
+
+    emit::debug!("{r} = {a} + {b}");
+
+    r
+}
+
+// A function called at the start of each `#[test]`
+#[cfg(test)]
+fn setup() -> Option<impl Drop> {
+	// Configure `emit`'s runtime
+    let rt = emit::setup()
+        .emit_to(emit_term::stdout())
+        .try_init()
+        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)));
+
+    // Set a panic hook so the location of the panic will also be captured
+    // We only need to do this once
+    if rt.is_some() {
+        std::panic::set_hook(Box::new(|payload| {
+            emit::error!("panic detected", #[emit::as_display] err: payload);
+        }));
+    }
+
+    rt
+}
+
+// Annotate test functions with `emit::span`, including the `setup` control parameter
+// for our `setup` function above
+#[test]
+#[emit::span(setup, fn_name, "test {fn_name}")]
+fn add_1_1() {
+    assert_eq!(2, add(1, 1));
+}
+```
+
+The `setup` function in the above example uses [`emit_term`](https://docs.rs/emit_term/1.17.2/emit_term/index.html) as its emitter. Since it uses `stdout` directly, it bypasses Rust's default test harness behavior of capturing output for passing tests. To preserve the default capturing, you can instead emit events with `println!`s:
+
+```rust
+# extern crate emit;
+fn setup() -> Option<impl Drop> {
+	emit::setup()
+        .emit_to(emit::emitter::from_fn(|evt| println!("{evt:?}")))
+        .try_init()
+        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)))
+}
+```
+
+The `setup` function also uses `panic::set_hook` to capture panics from failed assertions instead of adding the `catch_unwind` control parameter to the `#[span]` attribute. Rust's panic hooks are given more information about a panic than `catch_unwind`, so using a hook means we still get the location where the panic was first thrown. It might not be practical for all applications to use a panic hook this way, in which case you can still get the panic payload with the `catch_unwind` control parameter:
+
+```rust
+# extern crate emit;
+# extern crate emit_term;
+# pub fn add(a: i32, b: i32) -> i32 { a + b }
+# fn setup() {}
+#[test]
+#[emit::span(setup, catch_unwind: true, fn_name, "test {fn_name}")]
+fn add_1_1() {
+    assert_eq!(2, add(1, 1));
+}
+```

--- a/emitter/otlp/src/client/http/tokio.rs
+++ b/emitter/otlp/src/client/http/tokio.rs
@@ -8,7 +8,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{Arc, LazyLock, Mutex},
-    task::{self, Context, Poll},
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -400,7 +400,7 @@ impl HttpResponse {
         impl<'a, T: FnMut(&str, &str)> Future for BufNext<'a, T> {
             type Output = Result<bool, Error>;
 
-            fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+            fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
                 // SAFETY: `self` does not use interior pinning
                 let BufNext(incoming, trailer) = unsafe { Pin::get_unchecked_mut(self) };
 

--- a/emitter/term/src/lib.rs
+++ b/emitter/term/src/lib.rs
@@ -329,11 +329,11 @@ fn write_event(buf: &mut Buffer, evt: emit::event::Event<impl emit::props::Props
     write_plain(buf, "\n");
 
     if let Some(err) = evt.props().get(KEY_ERR) {
-        if let Some(err) = err.to_borrowed_error() {
-            write_plain(buf, "  ");
-            try_write_fg(buf, "err", lvl);
-            write_plain(buf, format_args!(": {err}\n"));
+        write_plain(buf, "  ");
+        try_write_fg(buf, "err", lvl);
+        write_plain(buf, format_args!(": {err}\n"));
 
+        if let Some(err) = err.to_borrowed_error() {
             for cause in iter::successors(err.source(), |err| (*err).source()) {
                 write_plain(buf, "  ");
                 try_write_fg(buf, "caused by", lvl);

--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -22,20 +22,30 @@ pub fn add(a: i32, b: i32) -> i32 {
 // at the end of the annotated function
 #[cfg(test)]
 fn setup() -> Option<impl Drop> {
-    emit::setup()
+    let rt = emit::setup()
         .emit_to(emit_term::stdout())
         .try_init()
-        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)))
+        .map(|init| init.flush_on_drop(std::time::Duration::from_secs(1)));
+
+    // Set a panic hook so the location of the panic will also be captured
+    // We only need to do this once
+    if rt.is_some() {
+        std::panic::set_hook(Box::new(|payload| {
+            emit::error!("panic detected", #[emit::as_display] err: payload);
+        }));
+    }
+
+    rt
 }
 
 #[test]
-#[emit::span(setup, fn_name, catch_unwind: true, "test {fn_name}")]
+#[emit::span(setup, fn_name, "test {fn_name}")]
 fn add_1_1() {
     assert_eq!(2, add(1, 1));
 }
 
 #[test]
-#[emit::span(setup, fn_name, catch_unwind: true, "test {fn_name}")]
+#[emit::span(setup, fn_name, "test {fn_name}")]
 fn add_1_0() {
     assert_eq!(2, add(1, 0));
 }

--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -29,13 +29,13 @@ fn setup() -> Option<impl Drop> {
 }
 
 #[test]
-#[emit::span(setup, fn_name, "test {fn_name}")]
+#[emit::span(setup, fn_name, catch_unwind, "test {fn_name}")]
 fn add_1_1() {
     assert_eq!(2, add(1, 1));
 }
 
 #[test]
-#[emit::span(setup, fn_name, "test {fn_name}")]
+#[emit::span(setup, fn_name, catch_unwind, "test {fn_name}")]
 fn add_1_0() {
     assert_eq!(2, add(1, 0));
 }

--- a/examples/common_patterns/testing.rs
+++ b/examples/common_patterns/testing.rs
@@ -29,13 +29,13 @@ fn setup() -> Option<impl Drop> {
 }
 
 #[test]
-#[emit::span(setup, fn_name, catch_unwind, "test {fn_name}")]
+#[emit::span(setup, fn_name, catch_unwind: true, "test {fn_name}")]
 fn add_1_1() {
     assert_eq!(2, add(1, 1));
 }
 
 #[test]
-#[emit::span(setup, fn_name, catch_unwind, "test {fn_name}")]
+#[emit::span(setup, fn_name, catch_unwind: true, "test {fn_name}")]
 fn add_1_0() {
     assert_eq!(2, add(1, 0));
 }

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -23,19 +23,16 @@ pub struct Arg<T> {
 
 impl Arg<bool> {
     pub fn bool(key: &'static str) -> Self {
-        Arg::new(key, move |fv| {
-            if let Expr::Lit(ExprLit {
+        Arg::new(key, move |fv| match fv.expr {
+            Expr::Lit(ExprLit {
                 lit: Lit::Bool(ref l),
                 ..
-            }) = fv.expr
-            {
-                Ok(l.value)
-            } else {
-                Err(syn::Error::new(
-                    fv.expr.span(),
-                    format_args!("`{}` requires a boolean value", key),
-                ))
-            }
+            }) => Ok(l.value),
+            Expr::Path(ExprPath { ref path, .. }) if path.is_ident(key) => Ok(true),
+            _ => Err(syn::Error::new(
+                fv.expr.span(),
+                format_args!("`{}` requires a boolean value", key),
+            )),
         })
     }
 }

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -28,7 +28,6 @@ impl Arg<bool> {
                 lit: Lit::Bool(ref l),
                 ..
             }) => Ok(l.value),
-            Expr::Path(ExprPath { ref path, .. }) if path.is_ident(key) => Ok(true),
             _ => Err(syn::Error::new(
                 fv.expr.span(),
                 format_args!("`{}` requires a boolean value", key),
@@ -39,39 +38,32 @@ impl Arg<bool> {
 
 impl Arg<String> {
     pub fn str(key: &'static str) -> Self {
-        Arg::new(key, move |fv| {
-            if let Expr::Lit(ExprLit {
+        Arg::new(key, move |fv| match fv.expr {
+            Expr::Lit(ExprLit {
                 lit: Lit::Str(ref l),
                 ..
-            }) = fv.expr
-            {
-                Ok(l.value())
-            } else {
-                Err(syn::Error::new(
-                    fv.expr.span(),
-                    format_args!("`{}` requires a string value", key),
-                ))
-            }
+            }) => Ok(l.value()),
+            _ => Err(syn::Error::new(
+                fv.expr.span(),
+                format_args!("`{}` requires a string value", key),
+            )),
         })
     }
 }
 
 impl Arg<Ident> {
     pub fn ident(key: &'static str) -> Self {
-        Arg::new(key, move |fv| {
-            if let Expr::Path(ExprPath { ref path, .. }) = fv.expr {
-                path.get_ident().cloned().ok_or_else(|| {
-                    syn::Error::new(
-                        fv.expr.span(),
-                        format_args!("`{}` requires an identifier value", key),
-                    )
-                })
-            } else {
-                Err(syn::Error::new(
+        Arg::new(key, move |fv| match fv.expr {
+            Expr::Path(ExprPath { ref path, .. }) => path.get_ident().cloned().ok_or_else(|| {
+                syn::Error::new(
                     fv.expr.span(),
-                    format_args!("`{}` requires a string value", key),
-                ))
-            }
+                    format_args!("`{}` requires an identifier value", key),
+                )
+            }),
+            _ => Err(syn::Error::new(
+                fv.expr.span(),
+                format_args!("`{}` requires a string value", key),
+            )),
         })
     }
 }

--- a/macros/src/doc_span.md
+++ b/macros/src/doc_span.md
@@ -47,18 +47,19 @@ where
 
 This macro accepts the following optional control parameters:
 
-| name        | type                          | description                                                                                                                                                                         |
-|-------------| ----------------------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `rt`        | `impl emit::runtime::Runtime` | The runtime to emit the event through.                                                                                                                                              |
-| `mdl`       | `impl Into<emit::Path>`       | The module the event belongs to. If unspecified the current module path is used.                                                                                                    |
-| `when`      | `impl emit::Filter`           | A filter to use instead of the one configured on the runtime.                                                                                                                       |
-| `guard`     | -                             | An identifier to bind an `emit::SpanGuard` to in the body of the span for manual completion.                                                                                        |
-| `fn_name`   | -                             | An identifier to bind the name of the annotated function to in the body of the span. The name is not automatically included on the span, but can be attached as a regular property. |
-| `ok_lvl`    | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.                                                                         |
-| `err_lvl`   | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.                             |
-| `panic_lvl` | `str` or `emit::Level`        | Detect whether the function panics and use the given level if it does.                                                                                                              |
-| `err`       | `impl Fn(&E) -> T`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `T` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static`                      |
-| `setup`     | `impl Fn() -> T`              | Invoke the expression before creating the span, binding the result to a value that's dropped at the end of the annotated function.                                                  |
+| name           | type                          | description                                                                                                                                                                         |
+|----------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rt`           | `impl emit::runtime::Runtime` | The runtime to emit the event through.                                                                                                                                              |
+| `mdl`          | `impl Into<emit::Path>`       | The module the event belongs to. If unspecified the current module path is used.                                                                                                    |
+| `when`         | `impl emit::Filter`           | A filter to use instead of the one configured on the runtime.                                                                                                                       |
+| `guard`        | -                             | An identifier to bind an `emit::SpanGuard` to in the body of the span for manual completion.                                                                                        |
+| `fn_name`      | -                             | An identifier to bind the name of the annotated function to in the body of the span. The name is not automatically included on the span, but can be attached as a regular property. |
+| `ok_lvl`       | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Ok`.                                                                         |
+| `err_lvl`      | `str` or `emit::Level`        | Assume the instrumented block returns a `Result`. Assign the event the given level when the result is `Err` and attach the error as the `err` property.                             |
+| `panic_lvl`    | `str` or `emit::Level`        | Detect whether the function panics and use the given level if it does.                                                                                                              |
+| `catch_unwind` | `bool`                        | Whether to wrap the instrumented block in a `catch_unwind`. If the block panics, the payload will be included as the `err` property.                                                |
+| `err`          | `impl Fn(&E) -> T`            | Assume the instrumented block returns a `Result`. Map the `Err` variant into a new type `T` that is `str`, `&(dyn Error + 'static)`, or `impl Error + 'static`                      |
+| `setup`        | `impl Fn() -> T`              | Invoke the expression before creating the span, binding the result to a value that's dropped at the end of the annotated function.                                                  |
 
 ## Parameter binding ordering
 

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -621,6 +621,12 @@ fn result_completion(
         })
     };
 
+    let panic_lvl_tokens = lvl_tokens(
+        panic_lvl_tokens.as_ref(),
+        default_lvl_tokens.as_ref(),
+        emit_core::well_known::LVL_ERROR,
+    );
+
     let body_tokens = if catch_unwind {
         quote!(match #body_tokens {
             emit::__private::core::result::Result::Ok(emit::__private::core::result::Result::Ok(__ok)) => #ok_branch,
@@ -644,11 +650,6 @@ fn result_completion(
     };
 
     // Similar to the non-result `completion` variant
-    let panic_lvl_tokens = lvl_tokens(
-        panic_lvl_tokens.as_ref(),
-        default_lvl_tokens.as_ref(),
-        emit_core::well_known::LVL_ERROR,
-    );
     let lvl_tokens = optional_lvl_tokens(default_lvl_tokens.as_ref(), default_lvl_tokens.as_ref());
 
     let default_completion_tokens = quote!(emit::__private::__private_complete_span(

--- a/macros/src/span.rs
+++ b/macros/src/span.rs
@@ -28,6 +28,7 @@ struct Args {
     when: args::WhenArg,
     guard: Option<Ident>,
     fn_name: Option<Ident>,
+    catch_unwind: Option<bool>,
     setup: Option<TokenStream>,
     ok_lvl: Option<TokenStream>,
     err_lvl: Option<TokenStream>,
@@ -78,8 +79,8 @@ impl Parse for Args {
             Ok(quote_spanned!(expr.span()=> #expr))
         });
         let mut guard = Arg::ident("guard");
-
         let mut fn_name = Arg::ident("fn_name");
+        let mut catch_unwind = Arg::bool("catch_unwind");
 
         args::set_from_field_values(
             input.parse_terminated(FieldValue::parse, Token![,])?.iter(),
@@ -92,14 +93,19 @@ impl Parse for Args {
                 &mut ok_lvl,
                 &mut err_lvl,
                 &mut panic_lvl,
+                &mut catch_unwind,
                 &mut setup,
                 &mut err,
             ],
         )?;
 
         if let Some(guard) = guard.peek() {
-            if ok_lvl.peek().is_some() || err_lvl.peek().is_some() || err.peek().is_some() {
-                return Err(syn::Error::new(guard.span(), "the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`"));
+            if ok_lvl.peek().is_some()
+                || err_lvl.peek().is_some()
+                || err.peek().is_some()
+                || catch_unwind.peek().is_some()
+            {
+                return Err(syn::Error::new(guard.span(), "the `guard` control parameter is incompatible with `catch_unwind`, `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`"));
             }
         }
 
@@ -110,6 +116,7 @@ impl Parse for Args {
             ok_lvl: ok_lvl.take_if_std()?,
             err_lvl: err_lvl.take_if_std()?,
             panic_lvl: panic_lvl.take_if_std()?,
+            catch_unwind: catch_unwind.take(),
             err: err.take_if_std()?,
             setup: setup.take(),
             guard: guard.take(),
@@ -140,6 +147,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
     let ok_lvl_tokens = args.ok_lvl;
     let err_lvl_tokens = args.err_lvl;
     let err_tokens = args.err;
+    let catch_unwind = args.catch_unwind.unwrap_or_default();
     let setup_tokens = args.setup;
 
     let rt_tokens = args.rt.to_tokens()?.to_ref_tokens();
@@ -195,6 +203,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
                 ok_lvl_tokens,
                 err_lvl_tokens,
                 err_tokens,
+                catch_unwind,
             )?)?;
         }
         // A synchronous block
@@ -215,6 +224,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
                 ok_lvl_tokens,
                 err_lvl_tokens,
                 err_tokens,
+                catch_unwind,
             )?)?;
         }
         // An asynchronous function
@@ -241,6 +251,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
                 ok_lvl_tokens,
                 err_lvl_tokens,
                 err_tokens,
+                catch_unwind,
             )?)?;
         }
         // An asynchronous block
@@ -261,6 +272,7 @@ pub fn expand_tokens(opts: ExpandTokens) -> Result<TokenStream, syn::Error> {
                 ok_lvl_tokens,
                 err_lvl_tokens,
                 err_tokens,
+                catch_unwind,
             )?)?;
         }
         _ => return Err(syn::Error::new(item.span(), "unrecognized item type")),
@@ -285,9 +297,16 @@ fn inject_sync(
     ok_lvl_tokens: Option<TokenStream>,
     err_lvl_tokens: Option<TokenStream>,
     err_tokens: Option<TokenStream>,
+    catch_unwind: bool,
 ) -> Result<TokenStream, syn::Error> {
     let template_tokens = template.template_tokens();
     let span_name_tokens = template.template_literal_tokens();
+
+    let body_tokens = if catch_unwind {
+        quote!(emit::__private::__private_catch_unwind(move || { #body_tokens }))
+    } else {
+        body_tokens
+    };
 
     let Completion {
         body_tokens,
@@ -298,12 +317,15 @@ fn inject_sync(
         // without control flow statements like `return` getting in the way
         //
         // We can't use a drop guard here because we need to match on the result
-        //
-        // We also need to specify the return type, otherwise inference seems to fail.
-        // We might be able to avoid this in the future
-        let body_tokens = quote!((move || {
-            #body_tokens
-        })());
+        let body_tokens = if catch_unwind {
+            // We've already wrapped the body in a closure so don't
+            // need to do it again
+            body_tokens
+        } else {
+            quote!((move || {
+                #body_tokens
+            })())
+        };
 
         result_completion(
             body_tokens,
@@ -315,14 +337,17 @@ fn inject_sync(
             ok_lvl_tokens,
             err_lvl_tokens,
             err_tokens,
+            catch_unwind,
         )?
     } else {
         completion(
             body_tokens,
             rt_tokens,
             &template_tokens,
+            span_guard,
             default_lvl_tokens,
             panic_lvl_tokens,
+            catch_unwind,
         )?
     };
 
@@ -371,9 +396,18 @@ fn inject_async(
     ok_lvl_tokens: Option<TokenStream>,
     err_lvl_tokens: Option<TokenStream>,
     err_tokens: Option<TokenStream>,
+    catch_unwind: bool,
 ) -> Result<TokenStream, syn::Error> {
     let template_tokens = template.template_tokens();
     let span_name_tokens = template.template_literal_tokens();
+
+    let body_tokens = if catch_unwind {
+        quote!(emit::__private::__private_catch_unwind_async(async move {
+            #body_tokens
+        }).await)
+    } else {
+        body_tokens
+    };
 
     let Completion {
         body_tokens,
@@ -381,11 +415,16 @@ fn inject_async(
         default_completion_tokens,
     } = if use_result_completion(&ok_lvl_tokens, &err_lvl_tokens, &err_tokens) {
         // Like the sync case, ensure control flow doesn't interrupt
-        // our matching of the result, and provide a concrete type
-        // for inference
-        let body_tokens = quote!(async move {
-            #body_tokens
-        }.await);
+        // our matching of the result
+        let body_tokens = if catch_unwind {
+            // We've already wrapped the body in an async block so don't need
+            // to do it again
+            body_tokens
+        } else {
+            quote!(async move {
+                #body_tokens
+            }.await)
+        };
 
         result_completion(
             body_tokens,
@@ -397,14 +436,17 @@ fn inject_async(
             ok_lvl_tokens,
             err_lvl_tokens,
             err_tokens,
+            catch_unwind,
         )?
     } else {
         completion(
             body_tokens,
             rt_tokens,
             &template_tokens,
+            span_guard,
             default_lvl_tokens,
             panic_lvl_tokens,
+            catch_unwind,
         )?
     };
 
@@ -535,87 +577,79 @@ fn result_completion(
     ok_lvl_tokens: Option<TokenStream>,
     err_lvl_tokens: Option<TokenStream>,
     err_tokens: Option<TokenStream>,
+    catch_unwind: bool,
 ) -> Result<Completion, syn::Error> {
     // If the span is applied to a Result-returning function then wrap the body
     // We'll attach the error to the span if the call fails and set the appropriate level
 
     let ok_branch = {
-        let lvl_tokens = ok_lvl_tokens
-            .map(|lvl| lvl.to_ref_tokens())
-            .or_else(|| default_lvl_tokens.as_ref().map(|lvl| lvl.to_ref_tokens()))
-            .to_option_tokens(quote!(&emit::Level));
+        let lvl_tokens = optional_lvl_tokens(ok_lvl_tokens.as_ref(), default_lvl_tokens.as_ref());
 
-        quote!(
-            emit::__private::core::result::Result::Ok(__ok) => {
-                #span_guard.complete_with(emit::__private::__private_complete_span_ok(
-                    #rt_tokens,
-                    #template_tokens,
-                    #lvl_tokens,
-                ));
+        quote!({
+            #span_guard.complete_with(emit::__private::__private_complete_span_ok(
+                #rt_tokens,
+                #template_tokens,
+                #lvl_tokens,
+            ));
 
-                emit::__private::core::result::Result::Ok(__ok)
-            }
-        )
+            emit::__private::core::result::Result::Ok(__ok)
+        })
     };
 
     let err_branch = {
         // In the error case, we don't just defer to the default level
         // If none is set then we'll mark it as an error
-        let lvl_tokens = err_lvl_tokens
-            .map(|lvl| lvl.to_ref_tokens())
-            .or_else(|| default_lvl_tokens.as_ref().map(|lvl| lvl.to_ref_tokens()))
-            .unwrap_or_else(|| {
-                let err_lvl = emit_core::well_known::LVL_ERROR;
-
-                quote!(#err_lvl)
-            });
+        let lvl_tokens = lvl_tokens(
+            err_lvl_tokens.as_ref(),
+            default_lvl_tokens.as_ref(),
+            emit_core::well_known::LVL_ERROR,
+        );
 
         let err_tokens = err_tokens
             .map(|mapper| quote!((#mapper)(&__err)))
             .unwrap_or_else(|| quote!(&__err));
 
-        quote!(
-            emit::__private::core::result::Result::Err(__err) => {
-                #span_guard.complete_with(emit::__private::__private_complete_span_err(
-                    #rt_tokens,
-                    #template_tokens,
-                    #lvl_tokens,
-                    #err_tokens,
-                ));
+        quote!({
+            #span_guard.complete_with(emit::__private::__private_complete_span_err(
+                #rt_tokens,
+                #template_tokens,
+                #lvl_tokens,
+                #err_tokens,
+            ));
 
-                emit::__private::core::result::Result::Err(__err)
-            }
-        )
+            emit::__private::core::result::Result::Err(__err)
+        })
     };
 
-    let body_tokens = quote!(match #body_tokens {
-        #ok_branch,
-        #err_branch,
-    });
+    let body_tokens = if catch_unwind {
+        quote!(match #body_tokens {
+            emit::__private::core::result::Result::Ok(emit::__private::core::result::Result::Ok(__ok)) => #ok_branch,
+            emit::__private::core::result::Result::Ok(emit::__private::core::result::Result::Err(__err)) => #err_branch,
+            emit::__private::core::result::Result::Err(__panic) => {
+                #span_guard.complete_with(emit::__private::__private_complete_span_panic(
+                    #rt_tokens,
+                    #template_tokens,
+                    #panic_lvl_tokens,
+                    &__panic,
+                ));
 
-    completion(
-        body_tokens,
-        rt_tokens,
-        template_tokens,
-        default_lvl_tokens,
-        panic_lvl_tokens,
-    )
-}
+                emit::__private::__private_resume_unwind(__panic)
+            },
+        })
+    } else {
+        quote!(match #body_tokens {
+            emit::__private::core::result::Result::Ok(__ok) => #ok_branch,
+            emit::__private::core::result::Result::Err(__err) => #err_branch,
+        })
+    };
 
-fn completion(
-    body_tokens: TokenStream,
-    rt_tokens: &TokenStream,
-    template_tokens: &TokenStream,
-    default_lvl_tokens: Option<TokenStream>,
-    panic_lvl_tokens: Option<TokenStream>,
-) -> Result<Completion, syn::Error> {
-    let lvl_tokens = default_lvl_tokens
-        .map(|lvl| lvl.to_ref_tokens())
-        .to_option_tokens(quote!(&emit::Level));
-
-    let panic_lvl_tokens = panic_lvl_tokens
-        .map(|lvl| lvl.to_ref_tokens())
-        .to_option_tokens(quote!(&emit::Level));
+    // Similar to the non-result `completion` variant
+    let panic_lvl_tokens = lvl_tokens(
+        panic_lvl_tokens.as_ref(),
+        default_lvl_tokens.as_ref(),
+        emit_core::well_known::LVL_ERROR,
+    );
+    let lvl_tokens = optional_lvl_tokens(default_lvl_tokens.as_ref(), default_lvl_tokens.as_ref());
 
     let default_completion_tokens = quote!(emit::__private::__private_complete_span(
         #rt_tokens,
@@ -629,6 +663,75 @@ fn completion(
         default_lvl_tokens: lvl_tokens,
         default_completion_tokens,
     })
+}
+
+fn completion(
+    body_tokens: TokenStream,
+    rt_tokens: &TokenStream,
+    template_tokens: &TokenStream,
+    span_guard: &Ident,
+    default_lvl_tokens: Option<TokenStream>,
+    panic_lvl_tokens: Option<TokenStream>,
+    catch_unwind: bool,
+) -> Result<Completion, syn::Error> {
+    let panic_lvl_tokens = lvl_tokens(
+        panic_lvl_tokens.as_ref(),
+        default_lvl_tokens.as_ref(),
+        emit_core::well_known::LVL_ERROR,
+    );
+    let lvl_tokens = optional_lvl_tokens(default_lvl_tokens.as_ref(), default_lvl_tokens.as_ref());
+
+    let default_completion_tokens = quote!(emit::__private::__private_complete_span(
+        #rt_tokens,
+        #template_tokens,
+        #lvl_tokens,
+        #panic_lvl_tokens,
+    ));
+
+    let body_tokens = if catch_unwind {
+        quote!(match #body_tokens {
+            emit::__private::core::result::Result::Ok(__r) => __r,
+            emit::__private::core::result::Result::Err(__panic) => {
+                #span_guard.complete_with(emit::__private::__private_complete_span_panic(
+                    #rt_tokens,
+                    #template_tokens,
+                    #panic_lvl_tokens,
+                    &__panic,
+                ));
+
+                emit::__private::__private_resume_unwind(__panic)
+            },
+        })
+    } else {
+        body_tokens
+    };
+
+    Ok(Completion {
+        body_tokens,
+        default_lvl_tokens: lvl_tokens,
+        default_completion_tokens,
+    })
+}
+
+fn optional_lvl_tokens(
+    lvl_tokens: Option<&TokenStream>,
+    default_lvl_tokens: Option<&TokenStream>,
+) -> TokenStream {
+    lvl_tokens
+        .map(|lvl| lvl.to_ref_tokens())
+        .or_else(|| default_lvl_tokens.as_ref().map(|lvl| lvl.to_ref_tokens()))
+        .to_option_tokens(quote!(&emit::Level))
+}
+
+fn lvl_tokens(
+    lvl_tokens: Option<&TokenStream>,
+    default_lvl_tokens: Option<&TokenStream>,
+    fallback_value: &str,
+) -> TokenStream {
+    lvl_tokens
+        .map(|lvl| lvl.to_ref_tokens())
+        .or_else(|| default_lvl_tokens.as_ref().map(|lvl| lvl.to_ref_tokens()))
+        .unwrap_or_else(|| quote!(#fallback_value))
 }
 
 pub struct ExpandNewTokens {
@@ -660,6 +763,7 @@ pub fn expand_new_tokens(opts: ExpandNewTokens) -> Result<TokenStream, syn::Erro
         ok_lvl,
         err_lvl,
         panic_lvl,
+        catch_unwind,
         err,
     } = args;
 
@@ -667,6 +771,7 @@ pub fn expand_new_tokens(opts: ExpandNewTokens) -> Result<TokenStream, syn::Erro
     args::ensure_missing("setup", setup.map(|arg| arg.span()))?;
     args::ensure_missing("ok_lvl", ok_lvl.map(|arg| arg.span()))?;
     args::ensure_missing("err_lvl", err_lvl.map(|arg| arg.span()))?;
+    args::ensure_missing("catch_unwind", catch_unwind.map(|arg| arg.span()))?;
     args::ensure_missing("err", err.map(|arg| arg.span()))?;
     args::ensure_missing("fn_name", fn_name.map(|arg| arg.span()))?;
 
@@ -686,13 +791,12 @@ pub fn expand_new_tokens(opts: ExpandNewTokens) -> Result<TokenStream, syn::Erro
 
     let evt_props_tokens = quote!(emit::Empty);
 
-    let lvl_tokens = default_lvl_tokens
-        .map(|lvl| lvl.to_ref_tokens())
-        .to_option_tokens(quote!(&emit::Level));
-
-    let panic_lvl_tokens = panic_lvl_tokens
-        .map(|lvl| lvl.to_ref_tokens())
-        .to_option_tokens(quote!(&emit::Level));
+    let panic_lvl_tokens = lvl_tokens(
+        panic_lvl_tokens.as_ref(),
+        default_lvl_tokens.as_ref(),
+        emit_core::well_known::LVL_ERROR,
+    );
+    let lvl_tokens = optional_lvl_tokens(default_lvl_tokens.as_ref(), default_lvl_tokens.as_ref());
 
     Ok(quote!(
         emit::__private::__private_begin_span(

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -1071,6 +1071,7 @@ pub async fn __private_catch_unwind_async<R>(
         type Output = Result<F::Output, Box<dyn Any + Send>>;
 
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: The inner future inherits pinning from `CatchUnwind`
             let inner = unsafe { self.map_unchecked_mut(|f| &mut f.0) };
 
             match catch_unwind(AssertUnwindSafe(|| inner.poll(cx))) {

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -24,7 +24,14 @@ use emit_core::{
 use crate::{frame::Frame, span::Span, Metric};
 
 #[cfg(feature = "std")]
-use std::error::Error;
+use std::{
+    boxed::Box,
+    error::Error,
+    future::Future,
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::metric::{sampler, Sampler};
 use crate::{
@@ -904,7 +911,7 @@ pub fn __private_complete_span<'a, 'b, E, F, C, T, R, CL: ?Sized, CLP: ?Sized>(
     rt: &'a Runtime<E, F, C, T, R>,
     tpl: impl Into<Template<'b>>,
     lvl: Option<&'b CL>,
-    panic_lvl: Option<&'b CLP>,
+    panic_lvl: &'b CLP,
 ) -> __PrivateCompleteSpan<'a, 'b, E, F, C, T, R, CL, CLP> {
     __PrivateCompleteSpan {
         rt,
@@ -918,7 +925,7 @@ pub struct __PrivateCompleteSpan<'a, 'b, E, F, C, T, R, CL: ?Sized, CLP: ?Sized>
     rt: &'a Runtime<E, F, C, T, R>,
     tpl: Template<'b>,
     lvl: Option<&'b CL>,
-    panic_lvl: Option<&'b CLP>,
+    panic_lvl: &'b CLP,
 }
 
 impl<'a, 'b, E, F, C, T, R, CL, CLP> crate::span::completion::Completion
@@ -941,7 +948,7 @@ where
             completion = completion.with_lvl(lvl);
         }
 
-        if let Some(lvl) = self.panic_lvl.and_then(|lvl| lvl.capture()) {
+        if let Some(lvl) = self.panic_lvl.capture() {
             completion = completion.with_panic_lvl(lvl);
         }
 
@@ -1032,6 +1039,97 @@ where
     fn complete<P: Props>(&self, span: Span<P>) {
         let lvl_prop = self.lvl.capture().map(|lvl| (KEY_LVL, lvl));
         let err_prop = self.err.capture().map(|err| (KEY_ERR, err));
+
+        emit_core::emit(
+            self.rt.emitter(),
+            crate::Empty,
+            self.rt.ctxt(),
+            self.rt.clock(),
+            span.to_event()
+                .with_tpl(self.tpl.by_ref())
+                .map_props(|span_props| [lvl_prop, err_prop].and_props(span_props)),
+        );
+    }
+}
+
+#[track_caller]
+#[cfg(feature = "std")]
+pub fn __private_catch_unwind<R>(f: impl FnOnce() -> R) -> Result<R, Box<dyn Any + Send>> {
+    catch_unwind(AssertUnwindSafe(f))
+}
+
+#[cfg(feature = "std")]
+pub async fn __private_catch_unwind_async<R>(
+    f: impl Future<Output = R>,
+) -> Result<R, Box<dyn Any + Send>> {
+    struct CatchUnwind<F>(F);
+
+    impl<F> Future for CatchUnwind<F>
+    where
+        F: Future,
+    {
+        type Output = Result<F::Output, Box<dyn Any + Send>>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let inner = unsafe { self.map_unchecked_mut(|f| &mut f.0) };
+
+            match catch_unwind(AssertUnwindSafe(|| inner.poll(cx))) {
+                Ok(Poll::Ready(r)) => Poll::Ready(Ok(r)),
+                Ok(Poll::Pending) => Poll::Pending,
+                Err(panic) => Poll::Ready(Err(panic)),
+            }
+        }
+    }
+
+    CatchUnwind(f).await
+}
+
+#[track_caller]
+#[cfg(feature = "std")]
+pub fn __private_resume_unwind(payload: Box<dyn Any + Send>) -> ! {
+    resume_unwind(payload)
+}
+
+#[cfg(feature = "std")]
+pub fn __private_complete_span_panic<'a, 'b, E, F, C, T, R, CL: ?Sized>(
+    rt: &'a Runtime<E, F, C, T, R>,
+    tpl: impl Into<Template<'b>>,
+    lvl: &'b CL,
+    payload: &'b Box<dyn Any + Send>,
+) -> __PrivateCompleteSpanPanic<'a, 'b, E, F, C, T, R, CL> {
+    __PrivateCompleteSpanPanic {
+        rt,
+        tpl: tpl.into(),
+        lvl,
+        payload,
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct __PrivateCompleteSpanPanic<'a, 'b, E, F, C, T, R, CL: ?Sized> {
+    rt: &'a Runtime<E, F, C, T, R>,
+    tpl: Template<'b>,
+    lvl: &'b CL,
+    payload: &'b Box<dyn Any + Send>,
+}
+
+#[cfg(feature = "std")]
+impl<'a, 'b, E, F, C, T, R, CL> crate::span::completion::Completion
+    for __PrivateCompleteSpanPanic<'a, 'b, E, F, C, T, R, CL>
+where
+    E: Emitter,
+    F: Filter,
+    C: Ctxt,
+    T: Clock,
+    R: Rng,
+    CL: CaptureLevel + ?Sized,
+{
+    #[track_caller]
+    fn complete<P: Props>(&self, span: Span<P>) {
+        let payload = span::completion::PanicError::extract(self.payload);
+
+        let lvl_prop = self.lvl.capture().map(|lvl| (KEY_LVL, lvl));
+        let err_prop = Some((KEY_ERR, payload.to_value()));
 
         emit_core::emit(
             self.rt.emitter(),

--- a/src/span.rs
+++ b/src/span.rs
@@ -1488,36 +1488,6 @@ pub mod completion {
 
     impl<'a, E: Emitter, C: Ctxt, L: ToValue> Completion for Default<'a, E, C, L> {
         fn complete<P: Props>(&self, span: Span<P>) {
-            struct PanicError;
-
-            impl fmt::Debug for PanicError {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    fmt::Display::fmt(self, f)
-                }
-            }
-
-            impl fmt::Display for PanicError {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, "panicked")
-                }
-            }
-
-            #[cfg(feature = "std")]
-            impl std::error::Error for PanicError {}
-
-            impl ToValue for PanicError {
-                fn to_value(&self) -> Value<'_> {
-                    #[cfg(feature = "std")]
-                    {
-                        Value::capture_error(self)
-                    }
-                    #[cfg(not(feature = "std"))]
-                    {
-                        Value::capture_display(self)
-                    }
-                }
-            }
-
             fn is_panicking() -> bool {
                 #[cfg(feature = "std")]
                 {
@@ -1536,7 +1506,7 @@ pub mod completion {
                         .map(|lvl| Value::from_any(lvl))
                         .or_else(|| Some(Value::from_any(&Level::Error)))
                         .map(|lvl| (KEY_LVL, lvl)),
-                    Some((KEY_ERR, Value::from_any(&PanicError))),
+                    Some((KEY_ERR, Value::from_any(&PanicError::UNKNOWN))),
                 ]
             } else {
                 [
@@ -1624,6 +1594,70 @@ pub mod completion {
     */
     pub const fn default<'a, E: Emitter, C: Ctxt>(emitter: E, ctxt: C) -> Default<'a, E, C> {
         Default::new(emitter, ctxt)
+    }
+
+    pub(crate) struct PanicError {
+        #[cfg(feature = "std")]
+        payload: Option<std::borrow::Cow<'static, str>>,
+        #[cfg(not(feature = "std"))]
+        payload: Option<&'static str>,
+    }
+
+    impl PanicError {
+        const UNKNOWN: Self = PanicError { payload: None };
+
+        #[cfg(feature = "std")]
+        pub(crate) fn extract(payload: &Box<dyn std::any::Any + Send>) -> Self {
+            if let Some(payload) = payload.downcast_ref::<&str>() {
+                return PanicError {
+                    payload: Some(std::borrow::Cow::Borrowed(payload)),
+                };
+            }
+
+            if let Some(payload) = payload.downcast_ref::<std::string::String>() {
+                return PanicError {
+                    payload: Some(std::borrow::Cow::Owned(payload.clone())),
+                };
+            }
+
+            PanicError { payload: None }
+        }
+
+        pub(crate) fn get(&self) -> &str {
+            let Some(ref payload) = self.payload else {
+                return "panicked";
+            };
+
+            payload
+        }
+    }
+
+    impl fmt::Debug for PanicError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(self.get(), f)
+        }
+    }
+
+    impl fmt::Display for PanicError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(self.get(), f)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for PanicError {}
+
+    impl ToValue for PanicError {
+        fn to_value(&self) -> Value<'_> {
+            #[cfg(feature = "std")]
+            {
+                Value::capture_error(self)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                Value::capture_display(self)
+            }
+        }
     }
 
     /**

--- a/test/ui/Cargo.toml
+++ b/test/ui/Cargo.toml
@@ -45,6 +45,9 @@ version = "1"
 version = "1"
 features = ["full"]
 
+[dependencies.futures]
+version = "0.3"
+
 [dependencies.rustversion]
 version = "1"
 

--- a/test/ui/src/compile_fail/std/span_guard_catch_unwind.rs
+++ b/test/ui/src/compile_fail/std/span_guard_catch_unwind.rs
@@ -1,0 +1,8 @@
+#[emit::span(rt: RT, guard: span, catch_unwind: true, "test")]
+pub fn exec(fail: bool) {
+    
+}
+
+fn main() {
+
+}

--- a/test/ui/src/compile_fail/std/span_guard_catch_unwind.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_catch_unwind.stderr
@@ -1,5 +1,5 @@
 error: the `guard` control parameter is incompatible with `catch_unwind`, `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
- --> src/compile_fail/std/span_guard_err_lvl.rs:1:29
+ --> src/compile_fail/std/span_guard_catch_unwind.rs:1:29
   |
-1 | #[emit::span(rt: RT, guard: span, err_lvl: emit::Level::Warn, "test")]
+1 | #[emit::span(rt: RT, guard: span, catch_unwind: true, "test")]
   |                             ^^^^

--- a/test/ui/src/compile_fail/std/span_guard_err.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_err.stderr
@@ -1,4 +1,4 @@
-error: the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
+error: the `guard` control parameter is incompatible with `catch_unwind`, `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
  --> src/compile_fail/std/span_guard_err.rs:1:29
   |
 1 | #[emit::span(rt: RT, guard: span, err: (|err| err), "test")]

--- a/test/ui/src/compile_fail/std/span_guard_ok_lvl.stderr
+++ b/test/ui/src/compile_fail/std/span_guard_ok_lvl.stderr
@@ -1,4 +1,4 @@
-error: the `guard` control parameter is incompatible with `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
+error: the `guard` control parameter is incompatible with `catch_unwind`, `ok_lvl`, `err_lvl`, `panic_lvl`, or `err`
  --> src/compile_fail/std/span_guard_ok_lvl.rs:1:29
   |
 1 | #[emit::span(rt: RT, guard: span, ok_lvl: emit::Level::Info, "test")]

--- a/test/ui/src/span.rs
+++ b/test/ui/src/span.rs
@@ -2,6 +2,9 @@ use ::std::time::Duration;
 
 use emit::{Ctxt, Emitter, Kind, Props, Str};
 
+#[cfg(feature = "std")]
+use futures::FutureExt;
+
 use crate::util::{StaticCalled, StaticRuntime, static_runtime};
 
 #[allow(unused_imports)]
@@ -1112,6 +1115,74 @@ fn span_panic_default() {
     assert!(CALLED.was_called());
 }
 
+#[test]
+#[cfg(feature = "std")]
+fn span_catch_unwind() {
+    use ::std::panic;
+
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(
+                emit::Level::Error,
+                evt.props().pull::<emit::Level, _>("lvl").unwrap()
+            );
+            assert_eq!(
+                "explicit panic",
+                evt.props().get("err").unwrap().to_string()
+            );
+
+            CALLED.record();
+        },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, catch_unwind: true, "greet {user}")]
+    fn exec(user: &str) {
+        panic!("explicit panic")
+    }
+
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| exec("Rust")));
+
+    RT.emitter().blocking_flush(Duration::from_secs(1));
+
+    assert!(CALLED.was_called());
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn span_catch_unwind_result() {
+    use ::std::{io, panic};
+
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(
+                emit::Level::Error,
+                evt.props().pull::<emit::Level, _>("lvl").unwrap()
+            );
+            assert_eq!(
+                "explicit panic",
+                evt.props().get("err").unwrap().to_string()
+            );
+
+            CALLED.record();
+        },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, catch_unwind: true, err_lvl: "warn", "greet {user}")]
+    fn exec(user: &str) -> ::std::result::Result<(), io::Error> {
+        panic!("explicit panic")
+    }
+
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| exec("Rust")));
+
+    RT.emitter().blocking_flush(Duration::from_secs(1));
+
+    assert!(CALLED.was_called());
+}
+
 #[tokio::test]
 #[cfg(feature = "std")]
 async fn span_panic_default_async() {
@@ -1236,6 +1307,72 @@ async fn span_panic_lvl_async() {
         exec().await;
     })
     .await;
+
+    assert!(CALLED.was_called());
+}
+
+#[tokio::test]
+#[cfg(feature = "std")]
+async fn span_catch_unwind_async() {
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(
+                emit::Level::Error,
+                evt.props().pull::<emit::Level, _>("lvl").unwrap()
+            );
+            assert_eq!(
+                "explicit panic",
+                evt.props().get("err").unwrap().to_string()
+            );
+
+            CALLED.record();
+        },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, catch_unwind: true, "greet {user}")]
+    async fn exec(user: &str) {
+        panic!("explicit panic")
+    }
+
+    let _ = exec("Rust").catch_unwind().await;
+
+    RT.emitter().blocking_flush(Duration::from_secs(1));
+
+    assert!(CALLED.was_called());
+}
+
+#[tokio::test]
+#[cfg(feature = "std")]
+async fn span_catch_unwind_result_async() {
+    use ::std::io;
+
+    static CALLED: StaticCalled = StaticCalled::new();
+    static RT: StaticRuntime = static_runtime(
+        |evt| {
+            assert_eq!(
+                emit::Level::Error,
+                evt.props().pull::<emit::Level, _>("lvl").unwrap()
+            );
+            assert_eq!(
+                "explicit panic",
+                evt.props().get("err").unwrap().to_string()
+            );
+
+            CALLED.record();
+        },
+        |_| true,
+    );
+
+    #[emit::span(rt: RT, catch_unwind: true, err_lvl: "warn", "greet {user}")]
+    async fn exec(user: &str) -> ::std::result::Result<(), io::Error> {
+        panic!("explicit panic")
+    }
+
+    let _ = exec("Rust").catch_unwind().await;
+
+    RT.emitter().blocking_flush(Duration::from_secs(1));
 
     assert!(CALLED.was_called());
 }


### PR DESCRIPTION
Closes #349 

This PR implements a `catch_unwind` control parameter that can be used to get the body of a panic in an annotated function.

`#[span]` will already emit an error event with the payload "panicked" by default if a panic occurs, but without `catch_unwind` we can't include the actual panic message itself. You need to opt-in to catching because it's not free. We still unfortunately can't get the location the panic occurred at, which is a pretty substantial limitation, but is still an improvement.

Still TODO:

- [x] Update control parameter docs
- [x] Add UI tests for `catch_unwind`