### PR TITLE
Don't mark user props as unique when custom keys could make them not

### DIFF
--- a/macros/src/props.rs
+++ b/macros/src/props.rs
@@ -148,8 +148,8 @@ impl Props {
             match_bound_tokens.push(kv_match_bound_tokens);
         }
 
-        let props_tokens =
-            quote!(emit::__private::__PrivateMacroProps::from_array([#(#match_bound_tokens),*]));
+        // TODO: Detect `is_sorted` through `key_as()` calls
+        let props_tokens = quote!(emit::__private::__PrivateMacroProps::from_array([#(#match_bound_tokens),*], false));
         let body_tokens = match_arm(props_tokens)?;
 
         Ok(quote!({
@@ -307,9 +307,7 @@ impl Props {
                         emit::__private::core::ops::ControlFlow::Continue(())
                     }
 
-                    fn is_unique(&self) -> bool {
-                        true
-                    }
+                    // TODO: detect `is_sorted` through `key_as()` calls
                 }
             }
 

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -1214,18 +1214,20 @@ pub fn __private_default_sampler<E: Emitter, F: Filter, C: Ctxt, T: Clock, R: Rn
     sampler::from_emitter(rt)
 }
 
-#[repr(transparent)]
-pub struct __PrivateMacroProps<'a, const N: usize>([(Str<'a>, Option<Value<'a>>); N]);
+pub struct __PrivateMacroProps<'a, const N: usize> {
+    props: [(Str<'a>, Option<Value<'a>>); N],
+    is_sorted: bool,
+}
 
 impl<'a, const N: usize> __PrivateMacroProps<'a, N> {
-    pub fn from_array(props: [(Str<'a>, Option<Value<'a>>); N]) -> Self {
-        __PrivateMacroProps(props)
+    pub fn from_array(props: [(Str<'a>, Option<Value<'a>>); N], is_sorted: bool) -> Self {
+        __PrivateMacroProps { props, is_sorted }
     }
 }
 
 impl<'a> ToValue for __PrivateMacroProps<'a, 1> {
     fn to_value(&self) -> Value<'_> {
-        self.0[0]
+        self.props[0]
             .1
             .as_ref()
             .map(|v| v.by_ref())
@@ -1238,7 +1240,7 @@ impl<'a, const N: usize> Props for __PrivateMacroProps<'a, N> {
         &'kv self,
         mut for_each: F,
     ) -> ControlFlow<()> {
-        for kv in &self.0 {
+        for kv in &self.props {
             let k = &kv.0;
 
             if let Some(ref v) = kv.1 {
@@ -1252,59 +1254,29 @@ impl<'a, const N: usize> Props for __PrivateMacroProps<'a, N> {
     fn get<'v, K: ToStr>(&'v self, key: K) -> Option<Value<'v>> {
         let key = key.to_str();
 
-        self.0
-            .binary_search_by(|(k, _)| k.cmp(&key))
-            .ok()
-            .and_then(|i| self.0[i].1.as_ref().map(|v| v.by_ref()))
+        if self.is_sorted {
+            self.props
+                .binary_search_by(|(k, _)| k.cmp(&key))
+                .ok()
+                .and_then(|i| self.props[i].1.as_ref().map(|v| v.by_ref()))
+        } else {
+            self.props
+                .iter()
+                .filter(|(k, _)| k == &key)
+                .filter_map(|(_, v)| v.as_ref())
+                .map(|v| v.by_ref())
+                .next()
+        }
     }
 
     fn is_unique(&self) -> bool {
-        true
+        self.is_sorted
     }
 
     fn size(&self) -> Option<usize> {
-        Some(self.0.len())
+        Some(self.props.len())
     }
 }
-
-#[repr(transparent)]
-pub struct __PrivateTupleMacroProps<T>(T);
-
-macro_rules! impl_private_tuple_macro_props {
-    (
-        $(($($idx:tt $T:tt)+),)+
-    ) => {
-        $(
-            impl<$($T: Props),*> Props for __PrivateTupleMacroProps<($($T),*)> {
-                fn for_each<'kv, F: FnMut(Str<'kv>, Value<'kv>) -> ControlFlow<()>>(&'kv self, mut for_each: F) -> ControlFlow<()> {
-                    $(
-                        self.0.$idx.for_each(&mut for_each)?;
-                    )*
-
-                    ControlFlow::Continue(())
-                }
-            }
-        )+
-    };
-}
-
-impl_private_tuple_macro_props!(
-    (0 P0 1 P1),
-    (0 P0 1 P1 2 P2),
-    (0 P0 1 P1 2 P2 3 P3),
-    (0 P0 1 P1 2 P2 3 P3 4 P4),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10 11 P11),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10 11 P11 12 P12),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10 11 P11 12 P12 13 P13),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10 11 P11 12 P12 13 P13 14 P14),
-    (0 P0 1 P1 2 P2 3 P3 4 P4 5 P5 6 P6 7 P7 8 P8 9 P9 10 P10 11 P11 12 P12 13 P13 14 P14 15 P15),
-);
 
 pub struct __PrivateMacroExtendedProps<P, T>(P, T);
 

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -13,7 +13,8 @@ fn props_basic() {
         d: "text",
     };
 
-    assert!(props.is_unique());
+    // NOTE: We could mark these as unique because there's no `#[emit::key]`
+    assert!(!props.is_unique());
 
     assert_eq!(1, props.b);
     assert_eq!(true, props.a);
@@ -24,6 +25,32 @@ fn props_basic() {
     assert_eq!(true, props.pull::<bool, _>("a").unwrap());
     assert_eq!(2.0, props.pull::<f64, _>("c").unwrap());
     assert_eq!("text", props.pull::<&str, _>("d").unwrap());
+}
+
+#[test]
+fn props_renamed() {
+    let props = emit::props! {
+        #[emit::key("c")]
+        b: 1,
+        #[emit::key("d")]
+        a: true,
+        #[emit::key("b")]
+        c: 2.0,
+        #[emit::key("a")]
+        d: "text",
+    };
+
+    assert!(!props.is_unique());
+
+    assert_eq!(1, props.b);
+    assert_eq!(true, props.a);
+    assert_eq!(2.0, props.c);
+    assert_eq!("text", props.d);
+
+    assert_eq!(1, props.pull::<i32, _>("c").unwrap());
+    assert_eq!(true, props.pull::<bool, _>("d").unwrap());
+    assert_eq!(2.0, props.pull::<f64, _>("b").unwrap());
+    assert_eq!("text", props.pull::<&str, _>("a").unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Closes #377 

This is a conservative fix that just unconditionally marks macro props as non-unique. I think the way we'd re-introduce this would be to add a hook to values that accepted a `custom_key` boolean. The `#[emit::key]` attribute would then rewrite this into a form that set that boolean to true, so we'd know whether all keys are compile-time identifiers or whether they could be runtime values.