### PR TITLE
Add FromIter and Extend impls for BucketSet and SpanLinkSet

### DIFF
--- a/book/src/producing-events/tracing/links.md
+++ b/book/src/producing-events/tracing/links.md
@@ -60,12 +60,9 @@ Since the expected type of `span_links` is a sequence, you'll need to use either
 fn wait_a_bit(sleep_ms: u64) {
     // Add span links to the guard rather than as props in the macro so they aren't
     // also added to any child spans or events
-    let mut span_links = emit::span::SpanLinkSet::new();
-
-    span_links.insert(emit::span::SpanLink::new(
-        emit::span::TraceId::from_u128(0x0a85ccaf666e11aaca6bd5d469e2850d).unwrap(),
-        emit::span::SpanId::from_u64(0x2b9caa35eaefed3a).unwrap(),
-    ));
+    let span_links = emit::span::SpanLinkSet::from_iter([
+        (emit::span::TraceId::from_u128(0x0a85ccaf666e11aaca6bd5d469e2850d).unwrap(), emit::span::SpanId::from_u64(0x2b9caa35eaefed3a).unwrap()),
+    ]);
 
     let _span = span.push_prop("span_links", span_links);
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1851,6 +1851,23 @@ pub mod exp {
                 }
             }
 
+            impl<'a> FromIterator<(Point, u64)> for BucketSet {
+                fn from_iter<I: IntoIterator<Item = (Point, u64)>>(iter: I) -> Self {
+                    let mut set = BucketSet::new();
+                    set.extend(iter);
+
+                    set
+                }
+            }
+
+            impl<'a> Extend<(Point, u64)> for BucketSet {
+                fn extend<I: IntoIterator<Item = (Point, u64)>>(&mut self, iter: I) {
+                    for (value, count) in iter {
+                        self.observe_all(value, count);
+                    }
+                }
+            }
+
             /**
             An iterator over sorted buckets from a [`BucketSet`].
 
@@ -2533,6 +2550,23 @@ pub mod exp {
                         let fmt = case.to_string();
                         assert_eq!(Some(case), BucketSet::try_from_str(&fmt).ok(), "{fmt}");
                     }
+                }
+
+                #[test]
+                fn bucket_set_from_iter() {
+                    let mut set = BucketSet::from_iter([
+                        (Point::new(0.0), 3),
+                        (Point::new(0.0), 2),
+                        (Point::new(1.0), 2),
+                    ]);
+
+                    assert_eq!(5, set.get(Point::new(0.0)).unwrap());
+                    assert_eq!(2, set.get(Point::new(1.0)).unwrap());
+
+                    set.extend([(Point::new(1.0), 3), (Point::new(2.0), 2)]);
+
+                    assert_eq!(5, set.get(Point::new(1.0)).unwrap());
+                    assert_eq!(2, set.get(Point::new(2.0)).unwrap());
                 }
 
                 #[test]

--- a/src/span.rs
+++ b/src/span.rs
@@ -1308,6 +1308,41 @@ pub mod span_link_set {
         }
     }
 
+    impl<'a> FromIterator<SpanLink> for SpanLinkSet {
+        fn from_iter<I: IntoIterator<Item = SpanLink>>(iter: I) -> Self {
+            let mut set = SpanLinkSet::new();
+            set.extend(iter);
+
+            set
+        }
+    }
+
+    impl<'a> Extend<SpanLink> for SpanLinkSet {
+        fn extend<I: IntoIterator<Item = SpanLink>>(&mut self, iter: I) {
+            for link in iter {
+                self.insert(link);
+            }
+        }
+    }
+
+    impl<'a> FromIterator<(TraceId, SpanId)> for SpanLinkSet {
+        fn from_iter<I: IntoIterator<Item = (TraceId, SpanId)>>(iter: I) -> Self {
+            Self::from_iter(
+                iter.into_iter()
+                    .map(|(trace_id, span_id)| SpanLink::new(trace_id, span_id)),
+            )
+        }
+    }
+
+    impl<'a> Extend<(TraceId, SpanId)> for SpanLinkSet {
+        fn extend<I: IntoIterator<Item = (TraceId, SpanId)>>(&mut self, iter: I) {
+            self.extend(
+                iter.into_iter()
+                    .map(|(trace_id, span_id)| SpanLink::new(trace_id, span_id)),
+            )
+        }
+    }
+
     /**
     An iterator over sorted links from a [`SpanLinkSet`].
 
@@ -1958,6 +1993,39 @@ pub mod span_link_set {
                 let fmt = case.to_string();
                 assert_eq!(Some(case), SpanLinkSet::try_from_str(&fmt).ok(), "{fmt}");
             }
+        }
+
+        #[test]
+        fn span_link_set_from_iter() {
+            let mut set = SpanLinkSet::from_iter([
+                SpanLink::new(
+                    TraceId::from_u128(0x0123456789abcdef0123456789abcdef).unwrap(),
+                    SpanId::from_u64(0x0123456789abcdef).unwrap(),
+                ),
+                SpanLink::new(
+                    TraceId::from_u128(0x0123456789abcdef0123456789abcdef).unwrap(),
+                    SpanId::from_u64(0x0123456789abcdef).unwrap(),
+                ),
+            ]);
+
+            assert!(set.contains(SpanLink::new(
+                TraceId::from_u128(0x0123456789abcdef0123456789abcdef).unwrap(),
+                SpanId::from_u64(0x0123456789abcdef).unwrap(),
+            )));
+
+            set.extend([SpanLink::new(
+                TraceId::from_u128(0xfedcba9876543210fedcba9876543210).unwrap(),
+                SpanId::from_u64(0xfedcba9876543210).unwrap(),
+            )]);
+
+            assert!(set.contains(SpanLink::new(
+                TraceId::from_u128(0x0123456789abcdef0123456789abcdef).unwrap(),
+                SpanId::from_u64(0x0123456789abcdef).unwrap(),
+            )));
+            assert!(set.contains(SpanLink::new(
+                TraceId::from_u128(0xfedcba9876543210fedcba9876543210).unwrap(),
+                SpanId::from_u64(0xfedcba9876543210).unwrap(),
+            )));
         }
 
         #[test]


### PR DESCRIPTION
This PR just rounds out the new `BucketSet` and `SpanLinkSet` support by adding `FromIterator` and `Extend` support to them.