### PR TITLE
Add a test to ensure multiple props in the same scope works

### DIFF
--- a/macros/src/capture.rs
+++ b/macros/src/capture.rs
@@ -142,9 +142,7 @@ pub fn rename_hook_tokens(
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |hook_args: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/macros/src/nullable.rs
+++ b/macros/src/nullable.rs
@@ -25,9 +25,7 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -25,9 +25,7 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -6,7 +6,6 @@ use core::{fmt, ops::ControlFlow};
 
 use emit_core::{
     and::And,
-    emitter::Emitter,
     event::{Event, ToEvent},
     extent::{Extent, ToExtent},
     or::Or,
@@ -725,6 +724,7 @@ mod alloc_support {
 
     use crate::{
         clock::{Clock, ErasedClock},
+        emitter::Emitter,
         metric::source::{ErasedSource, Source},
     };
 

--- a/test/ui/src/props.rs
+++ b/test/ui/src/props.rs
@@ -28,6 +28,20 @@ fn props_basic() {
 }
 
 #[test]
+fn props_multi_scope() {
+    let a = emit::props! {
+        a: 1,
+    };
+
+    let b = emit::props! {
+        b: 2,
+    };
+
+    assert_eq!(1, a.a);
+    assert_eq!(2, b.b);
+}
+
+#[test]
 fn props_renamed() {
     let props = emit::props! {
         #[emit::key("c")]


### PR DESCRIPTION
This PR just makes sure we generate hygienic code for `emit::props!` so multiple calls in the same scope don't produce conflicting names.