### PR TITLE
Produce template holes regardless of cfgs

### DIFF
--- a/macros/src/template.rs
+++ b/macros/src/template.rs
@@ -157,10 +157,9 @@ impl<'a> fv_template::LiteralVisitor for TemplateVisitor<'a> {
 
             let hole_tokens =
                 fmt::template_hole_with_hook(&field.attrs, &hole, true, field.captured)?;
-            match field.cfg_attr {
-                Some(ref cfg_attr) => parts.push(quote!(#cfg_attr { #hole_tokens })),
-                _ => parts.push(quote!(#hole_tokens)),
-            }
+
+            // NOTE: The hole is produced regardless of `cfg`'s on its property
+            parts.push(quote!(#hole_tokens));
 
             Ok::<(), syn::Error>(())
         })() {

--- a/test/ui/src/emit.rs
+++ b/test/ui/src/emit.rs
@@ -83,7 +83,7 @@ fn emit_interpolation() {
 fn emit_cfg() {
     let rt = simple_runtime(
         |evt| {
-            assert_eq!("Hello, , true", evt.msg().to_string());
+            assert_eq!("Hello, {disabled}, true", evt.msg().to_string());
         },
         |_| true,
     );

--- a/test/ui/src/tpl.rs
+++ b/test/ui/src/tpl.rs
@@ -19,7 +19,7 @@ fn tpl_event_meta() {
 #[test]
 fn tpl_cfg() {
     assert_eq!(
-        "Hello, {user}",
+        "Hello, {user}{ignored}",
         emit::tpl!("Hello, {#[cfg(not(emit_disabled))] user}{#[cfg(emit_disabled)]ignored}")
             .to_string()
     );


### PR DESCRIPTION
Closes #341 

This PR makes templates still produce a hole when `#[cfg]` would omit the value:

```rust
emit::emit!("Hello, {#[cfg(disabled) user}");
```

will now produce:

```
"Hello, {user}"
```

instead of:

```
"Hello, "
```