### PR TITLE
Serialize OTLP on the background worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "emitter/otlp/gen",
     "emitter/otlp/test/integration",
     "emitter/otlp/test/throughput",
+    "emitter/otlp/test/throughput-otel",
     "emitter/otlp/test/web/native",
     "macros",
     "examples/common_patterns",

--- a/book/src/producing-events/tracing/properties.md
+++ b/book/src/producing-events/tracing/properties.md
@@ -160,7 +160,7 @@ fn check(i: i32) {
 }
 ```
 
-This means you only want to include properties in your `#[span]` template that are ambiently useful, because they'll also appear on all child events.
+This means you only want to include properties in your `#[span]` template that are ambiently useful, because they'll also appear on all child events. It's generally more efficient to use private properties than shared ones.
 
 To make additional properties ambiently available during the execution of a span, see [Context](../logging/context.md#manually).
 

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -485,7 +485,7 @@ mod alloc_support {
 
     use crate::value::OwnedValue;
 
-    use core::{cmp, iter, mem, ptr};
+    use core::{cell::UnsafeCell, cmp, mem, ptr};
 
     use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
@@ -500,7 +500,7 @@ mod alloc_support {
     The hash algorithm used is FNV-1a.
     */
     pub struct OwnedProps {
-        buckets: *const [OwnedPropsBucket],
+        buckets: *const [UnsafeCell<OwnedPropsBucket>],
         nprops: usize,
         owner: OwnedPropsOwner,
         head: Option<*const OwnedProp>,
@@ -514,14 +514,8 @@ mod alloc_support {
     impl Clone for OwnedProps {
         fn clone(&self) -> Self {
             match self.owner {
-                OwnedPropsOwner::Box(_) => {
-                    let (nprops, props, head) = OwnedProps::cloned(self);
-
-                    OwnedProps::new_owned(nprops, props, head)
-                }
-                OwnedPropsOwner::Shared(ref props) => {
-                    OwnedProps::new_shared(self.nprops, props.clone(), self.head)
-                }
+                OwnedPropsOwner::Box(_) => Self::collect_owned(self),
+                OwnedPropsOwner::Shared(_) => Self::collect_shared(self),
             }
         }
     }
@@ -530,7 +524,6 @@ mod alloc_support {
         fn drop(&mut self) {
             match self.owner {
                 OwnedPropsOwner::Box(boxed) => {
-                    // SAFETY: We're dropping the box through our exclusive reference
                     drop(unsafe { Box::from_raw(boxed) });
                 }
                 OwnedPropsOwner::Shared(_) => {
@@ -541,7 +534,7 @@ mod alloc_support {
     }
 
     struct OwnedPropsBucket {
-        head: *mut OwnedProp,
+        head: Option<UnsafeCell<OwnedProp>>,
         tail: Vec<*mut OwnedProp>,
     }
 
@@ -549,12 +542,10 @@ mod alloc_support {
         fn drop(&mut self) {
             let mut guard = SliceDropGuard::new(&mut self.tail);
 
-            if !self.head.is_null() {
-                // SAFETY: We're dropping the box through our exclusive reference
-                drop(unsafe { Box::from_raw(self.head) })
+            if let Some(head) = self.head.take() {
+                drop(head);
             }
 
-            // SAFETY: We're dropping the value through our exclusive reference
             unsafe {
                 guard.drop();
             }
@@ -568,128 +559,71 @@ mod alloc_support {
     }
 
     enum OwnedPropsOwner {
-        Box(*mut [OwnedPropsBucket]),
-        Shared(Arc<[OwnedPropsBucket]>),
+        Box(*mut [UnsafeCell<OwnedPropsBucket>]),
+        Shared(Arc<[UnsafeCell<OwnedPropsBucket>]>),
     }
 
     impl OwnedProps {
-        fn cloned(src: &Self) -> (usize, Box<[OwnedPropsBucket]>, Option<*const OwnedProp>) {
-            // NOTE: This could be better optimized
-            // We already know what size each bucket should be, we could store
-            // the index of the bucket on each entry to re-assemble them
-
-            let nbuckets = src.buckets.len();
-            let mut nprops = 0;
-            let mut buckets = iter::from_fn(|| Some(OwnedPropsBucket::new()))
-                .take(nbuckets)
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-            let mut head = None::<*const OwnedProp>;
-            let mut tail = None::<*mut OwnedProp>;
-
-            // This method creates an independent copy of a set of owned props
-            // We can't simply clone the underlying collections, because they hold
-            // internal pointers that would be invalidated
-            let _ = src.for_each(|prop| {
-                let bucket = &mut buckets[idx(nbuckets, &prop.key)];
-
-                // SAFETY: `head` and `tail` point to values in `collected`, which outlives this function call
-                let prop = unsafe {
-                    OwnedProp::new(&mut head, &mut tail, prop.key.clone(), prop.value.clone())
-                };
-
-                bucket.push(prop);
-                nprops += 1;
-
-                ControlFlow::Continue(())
-            });
-
-            (nprops, buckets, head)
-        }
-
-        fn new_owned(
-            nprops: usize,
-            buckets: Box<[OwnedPropsBucket]>,
-            head: Option<*const OwnedProp>,
-        ) -> Self {
-            let buckets = Box::into_raw(buckets);
-            let owner = OwnedPropsOwner::Box(buckets);
-
-            OwnedProps {
-                nprops,
-                buckets,
-                owner,
-                head,
-            }
-        }
-
-        fn new_shared(
-            nprops: usize,
-            buckets: Arc<[OwnedPropsBucket]>,
-            head: Option<*const OwnedProp>,
-        ) -> Self {
-            let ptr = Arc::as_ptr(&buckets);
-            let owner = OwnedPropsOwner::Shared(buckets);
-            let buckets = ptr;
-
-            OwnedProps {
-                nprops,
-                buckets,
-                owner,
-                head,
-            }
-        }
-
-        fn collect(
-            props: impl Props,
-            mut key: impl FnMut(Str) -> Str<'static>,
-            mut value: impl FnMut(Value) -> OwnedValue,
-        ) -> (usize, Box<[OwnedPropsBucket]>, Option<*const OwnedProp>) {
-            // We want a reasonable number of buckets to reduce the number of keys to scan
-            // We don't want to overallocate if `props.size()` returns a nonsense value though
-            let nbuckets = cmp::min(128, props.size().unwrap_or(32));
-            let mut nprops = 0;
-            let mut buckets = iter::from_fn(|| Some(OwnedPropsBucket::new()))
-                .take(nbuckets)
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-            let mut head = None::<*const OwnedProp>;
-            let mut tail = None::<*mut OwnedProp>;
-
-            let _ = props.for_each(|k, v| {
-                let bucket = &mut buckets[idx(nbuckets, &k)];
-
-                if bucket.get(&k).is_some() {
-                    ControlFlow::Continue(())
-                } else {
-                    // SAFETY: `head` and `tail` point to values in `collected`, which outlives this function call
-                    let prop = unsafe { OwnedProp::new(&mut head, &mut tail, key(k), value(v)) };
-
-                    bucket.push(prop);
-                    nprops += 1;
-
-                    ControlFlow::Continue(())
-                }
-            });
-
-            (nprops, buckets, head)
-        }
-
         /**
         Collect a set of [`Props`] into an owned collection.
 
         Cloning will involve cloning the collection.
         */
         pub fn collect_owned(props: impl Props) -> Self {
-            let (nprops, buckets, head) = Self::collect(props, |k| k.to_owned(), |v| v.to_owned());
+            // We want a reasonable number of buckets to reduce the number of keys to scan
+            // We don't want to overallocate if `props.size()` returns a nonsense value though
+            let nbuckets = cmp::min(128, props.size().unwrap_or(32));
 
-            let buckets = Box::into_raw(buckets);
-            let owner = OwnedPropsOwner::Box(buckets);
+            let buckets = {
+                let mut buckets = Box::new_uninit_slice(nbuckets);
+
+                for elem in buckets.iter_mut() {
+                    elem.write(UnsafeCell::new(OwnedPropsBucket::new()));
+                }
+
+                unsafe { buckets.assume_init() }
+            };
+
+            let mut guard = BoxDropGuard::new(buckets);
+
+            let buckets_ptr = guard.as_ptr();
+
+            let mut nprops = 0;
+            let mut head = None::<*const OwnedProp>;
+            let mut tail = None::<*mut OwnedProp>;
+
+            let _ = props.for_each(|k, v| {
+                let bucket_ptr = unsafe {
+                    let bucket_ptr =
+                        (buckets_ptr as *mut UnsafeCell<OwnedPropsBucket>).add(idx(nbuckets, &k));
+
+                    (&*bucket_ptr).get()
+                };
+
+                if unsafe { &*bucket_ptr }.get(&k).is_some() {
+                    ControlFlow::Continue(())
+                } else {
+                    let prop = OwnedProp {
+                        key: k.to_owned(),
+                        value: v.to_owned(),
+                        next: None,
+                    };
+
+                    unsafe {
+                        OwnedPropsBucket::push(bucket_ptr, &mut head, &mut tail, prop);
+                    }
+                    nprops += 1;
+
+                    ControlFlow::Continue(())
+                }
+            });
+
+            let buckets_ptr = guard.take();
 
             OwnedProps {
                 nprops,
-                buckets,
-                owner,
+                buckets: buckets_ptr,
+                owner: OwnedPropsOwner::Box(buckets_ptr),
                 head,
             }
         }
@@ -700,10 +634,58 @@ mod alloc_support {
         Cloning will involve cloning the `Arc`, which may be cheaper than cloning the collection itself.
         */
         pub fn collect_shared(props: impl Props) -> Self {
-            let (nprops, buckets, head) =
-                Self::collect(props, |k| k.to_shared(), |v| v.to_shared());
+            // We want a reasonable number of buckets to reduce the number of keys to scan
+            // We don't want to overallocate if `props.size()` returns a nonsense value though
+            let nbuckets = cmp::min(128, props.size().unwrap_or(32));
 
-            Self::new_shared(nprops, buckets.into(), head)
+            let buckets = {
+                let mut buckets = Arc::new_uninit_slice(nbuckets);
+
+                for elem in Arc::get_mut(&mut buckets).unwrap().iter_mut() {
+                    elem.write(UnsafeCell::new(OwnedPropsBucket::new()));
+                }
+
+                unsafe { buckets.assume_init() }
+            };
+
+            let buckets_ptr = Arc::as_ptr(&buckets);
+
+            let mut nprops = 0;
+            let mut head = None::<*const OwnedProp>;
+            let mut tail = None::<*mut OwnedProp>;
+
+            let _ = props.for_each(|k, v| {
+                let bucket_ptr = unsafe {
+                    let bucket_ptr =
+                        (buckets_ptr as *mut UnsafeCell<OwnedPropsBucket>).add(idx(nbuckets, &k));
+
+                    (&*bucket_ptr).get()
+                };
+
+                if unsafe { &*bucket_ptr }.get(&k).is_some() {
+                    ControlFlow::Continue(())
+                } else {
+                    let prop = OwnedProp {
+                        key: k.to_shared(),
+                        value: v.to_shared(),
+                        next: None,
+                    };
+
+                    unsafe {
+                        OwnedPropsBucket::push(bucket_ptr, &mut head, &mut tail, prop);
+                    }
+                    nprops += 1;
+
+                    ControlFlow::Continue(())
+                }
+            });
+
+            OwnedProps {
+                nprops,
+                buckets: buckets_ptr,
+                owner: OwnedPropsOwner::Shared(buckets),
+                head,
+            }
         }
 
         /**
@@ -713,15 +695,13 @@ mod alloc_support {
         */
         pub fn to_shared(&self) -> Self {
             match self.owner {
-                OwnedPropsOwner::Box(_) => {
-                    // We need to clone the data into new allocations, since we don't own them
-                    let (nprops, buckets, head) = OwnedProps::cloned(self);
-
-                    Self::new_shared(nprops, Arc::from(buckets), head)
-                }
-                OwnedPropsOwner::Shared(ref owner) => {
-                    OwnedProps::new_shared(self.nprops, owner.clone(), self.head)
-                }
+                OwnedPropsOwner::Box(_) => Self::collect_shared(self),
+                OwnedPropsOwner::Shared(ref owner) => OwnedProps {
+                    nprops: self.nprops,
+                    buckets: self.buckets,
+                    owner: OwnedPropsOwner::Shared(owner.clone()),
+                    head: self.head,
+                },
             }
         }
 
@@ -733,8 +713,6 @@ mod alloc_support {
             let mut next = self.head;
 
             while let Some(current) = next.take() {
-                // SAFETY: The data in `current` is owned by `self`,
-                // which outlives this dereference
                 let current = unsafe { &*current };
 
                 for_each(&current)?;
@@ -748,10 +726,10 @@ mod alloc_support {
         fn get<'v, K: ToStr>(&'v self, key: K) -> Option<&'v OwnedProp> {
             let key = key.to_str();
 
-            // SAFETY: `buckets` is owned by `Self`, which outlives this function call
             let buckets = unsafe { &*self.buckets };
+            let bucket = buckets[idx(buckets.len(), &key)].get();
 
-            buckets[idx(buckets.len(), &key)].get(&key)
+            unsafe { &*bucket }.get(&key)
         }
     }
 
@@ -783,26 +761,60 @@ mod alloc_support {
     }
 
     impl OwnedPropsBucket {
+        #[inline]
         fn new() -> OwnedPropsBucket {
             OwnedPropsBucket {
-                head: ptr::null_mut(),
+                head: None,
                 tail: Vec::new(),
             }
         }
 
-        fn push(&mut self, mut prop: PropDropGuard) {
-            if self.head.is_null() {
-                self.head = prop.take();
+        #[inline]
+        unsafe fn push(
+            this: *mut Self,
+            head: &mut Option<*const OwnedProp>,
+            tail: &mut Option<*mut OwnedProp>,
+            prop: OwnedProp,
+        ) {
+            let head_field = unsafe { ptr::addr_of_mut!((*this).head) };
+
+            let prop_ptr = if unsafe { &*head_field }.is_none() {
+                unsafe {
+                    *head_field = Some(UnsafeCell::new(prop));
+
+                    (&*head_field).as_ref().unwrap().get()
+                }
             } else {
-                self.tail.reserve(1);
-                self.tail.push(prop.take());
+                let mut guard = BoxDropGuard::new(Box::new(prop));
+                let prop_ptr = guard.as_ptr();
+
+                unsafe {
+                    let tail_field = ptr::addr_of_mut!((*this).tail);
+
+                    (&mut *tail_field).reserve(1);
+                    (&mut *tail_field).push(guard.take());
+                };
+
+                prop_ptr
+            };
+
+            *head = head.or_else(|| Some(prop_ptr as *const _));
+
+            if let Some(tail) = tail {
+                unsafe {
+                    let tail_field = ptr::addr_of_mut!((**tail).next);
+
+                    *tail_field = Some(prop_ptr)
+                }
             }
+
+            *tail = Some(prop_ptr);
         }
 
+        #[inline]
         fn get(&self, k: &Str) -> Option<&OwnedProp> {
-            if !self.head.is_null() {
-                // SAFETY: `prop` is owned by `Self` and follows normal borrowing rules
-                let prop = unsafe { &*self.head };
+            if let Some(prop) = &self.head {
+                let prop = unsafe { &*prop.get() };
 
                 if prop.key == *k {
                     return Some(&prop);
@@ -810,7 +822,6 @@ mod alloc_support {
             }
 
             for prop in &self.tail {
-                // SAFETY: `prop` is owned by `Self` and follows normal borrowing rules
                 let prop = unsafe { &**prop };
 
                 if prop.key == *k {
@@ -822,39 +833,6 @@ mod alloc_support {
         }
     }
 
-    impl OwnedProp {
-        // SAFETY: `head` and `tail` must be valid to dereference within this function call
-        unsafe fn new(
-            head: &mut Option<*const OwnedProp>,
-            tail: &mut Option<*mut OwnedProp>,
-            key: Str<'static>,
-            value: OwnedValue,
-        ) -> PropDropGuard {
-            let guard = PropDropGuard::new(Box::new(OwnedProp {
-                key,
-                value,
-                next: None,
-            }));
-
-            let prop_ptr = guard.0;
-
-            *head = head.or_else(|| Some(prop_ptr));
-
-            if let Some(tail) = tail {
-                debug_assert!(head.is_some());
-
-                // SAFETY: The contract of `new` requires `tail` be valid to dereference
-                let tail = unsafe { &mut **tail };
-
-                debug_assert!(tail.next.is_none());
-                tail.next = Some(prop_ptr);
-            }
-            *tail = Some(prop_ptr);
-
-            guard
-        }
-    }
-
     struct SliceDropGuard<'a> {
         idx: usize,
         value: &'a mut [*mut OwnedProp],
@@ -863,7 +841,6 @@ mod alloc_support {
     impl<'a> Drop for SliceDropGuard<'a> {
         fn drop(&mut self) {
             // Attempt to resume dropping if a destructor panics
-            // SAFETY: We're dropping the value through our exclusive reference
             unsafe {
                 self.drop();
             }
@@ -887,29 +864,34 @@ mod alloc_support {
         }
     }
 
-    struct PropDropGuard(*mut OwnedProp);
+    struct BoxDropGuard<T: ?Sized>(Option<ptr::NonNull<T>>);
 
-    impl PropDropGuard {
-        fn new(prop: Box<OwnedProp>) -> Self {
-            PropDropGuard(Box::into_raw(prop))
+    impl<T: ?Sized> BoxDropGuard<T> {
+        fn new(value: Box<T>) -> Self {
+            BoxDropGuard(ptr::NonNull::new(Box::into_raw(value)))
         }
 
-        fn take(&mut self) -> *mut OwnedProp {
-            mem::replace(&mut self.0, ptr::null_mut())
+        fn as_ptr(&self) -> *mut T {
+            self.0.unwrap().as_ptr()
+        }
+
+        fn take(&mut self) -> *mut T {
+            mem::take(&mut self.0).unwrap().as_ptr()
         }
     }
 
-    impl Drop for PropDropGuard {
+    impl<T: ?Sized> Drop for BoxDropGuard<T> {
         fn drop(&mut self) {
-            if self.0.is_null() {
+            let Some(ptr) = self.0.take() else {
                 return;
-            }
+            };
 
             // SAFETY: We're dropping the value through our exclusive reference
-            drop(unsafe { Box::from_raw(self.0) });
+            drop(unsafe { Box::from_raw(ptr.as_ptr()) });
         }
     }
 
+    #[inline]
     fn idx(buckets: usize, k: &Str) -> usize {
         let mut hash = 0xcbf29ce484222325;
 

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -797,7 +797,7 @@ mod alloc_support {
             // but lets us store the `head` of each bucket inline, instead of in a separate allocation
 
             // SAETY: `head` is in bounds for `this`
-            let head_field = unsafe { ptr::addr_of_mut!((*this).head) };
+            let head_field = unsafe { &raw mut (*this).head };
 
             // SAFETY: `head_field` inherits validity of `this` ptr
             let prop_ptr = if unsafe { &*head_field }.is_none() {
@@ -813,7 +813,7 @@ mod alloc_support {
 
                 // SAETY: `tail` is in bounds for `this`, and `tail_field` inherits validity of `this` ptr
                 unsafe {
-                    let tail_field = ptr::addr_of_mut!((*this).tail);
+                    let tail_field = &raw mut (*this).tail;
 
                     (&mut *tail_field).reserve(1);
                     (&mut *tail_field).push(guard.take());
@@ -827,7 +827,7 @@ mod alloc_support {
             if let Some(tail) = tail {
                 // SAETY: `next` is in bounds for `tail`, and `tail_field` inherits validity of `tail` ptr
                 unsafe {
-                    let tail_field = ptr::addr_of_mut!((**tail).next);
+                    let tail_field = &raw mut (**tail).next;
 
                     *tail_field = Some(prop_ptr)
                 }

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -524,6 +524,7 @@ mod alloc_support {
         fn drop(&mut self) {
             match self.owner {
                 OwnedPropsOwner::Box(boxed) => {
+                    // SAFETY: We're dropping the box's owner
                     drop(unsafe { Box::from_raw(boxed) });
                 }
                 OwnedPropsOwner::Shared(_) => {
@@ -533,6 +534,7 @@ mod alloc_support {
         }
     }
 
+    // NOTE: `OwnedPropsBucket` is only ever stored inside a stable allocation
     struct OwnedPropsBucket {
         head: Option<UnsafeCell<OwnedProp>>,
         tail: Vec<*mut OwnedProp>,
@@ -546,6 +548,7 @@ mod alloc_support {
                 drop(head);
             }
 
+            // SAFETY: We're dropping the vec's owner
             unsafe {
                 guard.drop();
             }
@@ -578,45 +581,26 @@ mod alloc_support {
                 let mut buckets = Box::new_uninit_slice(nbuckets);
 
                 for elem in buckets.iter_mut() {
+                    // NOTE: `OwnedPropsBucket::new()` does not allocate
                     elem.write(UnsafeCell::new(OwnedPropsBucket::new()));
                 }
 
+                // SAFETY: All values in `buckets` have been initialized
                 unsafe { buckets.assume_init() }
             };
 
             let mut guard = BoxDropGuard::new(buckets);
 
-            let buckets_ptr = guard.as_ptr();
-
-            let mut nprops = 0;
-            let mut head = None::<*const OwnedProp>;
-            let mut tail = None::<*mut OwnedProp>;
-
-            let _ = props.for_each(|k, v| {
-                let bucket_ptr = unsafe {
-                    let bucket_ptr =
-                        (buckets_ptr as *mut UnsafeCell<OwnedPropsBucket>).add(idx(nbuckets, &k));
-
-                    (&*bucket_ptr).get()
-                };
-
-                if unsafe { &*bucket_ptr }.get(&k).is_some() {
-                    ControlFlow::Continue(())
-                } else {
-                    let prop = OwnedProp {
-                        key: k.to_owned(),
-                        value: v.to_owned(),
-                        next: None,
-                    };
-
-                    unsafe {
-                        OwnedPropsBucket::push(bucket_ptr, &mut head, &mut tail, prop);
-                    }
-                    nprops += 1;
-
-                    ControlFlow::Continue(())
-                }
-            });
+            // SAFETY: `buckets` is valid to dereference and `nbuckets` is within `buckets`
+            let (nprops, head) = unsafe {
+                Self::collect_internal(
+                    guard.as_ptr(),
+                    nbuckets,
+                    props,
+                    |k| k.to_owned(),
+                    |v| v.to_owned(),
+                )
+            };
 
             let buckets_ptr = guard.take();
 
@@ -642,19 +626,49 @@ mod alloc_support {
                 let mut buckets = Arc::new_uninit_slice(nbuckets);
 
                 for elem in Arc::get_mut(&mut buckets).unwrap().iter_mut() {
+                    // NOTE: `OwnedPropsBucket::new()` does not allocate
                     elem.write(UnsafeCell::new(OwnedPropsBucket::new()));
                 }
 
+                // SAFETY: All values in `buckets` have been initialized
                 unsafe { buckets.assume_init() }
             };
 
             let buckets_ptr = Arc::as_ptr(&buckets);
 
+            // SAFETY: `buckets` is valid to dereference and `nbuckets` is within `buckets`
+            let (nprops, head) = unsafe {
+                Self::collect_internal(
+                    buckets_ptr as *mut _,
+                    nbuckets,
+                    props,
+                    |k| k.to_shared(),
+                    |v| v.to_shared(),
+                )
+            };
+
+            OwnedProps {
+                nprops,
+                buckets: buckets_ptr,
+                owner: OwnedPropsOwner::Shared(buckets),
+                head,
+            }
+        }
+
+        #[inline]
+        unsafe fn collect_internal(
+            buckets_ptr: *mut [UnsafeCell<OwnedPropsBucket>],
+            nbuckets: usize,
+            props: impl Props,
+            mk_key: impl Fn(Str) -> Str<'static>,
+            mk_value: impl Fn(Value) -> OwnedValue,
+        ) -> (usize, Option<*const OwnedProp>) {
             let mut nprops = 0;
             let mut head = None::<*const OwnedProp>;
             let mut tail = None::<*mut OwnedProp>;
 
             let _ = props.for_each(|k, v| {
+                // SAFETY: `buckets_ptr` is valid to dereference and `idx` is within `buckets`
                 let bucket_ptr = unsafe {
                     let bucket_ptr =
                         (buckets_ptr as *mut UnsafeCell<OwnedPropsBucket>).add(idx(nbuckets, &k));
@@ -662,15 +676,18 @@ mod alloc_support {
                     (&*bucket_ptr).get()
                 };
 
+                // SAFETY: `bucket_ptr` is valid to dereference
                 if unsafe { &*bucket_ptr }.get(&k).is_some() {
                     ControlFlow::Continue(())
                 } else {
+                    // NOTE: `mk_key` and `mk_value` are user controlled, so may panic
                     let prop = OwnedProp {
-                        key: k.to_shared(),
-                        value: v.to_shared(),
+                        key: mk_key(k),
+                        value: mk_value(v),
                         next: None,
                     };
 
+                    // SAFETY: `bucket_ptr`, `head`, and `tail` are valid to dereference
                     unsafe {
                         OwnedPropsBucket::push(bucket_ptr, &mut head, &mut tail, prop);
                     }
@@ -680,12 +697,7 @@ mod alloc_support {
                 }
             });
 
-            OwnedProps {
-                nprops,
-                buckets: buckets_ptr,
-                owner: OwnedPropsOwner::Shared(buckets),
-                head,
-            }
+            (nprops, head)
         }
 
         /**
@@ -713,6 +725,7 @@ mod alloc_support {
             let mut next = self.head;
 
             while let Some(current) = next.take() {
+                // SAFETY: `current` was initialized via `collect_internal` so is valid to dereference
                 let current = unsafe { &*current };
 
                 for_each(&current)?;
@@ -726,9 +739,11 @@ mod alloc_support {
         fn get<'v, K: ToStr>(&'v self, key: K) -> Option<&'v OwnedProp> {
             let key = key.to_str();
 
+            // SAFETY: `buckets` was initialized via `collect_internal` so is valid to dereference
             let buckets = unsafe { &*self.buckets };
             let bucket = buckets[idx(buckets.len(), &key)].get();
 
+            // SAFETY: `current` was initialized via `collect_internal` so is valid to dereference
             unsafe { &*bucket }.get(&key)
         }
     }
@@ -762,13 +777,14 @@ mod alloc_support {
 
     impl OwnedPropsBucket {
         #[inline]
-        fn new() -> OwnedPropsBucket {
+        const fn new() -> OwnedPropsBucket {
             OwnedPropsBucket {
                 head: None,
                 tail: Vec::new(),
             }
         }
 
+        // SAFETY: Callers must ensure `this` is valid to dereference, and that `head` and `tail` are too
         #[inline]
         unsafe fn push(
             this: *mut Self,
@@ -776,9 +792,16 @@ mod alloc_support {
             tail: &mut Option<*mut OwnedProp>,
             prop: OwnedProp,
         ) {
+            // NOTE: This method is intentionally written to avoid ever creating a `&mut` reference
+            // This is necessary to appease Miri. It makes the code far more arcane than I'd like,
+            // but lets us store the `head` of each bucket inline, instead of in a separate allocation
+
+            // SAETY: `head` is in bounds for `this`
             let head_field = unsafe { ptr::addr_of_mut!((*this).head) };
 
+            // SAFETY: `head_field` inherits validity of `this` ptr
             let prop_ptr = if unsafe { &*head_field }.is_none() {
+                // SAFETY: `head_field` inherits validity of `this` ptr
                 unsafe {
                     *head_field = Some(UnsafeCell::new(prop));
 
@@ -788,6 +811,7 @@ mod alloc_support {
                 let mut guard = BoxDropGuard::new(Box::new(prop));
                 let prop_ptr = guard.as_ptr();
 
+                // SAETY: `tail` is in bounds for `this`, and `tail_field` inherits validity of `this` ptr
                 unsafe {
                     let tail_field = ptr::addr_of_mut!((*this).tail);
 
@@ -801,6 +825,7 @@ mod alloc_support {
             *head = head.or_else(|| Some(prop_ptr as *const _));
 
             if let Some(tail) = tail {
+                // SAETY: `next` is in bounds for `tail`, and `tail_field` inherits validity of `tail` ptr
                 unsafe {
                     let tail_field = ptr::addr_of_mut!((**tail).next);
 
@@ -814,6 +839,7 @@ mod alloc_support {
         #[inline]
         fn get(&self, k: &Str) -> Option<&OwnedProp> {
             if let Some(prop) = &self.head {
+                // SAFETY: `head` was initialized via `collect_internal` so is valid to dereference
                 let prop = unsafe { &*prop.get() };
 
                 if prop.key == *k {
@@ -822,6 +848,7 @@ mod alloc_support {
             }
 
             for prop in &self.tail {
+                // SAFETY: `tail` was initialized via `collect_internal` so is valid to dereference
                 let prop = unsafe { &**prop };
 
                 if prop.key == *k {
@@ -841,6 +868,7 @@ mod alloc_support {
     impl<'a> Drop for SliceDropGuard<'a> {
         fn drop(&mut self) {
             // Attempt to resume dropping if a destructor panics
+            // SAFETY: We own the value being dropped
             unsafe {
                 self.drop();
             }

--- a/core/src/props.rs
+++ b/core/src/props.rs
@@ -848,11 +848,13 @@ mod alloc_support {
     }
 
     impl<'a> SliceDropGuard<'a> {
+        #[inline]
         fn new(value: &'a mut [*mut OwnedProp]) -> Self {
             SliceDropGuard { value, idx: 0 }
         }
 
         // SAFETY: The value referenced by this guard must be getting dropped
+        #[inline]
         unsafe fn drop(&mut self) {
             while self.idx < self.value.len() {
                 let prop = self.value[self.idx];
@@ -867,14 +869,17 @@ mod alloc_support {
     struct BoxDropGuard<T: ?Sized>(Option<ptr::NonNull<T>>);
 
     impl<T: ?Sized> BoxDropGuard<T> {
+        #[inline]
         fn new(value: Box<T>) -> Self {
             BoxDropGuard(ptr::NonNull::new(Box::into_raw(value)))
         }
 
+        #[inline]
         fn as_ptr(&self) -> *mut T {
             self.0.unwrap().as_ptr()
         }
 
+        #[inline]
         fn take(&mut self) -> *mut T {
             mem::take(&mut self.0).unwrap().as_ptr()
         }

--- a/core/src/str.rs
+++ b/core/src/str.rs
@@ -111,6 +111,7 @@ impl Str<'static> {
     /**
     Create a new string from a value borrowed for `'static`.
     */
+    #[inline]
     pub const fn new(k: &'static str) -> Self {
         Str {
             value: k as *const str,
@@ -126,6 +127,7 @@ impl<'k> Str<'k> {
 
     The [`Str::new`] method should be preferred where possible.
     */
+    #[inline]
     pub const fn new_ref(k: &'k str) -> Str<'k> {
         Str {
             value: k as *const str,
@@ -151,6 +153,7 @@ impl<'k> Str<'k> {
     /**
     Get a reference to the underlying value.
     */
+    #[inline]
     pub const fn get(&self) -> &str {
         // NOTE: It's important here that the lifetime returned is not `'k`
         // If it was it would be possible to return a `&'static str` from
@@ -174,12 +177,14 @@ impl<'k> Str<'k> {
 }
 
 impl<'a> hash::Hash for Str<'a> {
+    #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.get().hash(state)
     }
 }
 
 impl<'a, 'b> PartialEq<Str<'b>> for Str<'a> {
+    #[inline]
     fn eq(&self, other: &Str<'b>) -> bool {
         self.get() == other.get()
     }
@@ -188,48 +193,56 @@ impl<'a, 'b> PartialEq<Str<'b>> for Str<'a> {
 impl<'a> Eq for Str<'a> {}
 
 impl<'a> PartialEq<str> for Str<'a> {
+    #[inline]
     fn eq(&self, other: &str) -> bool {
         self.get() == other
     }
 }
 
 impl<'a> PartialEq<Str<'a>> for str {
+    #[inline]
     fn eq(&self, other: &Str<'a>) -> bool {
         self == other.get()
     }
 }
 
 impl<'a, 'b> PartialEq<&'b str> for Str<'a> {
+    #[inline]
     fn eq(&self, other: &&'b str) -> bool {
         self.get() == *other
     }
 }
 
 impl<'a, 'b> PartialEq<Str<'b>> for &'a str {
+    #[inline]
     fn eq(&self, other: &Str<'b>) -> bool {
         *self == other.get()
     }
 }
 
 impl<'a, 'b> PartialOrd<Str<'b>> for Str<'a> {
+    #[inline]
     fn partial_cmp(&self, other: &Str<'b>) -> Option<core::cmp::Ordering> {
         self.get().partial_cmp(other.get())
     }
 }
 
 impl<'a> Ord for Str<'a> {
+    #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.get().cmp(other.get())
     }
 }
 
 impl<'k> Borrow<str> for Str<'k> {
+    #[inline]
     fn borrow(&self) -> &str {
         self.get()
     }
 }
 
 impl<'k> AsRef<str> for Str<'k> {
+    #[inline]
     fn as_ref(&self) -> &str {
         self.get()
     }

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -50,6 +50,8 @@ pub struct Template<'a> {
 enum TemplateKind<'a> {
     Literal([Part<'a>; 1]),
     Parts(&'a [Part<'a>]),
+    StaticLiteral([Part<'static>; 1]),
+    StaticParts(&'static [Part<'static>]),
     #[cfg(feature = "alloc")]
     Owned(Box<[Part<'static>]>),
 }
@@ -59,6 +61,8 @@ impl<'a> TemplateKind<'a> {
         match self {
             TemplateKind::Literal(parts) => parts,
             TemplateKind::Parts(parts) => parts,
+            TemplateKind::StaticLiteral(parts) => parts,
+            TemplateKind::StaticParts(parts) => parts,
             #[cfg(feature = "alloc")]
             TemplateKind::Owned(parts) => parts,
         }
@@ -89,7 +93,7 @@ impl Template<'static> {
     */
     pub const fn new(parts: &'static [Part<'static>]) -> Self {
         Template {
-            kind: TemplateKind::Parts(parts),
+            kind: TemplateKind::StaticParts(parts),
         }
     }
 
@@ -98,7 +102,7 @@ impl Template<'static> {
     */
     pub const fn literal(text: &'static str) -> Self {
         Template {
-            kind: TemplateKind::Literal([Part::text(text)]),
+            kind: TemplateKind::StaticLiteral([Part::text(text)]),
         }
     }
 }
@@ -136,6 +140,20 @@ impl<'a> Template<'a> {
             },
             TemplateKind::Parts(parts) => Template {
                 kind: TemplateKind::Parts(parts),
+            },
+            TemplateKind::StaticLiteral([ref part]) => {
+                if let Some(part) = part.by_static_ref() {
+                    Template {
+                        kind: TemplateKind::StaticLiteral([part]),
+                    }
+                } else {
+                    Template {
+                        kind: TemplateKind::Literal([part.by_ref()]),
+                    }
+                }
+            }
+            TemplateKind::StaticParts(parts) => Template {
+                kind: TemplateKind::StaticParts(parts),
             },
             #[cfg(feature = "alloc")]
             TemplateKind::Owned(ref parts) => Template {
@@ -718,6 +736,25 @@ impl<'a> Part<'a> {
         }
     }
 
+    fn by_static_ref(&self) -> Option<Part<'static>> {
+        Some(match self.0 {
+            PartKind::Text {
+                ref value,
+                needs_escaping,
+            } => Part(PartKind::Text {
+                value: Str::new(value.get_static()?),
+                needs_escaping,
+            }),
+            PartKind::Hole {
+                ref label,
+                ref formatter,
+            } => Part(PartKind::Hole {
+                label: Str::new(label.get_static()?),
+                formatter: formatter.clone(),
+            }),
+        })
+    }
+
     /**
     Set a formatter for a value interpolated into this part to use.
 
@@ -942,17 +979,40 @@ mod alloc_support {
         If the template already contains owned data then this method will simply clone it.
         */
         pub fn to_owned(&self) -> Template<'static> {
-            match self.kind {
-                TemplateKind::Owned(ref parts) => Template::new_owned(parts.clone()),
-                ref parts => {
-                    let mut dst = Vec::new();
+            fn collect_parts(parts: &[Part<'_>]) -> Box<[Part<'static>]> {
+                let mut dst = Vec::new();
 
-                    for part in parts.parts() {
-                        dst.push(part.to_owned());
-                    }
-
-                    Template::new_owned(dst)
+                for part in parts {
+                    dst.push(part.to_owned());
                 }
+
+                dst.into_boxed_slice()
+            }
+
+            match self.kind {
+                TemplateKind::Owned(ref parts) => Template {
+                    kind: TemplateKind::Owned(parts.clone()),
+                },
+                TemplateKind::StaticParts(parts) => Template {
+                    kind: TemplateKind::StaticParts(parts),
+                },
+                TemplateKind::StaticLiteral([ref part]) => {
+                    if let Some(part) = part.by_static_ref() {
+                        Template {
+                            kind: TemplateKind::StaticLiteral([part]),
+                        }
+                    } else {
+                        Template {
+                            kind: TemplateKind::StaticLiteral([part.to_owned()]),
+                        }
+                    }
+                }
+                TemplateKind::Parts(ref parts) => Template {
+                    kind: TemplateKind::Owned(collect_parts(parts)),
+                },
+                TemplateKind::Literal([ref part]) => Template {
+                    kind: TemplateKind::StaticLiteral([part.to_owned()]),
+                },
             }
         }
     }

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -53,6 +53,12 @@ features = ["std"]
 version = "2"
 features = ["std"]
 
+[dependencies.hashbrown]
+version = "0.17"
+
+[dependencies.fnv]
+version = "1"
+
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies.tokio]
 version = "1"
 default-features = false

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -6,12 +6,10 @@ This module is a consumer of `data`, using it to encode incoming events. These a
 
 use crate::{
     Error, OtlpMetrics,
-    data::{
-        self, EncodedEvent, EncodedPayload, EncodedScopeItems, RawEncoder, logs::LogsEventEncoder,
-        metrics::MetricsEventEncoder, traces::TracesEventEncoder,
-    },
+    data::{self, EncodedEvent, EncodedPayload, EncodedScopeItems, RawEncoder},
     internal_metrics::InternalMetrics,
 };
+use emit::Filter;
 use emit_batcher::BatchError;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -46,11 +44,13 @@ mod imp;
 #[path = "client/stub.rs"]
 mod imp;
 
+mod channel;
 mod http;
 mod logs;
 mod metrics;
 mod traces;
 
+pub(crate) use self::channel::{Channel, ChannelItem, SignalWorker};
 pub use self::{logs::*, metrics::*, traces::*};
 
 const DEFAULT_MAX_REQUEST_SIZE_BYTES: usize = 1024 * 1024; // 1MiB
@@ -69,20 +69,51 @@ pub struct Otlp {
 }
 
 struct OtlpInner {
-    otlp_logs: Option<(
-        ClientEventEncoder<LogsEventEncoder>,
-        emit_batcher::Sender<Channel>,
-    )>,
-    otlp_traces: Option<(
-        ClientEventEncoder<TracesEventEncoder>,
-        emit_batcher::Sender<Channel>,
-    )>,
-    otlp_metrics: Option<(
-        ClientEventEncoder<MetricsEventEncoder>,
-        emit_batcher::Sender<Channel>,
-    )>,
+    signals: SignalSenders,
     metrics: Arc<InternalMetrics>,
-    _handle: Handle,
+    #[allow(dead_code)]
+    handle: Option<Handle>,
+}
+
+/** Manages the senders for all configured OTLP signals. */
+pub(crate) struct SignalSenders {
+    logs: Option<emit_batcher::Sender<Channel>>,
+    traces: Option<emit_batcher::Sender<Channel>>,
+    metrics: Option<emit_batcher::Sender<Channel>>,
+}
+
+impl SignalSenders {
+    fn new(
+        logs: Option<emit_batcher::Sender<Channel>>,
+        traces: Option<emit_batcher::Sender<Channel>>,
+        metrics: Option<emit_batcher::Sender<Channel>>,
+    ) -> Self {
+        SignalSenders {
+            logs,
+            traces,
+            metrics,
+        }
+    }
+
+    fn configured_count(&self) -> u32 {
+        self.logs.as_ref().map(|_| 1).unwrap_or_default()
+            + self.traces.as_ref().map(|_| 1).unwrap_or_default()
+            + self.metrics.as_ref().map(|_| 1).unwrap_or_default()
+    }
+
+    fn metric_sources(
+        &self,
+    ) -> (
+        Option<emit_batcher::ChannelMetrics<Channel>>,
+        Option<emit_batcher::ChannelMetrics<Channel>>,
+        Option<emit_batcher::ChannelMetrics<Channel>>,
+    ) {
+        (
+            self.logs.as_ref().map(|s| s.metric_source()),
+            self.traces.as_ref().map(|s| s.metric_source()),
+            self.metrics.as_ref().map(|s| s.metric_source()),
+        )
+    }
 }
 
 impl Otlp {
@@ -101,22 +132,15 @@ impl Otlp {
     These metrics can be used to monitor the running health of your diagnostic pipeline.
     */
     pub fn metric_source(&self) -> OtlpMetrics {
+        let (logs, traces, metrics) = self
+            .inner
+            .as_ref()
+            .map(|i| i.signals.metric_sources())
+            .unwrap_or((None, None, None));
         OtlpMetrics {
-            logs_channel_metrics: self
-                .inner
-                .as_ref()
-                .and_then(|otlp| otlp.otlp_logs.as_ref())
-                .map(|(_, sender)| sender.metric_source()),
-            traces_channel_metrics: self
-                .inner
-                .as_ref()
-                .and_then(|otlp| otlp.otlp_traces.as_ref())
-                .map(|(_, sender)| sender.metric_source()),
-            metrics_channel_metrics: self
-                .inner
-                .as_ref()
-                .and_then(|otlp| otlp.otlp_metrics.as_ref())
-                .map(|(_, sender)| sender.metric_source()),
+            logs_channel_metrics: logs,
+            traces_channel_metrics: traces,
+            metrics_channel_metrics: metrics,
             metrics: self.metrics.clone(),
         }
     }
@@ -229,49 +253,46 @@ impl OtlpBuilder {
     }
 
     fn try_spawn_inner(self, metrics: Arc<InternalMetrics>) -> Result<OtlpInner, Error> {
-        let (otlp_logs, process_otlp_logs) = match self.otlp_logs {
+        let (otlp_logs, worker_logs) = match self.otlp_logs {
             Some(builder) => {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
-
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-
-                (Some((encoder, sender)), Some((transport, receiver)))
+                let worker = SignalWorker::new(encoder, transport, receiver);
+                (Some(sender), Some(worker))
             }
             None => (None, None),
         };
 
-        let (otlp_traces, process_otlp_traces) = match self.otlp_traces {
+        let (otlp_traces, worker_traces) = match self.otlp_traces {
             Some(builder) => {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
-
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-
-                (Some((encoder, sender)), Some((transport, receiver)))
+                let worker = SignalWorker::new(encoder, transport, receiver);
+                (Some(sender), Some(worker))
             }
             None => (None, None),
         };
 
-        let (otlp_metrics, process_otlp_metrics) = match self.otlp_metrics {
+        let (otlp_metrics, worker_metrics) = match self.otlp_metrics {
             Some(builder) => {
                 let (encoder, transport) =
                     builder.build(metrics.clone(), self.resource.as_ref())?;
-
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-
-                (Some((encoder, sender)), Some((transport, receiver)))
+                let worker = SignalWorker::new(encoder, transport, receiver);
+                (Some(sender), Some(worker))
             }
             None => (None, None),
         };
 
         Self::try_spawn_inner_imp(
             otlp_logs,
-            process_otlp_logs,
+            worker_logs,
             otlp_traces,
-            process_otlp_traces,
+            worker_traces,
             otlp_metrics,
-            process_otlp_metrics,
+            worker_metrics,
             metrics,
         )
     }
@@ -496,7 +517,7 @@ impl OtlpTransportBuilder {
     }
 }
 
-enum OtlpTransport<R> {
+pub(crate) enum OtlpTransport<R> {
     Http {
         http: HttpConnection,
         resource: Option<EncodedPayload>,
@@ -505,30 +526,27 @@ enum OtlpTransport<R> {
 }
 
 impl<R: data::RequestEncoder> OtlpTransport<R> {
-    pub(crate) async fn send(&self, mut channel: Channel) -> Result<(), BatchError<Channel>> {
+    pub(crate) async fn send<E: data::EventEncoder>(
+        &self,
+        event_encoder: &ClientEventEncoder<E>,
+        channel: Channel,
+    ) -> Result<(), BatchError<Channel>> {
         match self {
             OtlpTransport::Http {
                 http,
                 resource,
                 request_encoder,
-            } => {
-                // Process each request in the batch
-                while let Some(batch) = channel.requests.last() {
-                    match Self::send_batch(http, resource, request_encoder, batch).await {
-                        Ok(()) => {
-                            channel.requests.pop();
-                        }
-                        Err(e) => {
-                            return Err(e.map_retryable(|r| r.map(|_| channel)));
-                        }
-                    }
-
-                    channel.requests.pop();
-                }
-            }
+            } => channel::execute(
+                channel,
+                DEFAULT_MAX_REQUEST_SIZE_BYTES,
+                |event| event_encoder.encode_event(event),
+                |batch| {
+                    let batch = batch.clone();
+                    async move { Self::send_batch(http, resource, request_encoder, &batch).await }
+                },
+            )
+            .await,
         }
-
-        Ok(())
     }
 
     #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events", batch_size: batch.total_items())]
@@ -606,31 +624,26 @@ impl emit::Emitter for Otlp {
 
 impl OtlpInner {
     fn configured_signals(&self) -> u32 {
-        self.otlp_logs.as_ref().map(|_| 1).unwrap_or_default()
-            + self.otlp_traces.as_ref().map(|_| 1).unwrap_or_default()
-            + self.otlp_metrics.as_ref().map(|_| 1).unwrap_or_default()
+        self.signals.configured_count()
     }
 
     async fn flush(&self, timeout: Duration) -> bool {
-        // Same impl as `blocking_flush` below
-        let configured_signals = self.configured_signals();
-        let timeout = timeout / configured_signals;
-
+        let timeout = timeout / self.configured_signals();
         let mut fully_flushed = true;
 
-        if let Some((_, ref sender)) = self.otlp_logs {
+        if let Some(ref sender) = self.signals.logs {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
         }
 
-        if let Some((_, ref sender)) = self.otlp_traces {
+        if let Some(ref sender) = self.signals.traces {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
         }
 
-        if let Some((_, ref sender)) = self.otlp_metrics {
+        if let Some(ref sender) = self.signals.metrics {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
@@ -638,37 +651,39 @@ impl OtlpInner {
 
         fully_flushed
     }
+
+    /** Take the background handle, consuming the inner.
+    Used by tests to verify the worker thread shuts down cleanly. */
+    #[allow(dead_code)]
+    fn take_handle(&mut self) -> Handle {
+        self.handle.take().expect("handle already taken")
+    }
 }
 
 impl emit::Emitter for OtlpInner {
     fn emit<E: emit::event::ToEvent>(&self, evt: E) {
-        let evt = evt.to_event();
+        let owned = evt.to_event().to_owned();
 
-        if let Some((ref encoder, ref sender)) = self.otlp_metrics {
-            if let Some(event) = encoder.encode_event(&evt) {
-                return sender.send(ChannelItem {
-                    max_request_size_bytes: DEFAULT_MAX_REQUEST_SIZE_BYTES,
-                    event,
-                });
+        // Check metrics first (highest priority)
+        if let Some(ref sender) = self.signals.metrics {
+            if emit::kind::is_metric_filter().matches(&owned) {
+                sender.send(ChannelItem { event: owned });
+                return;
             }
         }
 
-        if let Some((ref encoder, ref sender)) = self.otlp_traces {
-            if let Some(event) = encoder.encode_event(&evt) {
-                return sender.send(ChannelItem {
-                    max_request_size_bytes: DEFAULT_MAX_REQUEST_SIZE_BYTES,
-                    event,
-                });
+        // Check traces second
+        if let Some(ref sender) = self.signals.traces {
+            if emit::kind::is_span_filter().matches(&owned) {
+                sender.send(ChannelItem { event: owned });
+                return;
             }
         }
 
-        if let Some((ref encoder, ref sender)) = self.otlp_logs {
-            if let Some(event) = encoder.encode_event(&evt) {
-                return sender.send(ChannelItem {
-                    max_request_size_bytes: DEFAULT_MAX_REQUEST_SIZE_BYTES,
-                    event,
-                });
-            }
+        // Logs is the fallback — accepts all events
+        if let Some(ref sender) = self.signals.logs {
+            sender.send(ChannelItem { event: owned });
+            return;
         }
 
         self.metrics.event_discarded.increment();
@@ -678,87 +693,28 @@ impl emit::Emitter for OtlpInner {
     Wait for up to `timeout` for any pending events to be sent to the backend OTLP service.
     */
     fn blocking_flush(&self, timeout: Duration) -> bool {
-        let configured_signals = self.configured_signals();
-        let timeout = timeout / configured_signals;
+        let timeout = timeout / self.configured_signals();
         let mut fully_flushed = true;
 
-        if let Some((_, ref sender)) = self.otlp_logs {
+        if let Some(ref sender) = self.signals.logs {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
         }
 
-        if let Some((_, ref sender)) = self.otlp_traces {
+        if let Some(ref sender) = self.signals.traces {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
         }
 
-        if let Some((_, ref sender)) = self.otlp_metrics {
+        if let Some(ref sender) = self.signals.metrics {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
         }
 
         fully_flushed
-    }
-}
-
-#[derive(Default)]
-pub(crate) struct Channel {
-    requests: Vec<EncodedScopeItems>,
-    current_request_size_bytes: usize,
-    total_items: usize,
-}
-
-pub(crate) struct ChannelItem {
-    max_request_size_bytes: usize,
-    event: EncodedEvent,
-}
-
-impl emit_batcher::Channel for Channel {
-    type Item = ChannelItem;
-
-    fn new() -> Self {
-        Channel::default()
-    }
-
-    fn push(&mut self, item: Self::Item) {
-        let incoming_size_bytes = item.event.payload.len();
-
-        // If the channel is empty or the current request is over its size limit then begin a new one
-        if self.requests.len() == 0
-            || self.current_request_size_bytes >= item.max_request_size_bytes
-        {
-            let mut request = EncodedScopeItems::new();
-            request.push(item.event);
-
-            self.requests.push(request);
-            self.current_request_size_bytes = incoming_size_bytes;
-        }
-        // If the current request still has capacity then push onto it
-        else {
-            self.requests.last_mut().unwrap().push(item.event);
-            self.current_request_size_bytes += incoming_size_bytes;
-        }
-
-        self.total_items += 1;
-    }
-
-    fn len(&self) -> usize {
-        self.total_items
-    }
-
-    fn clear(&mut self) {
-        let Channel {
-            requests,
-            total_items,
-            current_request_size_bytes,
-        } = self;
-
-        requests.clear();
-        *total_items = 0;
-        *current_request_size_bytes = 0;
     }
 }
 
@@ -786,7 +742,7 @@ impl Encoding {
     }
 }
 
-struct ClientEventEncoder<E> {
+pub(crate) struct ClientEventEncoder<E> {
     encoding: Encoding,
     encoder: E,
 }
@@ -809,7 +765,7 @@ impl<E: data::EventEncoder> ClientEventEncoder<E> {
     }
 }
 
-struct ClientRequestEncoder<R> {
+pub(crate) struct ClientRequestEncoder<R> {
     encoding: Encoding,
     encoder: R,
 }
@@ -866,9 +822,8 @@ mod tests {
         let mut otlp = Otlp::builder().spawn();
 
         let handle = {
-            let inner = otlp.inner.take().unwrap();
-
-            inner._handle
+            let mut inner = otlp.inner.take().unwrap();
+            inner.take_handle()
         };
 
         drop(otlp);
@@ -891,41 +846,13 @@ mod tests {
             .spawn();
 
         let handle = {
-            let inner = otlp.inner.take().unwrap();
-
-            inner._handle
+            let mut inner = otlp.inner.take().unwrap();
+            inner.take_handle()
         };
 
         drop(otlp);
 
         // Ensure the background thread is torn down
         handle.join().unwrap();
-    }
-
-    #[test]
-    fn otlp_channel_splits_requests_by_size() {
-        use emit_batcher::Channel as _;
-
-        for (max_request_size_bytes, expected_len) in [(0, 100), (1, 100), (10, 20)] {
-            let mut channel = Channel::new();
-
-            for _ in 0..100 {
-                channel.push(ChannelItem {
-                    max_request_size_bytes,
-                    event: EncodedEvent {
-                        scope: emit::path!("a"),
-                        payload: EncodedPayload::Json(sval_json::JsonStr::boxed("{}")),
-                    },
-                });
-            }
-
-            assert_eq!(100, channel.total_items);
-
-            assert_eq!(
-                expected_len,
-                channel.requests.len(),
-                "{max_request_size_bytes} did not produce {expected_len} items"
-            );
-        }
     }
 }

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use emit::Filter;
 use emit_batcher::BatchError;
-use std::{collections::HashMap, fmt, future::Future, sync::Arc, time::Duration};
+use std::{cmp, collections::HashMap, fmt, future::Future, sync::Arc, time::Duration};
 
 use self::{
     http::{HttpConnection, HttpVersion},
@@ -50,11 +50,12 @@ mod logs;
 mod metrics;
 mod traces;
 
-pub(crate) use self::channel::{Channel, ChannelItem, SignalWorker};
+pub(crate) use self::channel::{Channel, ChannelItem};
 pub use self::{logs::*, metrics::*, traces::*};
 
 const DEFAULT_MAX_REQUEST_SIZE_BYTES: usize = 1024 * 1024; // 1MiB
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_CHANNEL_SIZE_EVENTS: usize = 10_000;
 
 /**
 An [`emit::Emitter`] that sends diagnostic events via the OpenTelemetry Protocol (OTLP).
@@ -69,51 +70,17 @@ pub struct Otlp {
 }
 
 struct OtlpInner {
-    signals: SignalSenders,
     metrics: Arc<InternalMetrics>,
+    otlp_logs: Option<emit_batcher::Sender<Channel>>,
+    otlp_traces: Option<emit_batcher::Sender<Channel>>,
+    otlp_metrics: Option<emit_batcher::Sender<Channel>>,
     #[allow(dead_code)]
     handle: Option<Handle>,
 }
 
-/** Manages the senders for all configured OTLP signals. */
-pub(crate) struct SignalSenders {
-    logs: Option<emit_batcher::Sender<Channel>>,
-    traces: Option<emit_batcher::Sender<Channel>>,
-    metrics: Option<emit_batcher::Sender<Channel>>,
-}
-
-impl SignalSenders {
-    fn new(
-        logs: Option<emit_batcher::Sender<Channel>>,
-        traces: Option<emit_batcher::Sender<Channel>>,
-        metrics: Option<emit_batcher::Sender<Channel>>,
-    ) -> Self {
-        SignalSenders {
-            logs,
-            traces,
-            metrics,
-        }
-    }
-
-    fn configured_count(&self) -> u32 {
-        self.logs.as_ref().map(|_| 1).unwrap_or_default()
-            + self.traces.as_ref().map(|_| 1).unwrap_or_default()
-            + self.metrics.as_ref().map(|_| 1).unwrap_or_default()
-    }
-
-    fn metric_sources(
-        &self,
-    ) -> (
-        Option<emit_batcher::ChannelMetrics<Channel>>,
-        Option<emit_batcher::ChannelMetrics<Channel>>,
-        Option<emit_batcher::ChannelMetrics<Channel>>,
-    ) {
-        (
-            self.logs.as_ref().map(|s| s.metric_source()),
-            self.traces.as_ref().map(|s| s.metric_source()),
-            self.metrics.as_ref().map(|s| s.metric_source()),
-        )
-    }
+struct SignalWorker<S, E, R> {
+    pub(crate) transport: Arc<OtlpTransport<S, E, R>>,
+    pub(crate) receiver: emit_batcher::Receiver<Channel>,
 }
 
 impl Otlp {
@@ -132,15 +99,22 @@ impl Otlp {
     These metrics can be used to monitor the running health of your diagnostic pipeline.
     */
     pub fn metric_source(&self) -> OtlpMetrics {
-        let (logs, traces, metrics) = self
-            .inner
-            .as_ref()
-            .map(|i| i.signals.metric_sources())
-            .unwrap_or((None, None, None));
         OtlpMetrics {
-            logs_channel_metrics: logs,
-            traces_channel_metrics: traces,
-            metrics_channel_metrics: metrics,
+            logs_channel_metrics: self
+                .inner
+                .as_ref()
+                .and_then(|inner| inner.otlp_logs.as_ref())
+                .map(|signal| signal.metric_source()),
+            traces_channel_metrics: self
+                .inner
+                .as_ref()
+                .and_then(|inner| inner.otlp_traces.as_ref())
+                .map(|signal| signal.metric_source()),
+            metrics_channel_metrics: self
+                .inner
+                .as_ref()
+                .and_then(|inner| inner.otlp_metrics.as_ref())
+                .map(|signal| signal.metric_source()),
             metrics: self.metrics.clone(),
         }
     }
@@ -211,7 +185,7 @@ impl OtlpBuilder {
 
     Some OTLP receivers accept data without a resource but the OpenTelemetry specification itself mandates it.
     */
-    pub fn resource(mut self, attributes: impl emit::props::Props) -> Self {
+    pub fn resource(mut self, attributes: impl emit::Props) -> Self {
         let mut resource = Resource {
             attributes: HashMap::new(),
         };
@@ -255,9 +229,13 @@ impl OtlpBuilder {
     fn try_spawn_inner(self, metrics: Arc<InternalMetrics>) -> Result<OtlpInner, Error> {
         let (otlp_logs, worker_logs) = match self.otlp_logs {
             Some(builder) => {
-                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
-                let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(transport, receiver);
+                let transport = Arc::new(builder.build(metrics.clone(), self.resource.as_ref())?);
+                let (sender, receiver) = emit_batcher::bounded(DEFAULT_CHANNEL_SIZE_EVENTS);
+                let worker = SignalWorker {
+                    transport,
+                    receiver,
+                };
+
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -265,9 +243,13 @@ impl OtlpBuilder {
 
         let (otlp_traces, worker_traces) = match self.otlp_traces {
             Some(builder) => {
-                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
-                let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(transport, receiver);
+                let transport = Arc::new(builder.build(metrics.clone(), self.resource.as_ref())?);
+                let (sender, receiver) = emit_batcher::bounded(DEFAULT_CHANNEL_SIZE_EVENTS);
+                let worker = SignalWorker {
+                    transport,
+                    receiver,
+                };
+
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -275,9 +257,13 @@ impl OtlpBuilder {
 
         let (otlp_metrics, worker_metrics) = match self.otlp_metrics {
             Some(builder) => {
-                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
-                let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(transport, receiver);
+                let transport = Arc::new(builder.build(metrics.clone(), self.resource.as_ref())?);
+                let (sender, receiver) = emit_batcher::bounded(DEFAULT_CHANNEL_SIZE_EVENTS);
+                let worker = SignalWorker {
+                    transport,
+                    receiver,
+                };
+
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -620,27 +606,33 @@ impl emit::Emitter for Otlp {
 }
 
 impl OtlpInner {
-    fn configured_signals(&self) -> u32 {
-        self.signals.configured_count()
+    fn timeout_per_signal(&self, timeout: Duration) -> Duration {
+        let logs = self.otlp_logs.as_ref().map(|_| 1).unwrap_or(0);
+        let traces = self.otlp_traces.as_ref().map(|_| 1).unwrap_or(0);
+        let metrics = self.otlp_metrics.as_ref().map(|_| 1).unwrap_or(0);
+
+        let budget = cmp::max(1, logs + traces + metrics);
+
+        timeout / budget
     }
 
     async fn flush(&self, timeout: Duration) -> bool {
-        let timeout = timeout / self.configured_signals();
+        let timeout = self.timeout_per_signal(timeout);
         let mut fully_flushed = true;
 
-        if let Some(ref sender) = self.signals.logs {
+        if let Some(ref sender) = self.otlp_logs {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
         }
 
-        if let Some(ref sender) = self.signals.traces {
+        if let Some(ref sender) = self.otlp_traces {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
         }
 
-        if let Some(ref sender) = self.signals.metrics {
+        if let Some(ref sender) = self.otlp_metrics {
             if !imp::flush(sender, timeout).await {
                 fully_flushed = false;
             }
@@ -659,27 +651,30 @@ impl OtlpInner {
 
 impl emit::Emitter for OtlpInner {
     fn emit<E: emit::event::ToEvent>(&self, evt: E) {
-        let owned = evt.to_event().to_owned();
+        let evt = evt.to_event();
 
-        // Check metrics first (highest priority)
-        if let Some(ref sender) = self.signals.metrics {
-            if emit::kind::is_metric_filter().matches(&owned) {
-                sender.send(ChannelItem { event: owned });
+        if let Some(ref sender) = self.otlp_metrics {
+            if emit::kind::is_metric_filter().matches(&evt) {
+                sender.send(ChannelItem {
+                    event: evt.to_owned(),
+                });
                 return;
             }
         }
 
-        // Check traces second
-        if let Some(ref sender) = self.signals.traces {
-            if emit::kind::is_span_filter().matches(&owned) {
-                sender.send(ChannelItem { event: owned });
+        if let Some(ref sender) = self.otlp_traces {
+            if emit::kind::is_span_filter().matches(&evt) {
+                sender.send(ChannelItem {
+                    event: evt.to_owned(),
+                });
                 return;
             }
         }
 
-        // Logs is the fallback — accepts all events
-        if let Some(ref sender) = self.signals.logs {
-            sender.send(ChannelItem { event: owned });
+        if let Some(ref sender) = self.otlp_logs {
+            sender.send(ChannelItem {
+                event: evt.to_owned(),
+            });
             return;
         }
 
@@ -690,22 +685,22 @@ impl emit::Emitter for OtlpInner {
     Wait for up to `timeout` for any pending events to be sent to the backend OTLP service.
     */
     fn blocking_flush(&self, timeout: Duration) -> bool {
-        let timeout = timeout / self.configured_signals();
+        let timeout = self.timeout_per_signal(timeout);
         let mut fully_flushed = true;
 
-        if let Some(ref sender) = self.signals.logs {
+        if let Some(ref sender) = self.otlp_logs {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
         }
 
-        if let Some(ref sender) = self.signals.traces {
+        if let Some(ref sender) = self.otlp_traces {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
         }
 
-        if let Some(ref sender) = self.signals.metrics {
+        if let Some(ref sender) = self.otlp_metrics {
             if !emit_batcher::blocking_flush(sender, timeout) {
                 fully_flushed = false;
             }
@@ -751,10 +746,7 @@ impl<E> ClientEventEncoder<E> {
 }
 
 impl<E: data::EventEncoder> ClientEventEncoder<E> {
-    pub fn encode_event(
-        &self,
-        evt: &emit::event::Event<impl emit::props::Props>,
-    ) -> Option<EncodedEvent> {
+    pub fn encode_event(&self, evt: &emit::event::Event<impl emit::Props>) -> Option<EncodedEvent> {
         match self.encoding {
             Encoding::Proto => self.encoder.encode_event::<data::Proto>(evt),
             Encoding::Json => self.encoder.encode_event::<data::Json>(evt),

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use emit::Filter;
 use emit_batcher::BatchError;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, future::Future, sync::Arc, time::Duration};
 
 use self::{
     http::{HttpConnection, HttpVersion},
@@ -255,10 +255,9 @@ impl OtlpBuilder {
     fn try_spawn_inner(self, metrics: Arc<InternalMetrics>) -> Result<OtlpInner, Error> {
         let (otlp_logs, worker_logs) = match self.otlp_logs {
             Some(builder) => {
-                let (encoder, transport) =
-                    builder.build(metrics.clone(), self.resource.as_ref())?;
+                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(encoder, transport, receiver);
+                let worker = SignalWorker::new(transport, receiver);
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -266,10 +265,9 @@ impl OtlpBuilder {
 
         let (otlp_traces, worker_traces) = match self.otlp_traces {
             Some(builder) => {
-                let (encoder, transport) =
-                    builder.build(metrics.clone(), self.resource.as_ref())?;
+                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(encoder, transport, receiver);
+                let worker = SignalWorker::new(transport, receiver);
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -277,10 +275,9 @@ impl OtlpBuilder {
 
         let (otlp_metrics, worker_metrics) = match self.otlp_metrics {
             Some(builder) => {
-                let (encoder, transport) =
-                    builder.build(metrics.clone(), self.resource.as_ref())?;
+                let transport = builder.build(metrics.clone(), self.resource.as_ref())?;
                 let (sender, receiver) = emit_batcher::bounded(10_000);
-                let worker = SignalWorker::new(encoder, transport, receiver);
+                let worker = SignalWorker::new(transport, receiver);
                 (Some(sender), Some(worker))
             }
             None => (None, None),
@@ -375,191 +372,191 @@ impl OtlpTransportBuilder {
         self
     }
 
-    fn build<R>(
+    fn build<E, R>(
         self,
         metrics: Arc<InternalMetrics>,
+        event_encoder: ClientEventEncoder<E>,
         resource: Option<EncodedPayload>,
         request_encoder: ClientRequestEncoder<R>,
-    ) -> Result<OtlpTransport<R>, Error> {
+    ) -> Result<OtlpTransport<HttpConnection, E, R>, Error> {
         let mut url = self.url_base;
 
         if let Some(path) = self.url_path {
             crate::push_path(&mut url, path);
         }
 
-        Ok(match self.protocol {
+        let request_sender = match self.protocol {
             // Configure the transport to use regular HTTP requests
-            Protocol::Http => OtlpTransport::Http {
-                http: HttpConnection::new(
-                    HttpVersion::Http1,
-                    metrics.clone(),
-                    url,
-                    self.allow_compression,
-                    self.headers,
-                    |req| Ok(req),
-                    move |res| {
-                        let metrics = metrics.clone();
+            Protocol::Http => HttpConnection::new(
+                HttpVersion::Http1,
+                metrics.clone(),
+                url,
+                self.allow_compression,
+                self.headers,
+                |req| Ok(req),
+                move |res| {
+                    let metrics = metrics.clone();
 
-                        async move {
-                            let status = res.http_status();
+                    async move {
+                        let status = res.http_status();
 
-                            // A request is considered successful if it returns 2xx status code
-                            if status >= 200 && status < 300 {
-                                metrics.http_batch_sent.increment();
+                        // A request is considered successful if it returns 2xx status code
+                        if status >= 200 && status < 300 {
+                            metrics.http_batch_sent.increment();
 
-                                Ok(())
-                            } else {
-                                metrics.http_batch_failed.increment();
+                            Ok(())
+                        } else {
+                            metrics.http_batch_failed.increment();
 
-                                Err(Error::msg(format_args!(
-                                    "OTLP HTTP server responded {status}"
-                                )))
-                            }
+                            Err(Error::msg(format_args!(
+                                "OTLP HTTP server responded {status}"
+                            )))
                         }
-                    },
-                )?,
-                resource,
-                request_encoder,
-            },
+                    }
+                },
+            )?,
             // Configure the transport to use gRPC requests
             // These are mostly the same as regular HTTP requests, but use
             // a simple message framing protocol and carry status codes in a trailer
             // instead of the response status
-            Protocol::Grpc => OtlpTransport::Http {
-                http: HttpConnection::new(
-                    HttpVersion::Http2,
-                    metrics.clone(),
-                    url,
-                    self.allow_compression,
-                    self.headers,
-                    |req| {
-                        let content_type_header = match req.content_type_header() {
-                            "application/x-protobuf" => "application/grpc+proto",
-                            content_type => {
-                                return Err(Error::msg(format_args!(
-                                    "unsupported content type '{content_type}'"
-                                )));
+            Protocol::Grpc => HttpConnection::new(
+                HttpVersion::Http2,
+                metrics.clone(),
+                url,
+                self.allow_compression,
+                self.headers,
+                |req| {
+                    let content_type_header = match req.content_type_header() {
+                        "application/x-protobuf" => "application/grpc+proto",
+                        content_type => {
+                            return Err(Error::msg(format_args!(
+                                "unsupported content type '{content_type}'"
+                            )));
+                        }
+                    };
+
+                    // Wrap the content in the gRPC frame protocol
+                    // This is a simple length-prefixed format that uses
+                    // 5 bytes to indicate the length and compression of the message
+                    let len = (u32::try_from(req.content_payload_len()).unwrap()).to_be_bytes();
+
+                    Ok(
+                        // If the content is compressed then set the gRPC compression header byte for it
+                        if let Some(compression) = req.content_encoding_header() {
+                            req.with_content_encoding_header(None)
+                                .with_content_type_header(content_type_header)
+                                .with_headers(match compression {
+                                    "gzip" => &[("grpc-encoding", "gzip")],
+                                    compression => {
+                                        return Err(Error::msg(format_args!(
+                                            "unsupported compression '{compression}'"
+                                        )));
+                                    }
+                                })
+                                .with_content_frame([1, len[0], len[1], len[2], len[3]])
+                        }
+                        // If the content is not compressed then leave the gRPC compression header byte unset
+                        else {
+                            req.with_content_type_header(content_type_header)
+                                .with_content_frame([0, len[0], len[1], len[2], len[3]])
+                        },
+                    )
+                },
+                move |res| {
+                    let metrics = metrics.clone();
+
+                    async move {
+                        let mut status = 0;
+                        let mut msg = String::new();
+
+                        res.stream_trailers(|k, v| match k {
+                            "grpc-status" => {
+                                status = v.parse().unwrap_or(0);
                             }
-                        };
-
-                        // Wrap the content in the gRPC frame protocol
-                        // This is a simple length-prefixed format that uses
-                        // 5 bytes to indicate the length and compression of the message
-                        let len = (u32::try_from(req.content_payload_len()).unwrap()).to_be_bytes();
-
-                        Ok(
-                            // If the content is compressed then set the gRPC compression header byte for it
-                            if let Some(compression) = req.content_encoding_header() {
-                                req.with_content_encoding_header(None)
-                                    .with_content_type_header(content_type_header)
-                                    .with_headers(match compression {
-                                        "gzip" => &[("grpc-encoding", "gzip")],
-                                        compression => {
-                                            return Err(Error::msg(format_args!(
-                                                "unsupported compression '{compression}'"
-                                            )));
-                                        }
-                                    })
-                                    .with_content_frame([1, len[0], len[1], len[2], len[3]])
+                            "grpc-message" => {
+                                msg = v.into();
                             }
-                            // If the content is not compressed then leave the gRPC compression header byte unset
-                            else {
-                                req.with_content_type_header(content_type_header)
-                                    .with_content_frame([0, len[0], len[1], len[2], len[3]])
-                            },
-                        )
-                    },
-                    move |res| {
-                        let metrics = metrics.clone();
+                            _ => {}
+                        })
+                        .await?;
 
-                        async move {
-                            let mut status = 0;
-                            let mut msg = String::new();
+                        // A request is considered successful if the grpc-status trailer is 0
+                        if status == 0 {
+                            metrics.grpc_batch_sent.increment();
 
-                            res.stream_trailers(|k, v| match k {
-                                "grpc-status" => {
-                                    status = v.parse().unwrap_or(0);
-                                }
-                                "grpc-message" => {
-                                    msg = v.into();
-                                }
-                                _ => {}
-                            })
-                            .await?;
+                            Ok(())
+                        }
+                        // In any other case the request failed and may carry some diagnostic message
+                        else {
+                            metrics.grpc_batch_failed.increment();
 
-                            // A request is considered successful if the grpc-status trailer is 0
-                            if status == 0 {
-                                metrics.grpc_batch_sent.increment();
-
-                                Ok(())
-                            }
-                            // In any other case the request failed and may carry some diagnostic message
-                            else {
-                                metrics.grpc_batch_failed.increment();
-
-                                if msg.len() > 0 {
-                                    Err(Error::msg(format_args!(
-                                        "OTLP gRPC server responded {status} {msg}"
-                                    )))
-                                } else {
-                                    Err(Error::msg(format_args!(
-                                        "OTLP gRPC server responded {status}"
-                                    )))
-                                }
+                            if msg.len() > 0 {
+                                Err(Error::msg(format_args!(
+                                    "OTLP gRPC server responded {status} {msg}"
+                                )))
+                            } else {
+                                Err(Error::msg(format_args!(
+                                    "OTLP gRPC server responded {status}"
+                                )))
                             }
                         }
-                    },
-                )?,
-                resource,
-                request_encoder,
-            },
+                    }
+                },
+            )?,
+        };
+
+        Ok(OtlpTransport {
+            event_encoder,
+            request_sender,
+            resource,
+            request_encoder,
         })
     }
 }
 
-pub(crate) enum OtlpTransport<R> {
-    Http {
-        http: HttpConnection,
-        resource: Option<EncodedPayload>,
-        request_encoder: ClientRequestEncoder<R>,
-    },
+pub(crate) struct OtlpTransport<S, E, R> {
+    event_encoder: ClientEventEncoder<E>,
+    request_sender: S,
+    resource: Option<EncodedPayload>,
+    request_encoder: ClientRequestEncoder<R>,
 }
 
-impl<R: data::RequestEncoder> OtlpTransport<R> {
-    pub(crate) async fn send<E: data::EventEncoder>(
-        &self,
-        event_encoder: &ClientEventEncoder<E>,
-        channel: Channel,
-    ) -> Result<(), BatchError<Channel>> {
-        match self {
-            OtlpTransport::Http {
-                http,
-                resource,
-                request_encoder,
-            } => channel::execute(
-                channel,
-                DEFAULT_MAX_REQUEST_SIZE_BYTES,
-                |event| event_encoder.encode_event(event),
-                |batch| {
-                    let batch = batch.clone();
-                    async move { Self::send_batch(http, resource, request_encoder, &batch).await }
-                },
-            )
-            .await,
-        }
+impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
+    OtlpTransport<S, E, R>
+{
+    pub(crate) async fn send(&self, channel: Channel) -> Result<(), BatchError<Channel>> {
+        let event_encoder = &self.event_encoder;
+        channel::execute(
+            channel,
+            DEFAULT_MAX_REQUEST_SIZE_BYTES,
+            |event| event_encoder.encode_event(event),
+            |batch| {
+                let batch = batch.clone();
+                async move {
+                    Self::send_batch(
+                        &self.request_sender,
+                        &self.resource,
+                        &self.request_encoder,
+                        &batch,
+                    )
+                    .await
+                }
+            },
+        )
+        .await
     }
 
-    #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events", batch_size: batch.total_items())]
+    #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events to {uri}", batch_size: batch.total_items(), uri: request_sender.uri())]
     pub(crate) async fn send_batch(
-        http: &HttpConnection,
+        request_sender: &S,
         resource: &Option<EncodedPayload>,
         request_encoder: &ClientRequestEncoder<R>,
         batch: &EncodedScopeItems,
     ) -> Result<(), BatchError<()>> {
-        let uri = http.uri();
+        let uri = request_sender.uri();
         let batch_size = batch.total_items();
 
-        match http
+        match request_sender
             .send(
                 request_encoder.encode_request(resource.as_ref(), &batch)?,
                 DEFAULT_REQUEST_TIMEOUT,
@@ -763,6 +760,16 @@ impl<E: data::EventEncoder> ClientEventEncoder<E> {
             Encoding::Json => self.encoder.encode_event::<data::Json>(evt),
         }
     }
+}
+
+pub(crate) trait ClientRequestSender {
+    fn uri(&self) -> &(impl fmt::Display + 'static);
+
+    fn send(
+        &self,
+        body: EncodedPayload,
+        timeout: Duration,
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
 pub(crate) struct ClientRequestEncoder<R> {

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -510,12 +510,17 @@ pub(crate) struct OtlpTransport<S, E, R> {
 impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
     OtlpTransport<S, E, R>
 {
-    pub(crate) async fn send(&self, channel: Channel) -> Result<(), BatchError<Channel>> {
+    pub(crate) async fn send(
+        &self,
+        channel: Channel,
+        metrics: &InternalMetrics,
+    ) -> Result<(), BatchError<Channel>> {
         let event_encoder = &self.event_encoder;
 
         channel::batch(
             channel,
             DEFAULT_MAX_REQUEST_SIZE_BYTES,
+            metrics,
             |event| event_encoder.encode_event(event),
             |batch| {
                 let batch = batch.clone();

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -771,7 +771,7 @@ pub(crate) trait ClientRequestSender {
         &self,
         body: EncodedPayload,
         timeout: Duration,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>>;
 }
 
 pub(crate) struct ClientRequestEncoder<R> {
@@ -819,8 +819,6 @@ fn encode_resource(encoding: Encoding, resource: &Resource) -> EncodedPayload {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     #[cfg(not(all(
         target_arch = "wasm32",
@@ -828,6 +826,8 @@ mod tests {
         target_os = "unknown"
     )))]
     fn otlp_empty_closes_bg_thread_on_drop() {
+        use super::*;
+
         let mut otlp = Otlp::builder().spawn();
 
         let handle = {
@@ -848,6 +848,8 @@ mod tests {
         target_os = "unknown"
     )))]
     fn otlp_non_empty_closes_bg_thread_on_drop() {
+        use super::*;
+
         let mut otlp = Otlp::builder()
             .logs(OtlpLogsBuilder::proto(OtlpTransportBuilder::http(
                 "http://localhost:4319",

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -50,7 +50,7 @@ mod logs;
 mod metrics;
 mod traces;
 
-pub(crate) use self::channel::{Channel, ChannelItem};
+pub(crate) use self::channel::{Channel, ChannelEvent, ChannelItem};
 pub use self::{logs::*, metrics::*, traces::*};
 
 const DEFAULT_MAX_REQUEST_SIZE_BYTES: usize = 1024 * 1024; // 1MiB
@@ -525,7 +525,7 @@ impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
             channel,
             DEFAULT_MAX_REQUEST_SIZE_BYTES,
             metrics,
-            |event| event_encoder.encode_event(event),
+            |event| event_encoder.encode_event(event.get()),
             |batch| {
                 let batch = batch.clone();
                 async move {
@@ -666,7 +666,7 @@ impl emit::Emitter for OtlpInner {
         if let Some(ref sender) = self.otlp_metrics {
             if emit::kind::is_metric_filter().matches(&evt) {
                 sender.send(ChannelItem {
-                    event: evt.to_owned(),
+                    event: ChannelEvent::from_evt(evt),
                 });
                 return;
             }
@@ -675,7 +675,7 @@ impl emit::Emitter for OtlpInner {
         if let Some(ref sender) = self.otlp_traces {
             if emit::kind::is_span_filter().matches(&evt) {
                 sender.send(ChannelItem {
-                    event: evt.to_owned(),
+                    event: ChannelEvent::from_evt(evt),
                 });
                 return;
             }
@@ -683,7 +683,7 @@ impl emit::Emitter for OtlpInner {
 
         if let Some(ref sender) = self.otlp_logs {
             sender.send(ChannelItem {
-                event: evt.to_owned(),
+                event: ChannelEvent::from_evt(evt),
             });
             return;
         }

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -81,6 +81,7 @@ struct OtlpInner {
 struct SignalWorker<S, E, R> {
     pub(crate) transport: Arc<OtlpTransport<S, E, R>>,
     pub(crate) receiver: emit_batcher::Receiver<Channel>,
+    pub(crate) metrics: Arc<InternalMetrics>,
 }
 
 impl Otlp {
@@ -234,6 +235,7 @@ impl OtlpBuilder {
                 let worker = SignalWorker {
                     transport,
                     receiver,
+                    metrics: metrics.clone(),
                 };
 
                 (Some(sender), Some(worker))
@@ -248,6 +250,7 @@ impl OtlpBuilder {
                 let worker = SignalWorker {
                     transport,
                     receiver,
+                    metrics: metrics.clone(),
                 };
 
                 (Some(sender), Some(worker))
@@ -262,6 +265,7 @@ impl OtlpBuilder {
                 let worker = SignalWorker {
                     transport,
                     receiver,
+                    metrics: metrics.clone(),
                 };
 
                 (Some(sender), Some(worker))

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -50,7 +50,7 @@ mod logs;
 mod metrics;
 mod traces;
 
-pub(crate) use self::channel::{Channel, ChannelEvent, ChannelItem};
+pub(crate) use self::channel::{Channel, ChannelEvent};
 pub use self::{logs::*, metrics::*, traces::*};
 
 const DEFAULT_MAX_REQUEST_SIZE_BYTES: usize = 1024 * 1024; // 1MiB
@@ -665,26 +665,20 @@ impl emit::Emitter for OtlpInner {
 
         if let Some(ref sender) = self.otlp_metrics {
             if emit::kind::is_metric_filter().matches(&evt) {
-                sender.send(ChannelItem {
-                    event: ChannelEvent::from_evt(evt),
-                });
+                sender.send(ChannelEvent::from_evt(evt));
                 return;
             }
         }
 
         if let Some(ref sender) = self.otlp_traces {
             if emit::kind::is_span_filter().matches(&evt) {
-                sender.send(ChannelItem {
-                    event: ChannelEvent::from_evt(evt),
-                });
+                sender.send(ChannelEvent::from_evt(evt));
                 return;
             }
         }
 
         if let Some(ref sender) = self.otlp_logs {
-            sender.send(ChannelItem {
-                event: ChannelEvent::from_evt(evt),
-            });
+            sender.send(ChannelEvent::from_evt(evt));
             return;
         }
 

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -512,14 +512,62 @@ impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
 {
     pub(crate) async fn send(&self, channel: Channel) -> Result<(), BatchError<Channel>> {
         let event_encoder = &self.event_encoder;
-        channel::execute(
+
+        channel::batch(
             channel,
             DEFAULT_MAX_REQUEST_SIZE_BYTES,
             |event| event_encoder.encode_event(event),
             |batch| {
                 let batch = batch.clone();
                 async move {
-                    Self::send_batch(
+                    #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events to {uri}", batch_size: batch.total_items(), uri: request_sender.uri())]
+                    async fn send_batch<S: ClientRequestSender, R: data::RequestEncoder>(
+                        request_sender: &S,
+                        resource: &Option<EncodedPayload>,
+                        request_encoder: &ClientRequestEncoder<R>,
+                        batch: &EncodedScopeItems,
+                    ) -> Result<(), BatchError<()>> {
+                        let uri = request_sender.uri();
+                        let batch_size = batch.total_items();
+
+                        match request_sender
+                            .send(
+                                request_encoder.encode_request(resource.as_ref(), &batch)?,
+                                DEFAULT_REQUEST_TIMEOUT,
+                            )
+                            .await
+                        {
+                            Ok(res) => {
+                                span.complete_with(emit::span::completion::from_fn(|evt| {
+                                    emit::debug!(
+                                        rt: emit::runtime::internal(),
+                                        evt,
+                                        "OTLP batch of {batch_size} events to {uri}",
+                                        batch_size,
+                                    )
+                                }));
+
+                                res
+                            }
+                            Err(err) => {
+                                span.complete_with(emit::span::completion::from_fn(|evt| {
+                                    emit::warn!(
+                                        rt: emit::runtime::internal(),
+                                        evt,
+                                        "OTLP batch of {batch_size} events to {uri} failed: {err}",
+                                        batch_size,
+                                        err,
+                                    )
+                                }));
+
+                                return Err(BatchError::retry(err, ()));
+                            }
+                        };
+
+                        Ok(())
+                    }
+
+                    send_batch(
                         &self.request_sender,
                         &self.resource,
                         &self.request_encoder,
@@ -530,53 +578,6 @@ impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
             },
         )
         .await
-    }
-
-    #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events to {uri}", batch_size: batch.total_items(), uri: request_sender.uri())]
-    pub(crate) async fn send_batch(
-        request_sender: &S,
-        resource: &Option<EncodedPayload>,
-        request_encoder: &ClientRequestEncoder<R>,
-        batch: &EncodedScopeItems,
-    ) -> Result<(), BatchError<()>> {
-        let uri = request_sender.uri();
-        let batch_size = batch.total_items();
-
-        match request_sender
-            .send(
-                request_encoder.encode_request(resource.as_ref(), &batch)?,
-                DEFAULT_REQUEST_TIMEOUT,
-            )
-            .await
-        {
-            Ok(res) => {
-                span.complete_with(emit::span::completion::from_fn(|evt| {
-                    emit::debug!(
-                        rt: emit::runtime::internal(),
-                        evt,
-                        "OTLP batch of {batch_size} events to {uri}",
-                        batch_size,
-                    )
-                }));
-
-                res
-            }
-            Err(err) => {
-                span.complete_with(emit::span::completion::from_fn(|evt| {
-                    emit::warn!(
-                        rt: emit::runtime::internal(),
-                        evt,
-                        "OTLP batch of {batch_size} events to {uri} failed: {err}",
-                        batch_size,
-                        err,
-                    )
-                }));
-
-                return Err(BatchError::retry(err, ()));
-            }
-        };
-
-        Ok(())
     }
 }
 

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use emit_batcher::BatchError;
 
-use super::{ClientEventEncoder, OtlpTransport};
+use super::OtlpTransport;
 use crate::data::{EncodedEvent, EncodedScopeItems};
 
 /**
@@ -204,45 +204,31 @@ impl emit_batcher::Channel for Channel {
 }
 
 /**
-Bundles the event encoder, transport, and batcher receiver for a single signal.
+Bundles the transport and batcher receiver for a single signal.
 
-The encoder and transport are shared via [`Arc`] so the batcher callback
-can access them without requiring `Clone` on either. The receiver is
+The transport is shared via [`Arc`] so the batcher callback
+can access it without requiring `Clone`. The receiver is
 consumed by [`SignalWorker::into_receiver`].
 */
-pub(crate) struct SignalWorker<E, R> {
-    inner: Arc<SignalWorkerInner<E, R>>,
+pub(crate) struct SignalWorker<S, E, R> {
+    transport: Arc<OtlpTransport<S, E, R>>,
     receiver: emit_batcher::Receiver<Channel>,
 }
 
-pub(crate) struct SignalWorkerInner<E, R> {
-    pub event_encoder: ClientEventEncoder<E>,
-    pub transport: OtlpTransport<R>,
-}
-
-impl<E, R> SignalWorker<E, R> {
+impl<S, E, R> SignalWorker<S, E, R> {
     pub fn new(
-        event_encoder: ClientEventEncoder<E>,
-        transport: OtlpTransport<R>,
+        transport: OtlpTransport<S, E, R>,
         receiver: emit_batcher::Receiver<Channel>,
     ) -> Self {
         SignalWorker {
-            inner: Arc::new(SignalWorkerInner {
-                event_encoder,
-                transport,
-            }),
+            transport: Arc::new(transport),
             receiver,
         }
     }
 
-    /** Consume the worker, returning the `Arc` inner (for the callback) and the receiver (for the batcher). */
-    pub fn into_receiver(
-        self,
-    ) -> (
-        Arc<SignalWorkerInner<E, R>>,
-        emit_batcher::Receiver<Channel>,
-    ) {
-        (self.inner, self.receiver)
+    /** Consume the worker, returning the `Arc` transport (for the callback) and the receiver (for the batcher). */
+    pub fn into_receiver(self) -> (Arc<OtlpTransport<S, E, R>>, emit_batcher::Receiver<Channel>) {
+        (self.transport, self.receiver)
     }
 }
 

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -1,0 +1,549 @@
+/*!
+Channel infrastructure for the OTLP emitter.
+
+Events are sent from the caller thread through a [`Channel`] to a background
+[`SignalWorker`], which serializes and ships them via HTTP.
+*/
+
+use std::sync::Arc;
+
+use emit_batcher::BatchError;
+
+use super::{ClientEventEncoder, OtlpTransport};
+use crate::data::{EncodedEvent, EncodedScopeItems};
+
+/**
+Execute the batching loop over a channel.
+
+Iterates events from the current cursor position, encodes them via
+`encode_event`, accumulates into size-bounded batches, and ships each
+batch through `send_batch`. On send failure the cursor is reset to the
+start of the failed batch so the caller can retry from that point.
+
+# Arguments
+
+* `channel` — the channel to process (cursor is updated in place)
+* `max_request_size` — maximum bytes per batch before flushing
+* `encode_event` — closure that encodes a raw event; returns `None` to skip
+* `send_batch` — async closure that ships an encoded batch; returns `Err` on failure
+
+# Returns
+
+`Ok(())` when all events (from the cursor onward) are encoded and sent.
+On failure the channel cursor is reset to the start of the failed batch.
+*/
+pub(crate) async fn execute<F, S>(
+    mut channel: Channel,
+    max_request_size: usize,
+    mut encode_event: impl FnMut(&OwnedEvent) -> Option<EncodedEvent>,
+    mut send_batch: F,
+) -> Result<(), BatchError<Channel>>
+where
+    F: FnMut(&EncodedScopeItems) -> S,
+    S: std::future::Future<Output = Result<(), BatchError<()>>>,
+{
+    let mut batch = EncodedScopeItems::new();
+    let mut current_batch_size: usize = 0;
+    // Cursor position of the first event in the current batch.
+    // On send failure we reset to here so the batch is re-sent.
+    let mut batch_start = channel.cursor;
+
+    let mut scope_idx = channel.cursor.scope_index();
+    let mut event_idx = channel.cursor.event_index();
+
+    while scope_idx < channel.scopes.len() {
+        let events = &channel.scopes[scope_idx].1;
+        while event_idx < events.len() {
+            let event = &events[event_idx];
+            event_idx += 1;
+
+            let Some(encoded) = encode_event(event) else {
+                continue;
+            };
+
+            let event_size = encoded.payload.len();
+
+            if current_batch_size > 0 && current_batch_size + event_size > max_request_size {
+                match send_batch(&batch).await {
+                    Ok(()) => {
+                        batch = EncodedScopeItems::new();
+                        current_batch_size = 0;
+                        batch_start = Cursor::at(scope_idx, event_idx);
+                    }
+                    Err(e) => {
+                        channel.cursor = batch_start;
+                        return Err(e.map_retryable(|r| r.map(|_| channel)));
+                    }
+                }
+            }
+
+            // Mark batch start on the first event added
+            if batch.total_items() == 0 {
+                batch_start = Cursor::at(scope_idx, event_idx - 1);
+            }
+
+            batch.push(encoded);
+            current_batch_size += event_size;
+        }
+
+        event_idx = 0;
+        scope_idx += 1;
+    }
+
+    if batch.total_items() > 0 {
+        match send_batch(&batch).await {
+            Ok(()) => {}
+            Err(e) => {
+                channel.cursor = batch_start;
+                return Err(e.map_retryable(|r| r.map(|_| channel)));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/** An owned event ready to be sent through a [`Channel`]. */
+pub(crate) type OwnedEvent = emit::event::Event<'static, emit::props::OwnedProps>;
+
+/**
+Cursor position within a [`Channel`].
+
+Tracks `(scope_index, event_index)` — the next event to process during
+resumable batch sending. On send failure the cursor is reset to the start
+of the failed batch; on success it advances past the sent events.
+*/
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Cursor {
+    scope_index: usize,
+    event_index: usize,
+}
+
+impl Cursor {
+    pub(crate) const fn new() -> Self {
+        Cursor {
+            scope_index: 0,
+            event_index: 0,
+        }
+    }
+
+    pub(crate) const fn at(scope_index: usize, event_index: usize) -> Self {
+        Cursor {
+            scope_index,
+            event_index,
+        }
+    }
+
+    pub(crate) const fn scope_index(&self) -> usize {
+        self.scope_index
+    }
+
+    pub(crate) const fn event_index(&self) -> usize {
+        self.event_index
+    }
+}
+
+/**
+A channel that groups raw events by scope path.
+
+Events pushed into the channel are grouped by their module path so the
+background worker can iterate scope-by-scope during serialization. A
+[`Cursor`] tracks how far the worker has processed for resumable retry.
+*/
+pub(crate) struct Channel {
+    /** Events grouped by scope. A `Vec` so iteration order is deterministic
+    and the worker can index into it for resumable processing on retry. */
+    pub(crate) scopes: Vec<(emit::Path<'static>, Vec<OwnedEvent>)>,
+    pub(crate) total_items: usize,
+    /** Cursor tracking how far the worker has successfully processed this
+    channel. Reset on `clear()` or when a batch is fully sent. */
+    pub(crate) cursor: Cursor,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Channel {
+            scopes: Vec::new(),
+            total_items: 0,
+            cursor: Cursor::new(),
+        }
+    }
+}
+
+/** Item pushed into a [`Channel`] from the caller thread. */
+pub(crate) struct ChannelItem {
+    pub(crate) event: OwnedEvent,
+}
+
+impl emit_batcher::Channel for Channel {
+    type Item = ChannelItem;
+
+    fn new() -> Self {
+        Channel::default()
+    }
+
+    fn push(&mut self, item: Self::Item) {
+        let scope = item.event.mdl().to_owned();
+        if let Some(entry) = self.scopes.iter_mut().find(|(s, _)| *s == scope) {
+            entry.1.push(item.event);
+        } else {
+            self.scopes.push((scope, vec![item.event]));
+        }
+        self.total_items += 1;
+    }
+
+    fn len(&self) -> usize {
+        self.total_items
+    }
+
+    fn clear(&mut self) {
+        self.scopes.clear();
+        self.total_items = 0;
+        self.cursor = Cursor::new();
+    }
+}
+
+/**
+Bundles the event encoder, transport, and batcher receiver for a single signal.
+
+The encoder and transport are shared via [`Arc`] so the batcher callback
+can access them without requiring `Clone` on either. The receiver is
+consumed by [`SignalWorker::into_receiver`].
+*/
+pub(crate) struct SignalWorker<E, R> {
+    inner: Arc<SignalWorkerInner<E, R>>,
+    receiver: emit_batcher::Receiver<Channel>,
+}
+
+pub(crate) struct SignalWorkerInner<E, R> {
+    pub event_encoder: ClientEventEncoder<E>,
+    pub transport: OtlpTransport<R>,
+}
+
+impl<E, R> SignalWorker<E, R> {
+    pub fn new(
+        event_encoder: ClientEventEncoder<E>,
+        transport: OtlpTransport<R>,
+        receiver: emit_batcher::Receiver<Channel>,
+    ) -> Self {
+        SignalWorker {
+            inner: Arc::new(SignalWorkerInner {
+                event_encoder,
+                transport,
+            }),
+            receiver,
+        }
+    }
+
+    /** Consume the worker, returning the `Arc` inner (for the callback) and the receiver (for the batcher). */
+    pub fn into_receiver(
+        self,
+    ) -> (
+        Arc<SignalWorkerInner<E, R>>,
+        emit_batcher::Receiver<Channel>,
+    ) {
+        (self.inner, self.receiver)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use emit_batcher::Channel as _;
+
+    use super::*;
+
+    #[test]
+    fn channel_groups_by_scope() {
+        let mut channel = Channel::new();
+
+        channel.push(ChannelItem {
+            event: emit::event::Event::new(
+                emit::path!("app::module_a"),
+                emit::template::Template::literal("event 1"),
+                emit::empty::Empty,
+                emit::empty::Empty,
+            )
+            .to_owned(),
+        });
+
+        channel.push(ChannelItem {
+            event: emit::event::Event::new(
+                emit::path!("app::module_b"),
+                emit::template::Template::literal("event 2"),
+                emit::empty::Empty,
+                emit::empty::Empty,
+            )
+            .to_owned(),
+        });
+
+        channel.push(ChannelItem {
+            event: emit::event::Event::new(
+                emit::path!("app::module_a"),
+                emit::template::Template::literal("event 3"),
+                emit::empty::Empty,
+                emit::empty::Empty,
+            )
+            .to_owned(),
+        });
+
+        assert_eq!(3, channel.len());
+        assert_eq!(2, channel.scopes.len());
+        assert_eq!(2, channel.scopes[0].1.len()); // module_a: 2 events
+        assert_eq!(1, channel.scopes[1].1.len()); // module_b: 1 event
+        assert_eq!(Cursor::new(), channel.cursor);
+    }
+
+    #[test]
+    fn channel_clear_resets_cursor() {
+        let mut channel = Channel::new();
+
+        channel.push(ChannelItem {
+            event: emit::event::Event::new(
+                emit::path!("app::module_a"),
+                emit::template::Template::literal("event 1"),
+                emit::empty::Empty,
+                emit::empty::Empty,
+            )
+            .to_owned(),
+        });
+
+        channel.clear();
+
+        assert_eq!(0, channel.len());
+        assert_eq!(0, channel.scopes.len());
+        assert_eq!(Cursor::new(), channel.cursor);
+    }
+
+    #[test]
+    fn cursor_construction() {
+        let c = Cursor::new();
+        assert_eq!(0, c.scope_index());
+        assert_eq!(0, c.event_index());
+
+        let c = Cursor::at(3, 7);
+        assert_eq!(3, c.scope_index());
+        assert_eq!(7, c.event_index());
+    }
+
+    // ---- execute tests ----
+
+    use crate::data::EncodedPayload;
+
+    fn make_event(path: emit::Path<'static>) -> OwnedEvent {
+        emit::event::Event::new(
+            path,
+            emit::template::Template::literal("event"),
+            emit::empty::Empty,
+            emit::empty::Empty,
+        )
+        .to_owned()
+    }
+
+    /** Build a mock encoded event with a payload of the given byte length. */
+    fn mock_encoded(scope: emit::Path<'static>, payload_size: usize) -> EncodedEvent {
+        EncodedEvent {
+            scope,
+            payload: EncodedPayload::Json(sval_json::JsonStr::boxed("x".repeat(payload_size))),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_sends_all_events_in_single_batch() {
+        let mut channel = Channel::new();
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::a")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::b")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::c")),
+        });
+
+        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
+
+        let result = execute(
+            channel,
+            usize::MAX,
+            |evt| Some(mock_encoded(evt.mdl().to_owned(), 10)),
+            |batch| {
+                let items = batch.total_items();
+                let sent = sent_batches.clone();
+                async move {
+                    sent.lock().unwrap().push(items);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(vec![3], *sent_batches.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn execute_chunks_by_size() {
+        let mut channel = Channel::new();
+        for _ in 0..5 {
+            channel.push(ChannelItem {
+                event: make_event(emit::path!("mod::e")),
+            });
+        }
+
+        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
+        // Each payload is 20 bytes; limit of 45 forces splits: 2+2+1
+        let result = execute(
+            channel,
+            45,
+            |evt| Some(mock_encoded(evt.mdl().to_owned(), 20)),
+            |batch| {
+                let items = batch.total_items();
+                let sent = sent_batches.clone();
+                async move {
+                    sent.lock().unwrap().push(items);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(vec![2, 2, 1], *sent_batches.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn execute_resets_cursor_on_failure() {
+        let mut channel = Channel::new();
+        for _ in 0..4 {
+            channel.push(ChannelItem {
+                event: make_event(emit::path!("mod::e")),
+            });
+        }
+
+        let send_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let result = execute(
+            channel,
+            45,
+            |evt| Some(mock_encoded(evt.mdl().to_owned(), 20)),
+            |_batch| {
+                let count = send_count.clone();
+                async move {
+                    let n = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                    if n == 1 {
+                        Ok(())
+                    } else {
+                        Err(BatchError::retry(crate::Error::msg("fail"), ()))
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(2, send_count.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn execute_skips_encoding_failures() {
+        let mut channel = Channel::new();
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::a")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::b")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::c")),
+        });
+
+        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
+        let encode_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let result = execute(
+            channel,
+            usize::MAX,
+            |evt| {
+                let count = encode_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                if count == 2 {
+                    None // skip the second event
+                } else {
+                    Some(mock_encoded(evt.mdl().to_owned(), 10))
+                }
+            },
+            |batch| {
+                let items = batch.total_items();
+                let sent = sent_batches.clone();
+                async move {
+                    sent.lock().unwrap().push(items);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(3, encode_count.load(std::sync::atomic::Ordering::SeqCst));
+        assert_eq!(vec![2], *sent_batches.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn execute_resumes_from_cursor() {
+        let mut channel = Channel::new();
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::a")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::b")),
+        });
+        channel.push(ChannelItem {
+            event: make_event(emit::path!("mod::c")),
+        });
+
+        // Advance cursor to skip first event
+        channel.cursor = Cursor::at(0, 1);
+
+        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
+
+        let result = execute(
+            channel,
+            usize::MAX,
+            |evt| Some(mock_encoded(evt.mdl().to_owned(), 10)),
+            |batch| {
+                let items = batch.total_items();
+                let sent = sent_batches.clone();
+                async move {
+                    sent.lock().unwrap().push(items);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(vec![2], *sent_batches.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn execute_empty_channel() {
+        let channel = Channel::new();
+        let sent = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let result = execute(
+            channel,
+            usize::MAX,
+            |_| Some(mock_encoded(emit::path!("mod"), 10)),
+            |_batch| {
+                let s = sent.clone();
+                async move {
+                    s.store(true, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(!sent.load(std::sync::atomic::Ordering::SeqCst));
+    }
+}

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -5,175 +5,92 @@ Events are sent from the caller thread through a [`Channel`] to a background
 [`SignalWorker`], which serializes and ships them via HTTP.
 */
 
-use std::sync::Arc;
+use std::future::Future;
 
 use emit_batcher::BatchError;
 
-use super::OtlpTransport;
 use crate::data::{EncodedEvent, EncodedScopeItems};
 
-/**
-Execute the batching loop over a channel.
-
-Iterates events from the current cursor position, encodes them via
-`encode_event`, accumulates into size-bounded batches, and ships each
-batch through `send_batch`. On send failure the cursor is reset to the
-start of the failed batch so the caller can retry from that point.
-
-# Arguments
-
-* `channel` — the channel to process (cursor is updated in place)
-* `max_request_size` — maximum bytes per batch before flushing
-* `encode_event` — closure that encodes a raw event; returns `None` to skip
-* `send_batch` — async closure that ships an encoded batch; returns `Err` on failure
-
-# Returns
-
-`Ok(())` when all events (from the cursor onward) are encoded and sent.
-On failure the channel cursor is reset to the start of the failed batch.
-*/
-pub(crate) async fn execute<F, S>(
+pub(crate) async fn execute<F>(
     mut channel: Channel,
     max_request_size: usize,
-    mut encode_event: impl FnMut(&OwnedEvent) -> Option<EncodedEvent>,
-    mut send_batch: F,
+    mut encode_event: impl FnMut(&ChannelEvent) -> Option<EncodedEvent>,
+    mut send_batch: impl FnMut(&EncodedScopeItems) -> F,
 ) -> Result<(), BatchError<Channel>>
 where
-    F: FnMut(&EncodedScopeItems) -> S,
-    S: std::future::Future<Output = Result<(), BatchError<()>>>,
+    F: Future<Output = Result<(), BatchError<()>>>,
 {
+    // TODO: Clear out events as they're processed
+    // TODO: Review this more thoroughly
     let mut batch = EncodedScopeItems::new();
-    let mut current_batch_size: usize = 0;
-    // Cursor position of the first event in the current batch.
-    // On send failure we reset to here so the batch is re-sent.
-    let mut batch_start = channel.cursor;
 
-    let mut scope_idx = channel.cursor.scope_index();
-    let mut event_idx = channel.cursor.event_index();
+    let mut scope_index = channel.cursor.scope_index;
+    let mut event_index = channel.cursor.event_index;
 
-    while scope_idx < channel.scopes.len() {
-        let events = &channel.scopes[scope_idx].1;
-        while event_idx < events.len() {
-            let event = &events[event_idx];
-            event_idx += 1;
+    while scope_index < channel.scopes.len() {
+        let events = &channel.scopes[scope_index].1;
+
+        while event_index < events.len() {
+            let event = &events[event_index];
+            event_index += 1;
 
             let Some(encoded) = encode_event(event) else {
+                // TODO: metric
                 continue;
             };
 
-            let event_size = encoded.payload.len();
-
-            if current_batch_size > 0 && current_batch_size + event_size > max_request_size {
+            if batch.total_items() > 0
+                && batch.total_size_bytes() + encoded.size_bytes() > max_request_size
+            {
+                // We've reached the maximum size of a single batcg; send it then start a new one
                 match send_batch(&batch).await {
                     Ok(()) => {
                         batch = EncodedScopeItems::new();
-                        current_batch_size = 0;
-                        batch_start = Cursor::at(scope_idx, event_idx);
+                        channel.cursor = ChannelCursor {
+                            scope_index,
+                            event_index,
+                        };
                     }
-                    Err(e) => {
-                        channel.cursor = batch_start;
-                        return Err(e.map_retryable(|r| r.map(|_| channel)));
-                    }
+                    Err(e) => return Err(e.map_retryable(|r| r.map(|_| channel))),
                 }
             }
 
-            // Mark batch start on the first event added
-            if batch.total_items() == 0 {
-                batch_start = Cursor::at(scope_idx, event_idx - 1);
-            }
-
             batch.push(encoded);
-            current_batch_size += event_size;
         }
 
-        event_idx = 0;
-        scope_idx += 1;
+        event_index = 0;
+        scope_index += 1;
     }
 
+    // Send the final batch
     if batch.total_items() > 0 {
         match send_batch(&batch).await {
-            Ok(()) => {}
-            Err(e) => {
-                channel.cursor = batch_start;
-                return Err(e.map_retryable(|r| r.map(|_| channel)));
-            }
+            Ok(()) => Ok(()),
+            Err(e) => Err(e.map_retryable(|r| r.map(|_| channel))),
         }
+    } else {
+        Ok(())
     }
-
-    Ok(())
 }
 
-/** An owned event ready to be sent through a [`Channel`]. */
-pub(crate) type OwnedEvent = emit::event::Event<'static, emit::props::OwnedProps>;
-
-/**
-Cursor position within a [`Channel`].
-
-Tracks `(scope_index, event_index)` — the next event to process during
-resumable batch sending. On send failure the cursor is reset to the start
-of the failed batch; on success it advances past the sent events.
-*/
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Cursor {
+pub(crate) struct ChannelCursor {
     scope_index: usize,
     event_index: usize,
 }
 
-impl Cursor {
-    pub(crate) const fn new() -> Self {
-        Cursor {
-            scope_index: 0,
-            event_index: 0,
-        }
-    }
-
-    pub(crate) const fn at(scope_index: usize, event_index: usize) -> Self {
-        Cursor {
-            scope_index,
-            event_index,
-        }
-    }
-
-    pub(crate) const fn scope_index(&self) -> usize {
-        self.scope_index
-    }
-
-    pub(crate) const fn event_index(&self) -> usize {
-        self.event_index
-    }
-}
-
-/**
-A channel that groups raw events by scope path.
-
-Events pushed into the channel are grouped by their module path so the
-background worker can iterate scope-by-scope during serialization. A
-[`Cursor`] tracks how far the worker has processed for resumable retry.
-*/
+#[derive(Default)]
 pub(crate) struct Channel {
-    /** Events grouped by scope. A `Vec` so iteration order is deterministic
-    and the worker can index into it for resumable processing on retry. */
-    pub(crate) scopes: Vec<(emit::Path<'static>, Vec<OwnedEvent>)>,
+    pub(crate) scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
     pub(crate) total_items: usize,
-    /** Cursor tracking how far the worker has successfully processed this
-    channel. Reset on `clear()` or when a batch is fully sent. */
-    pub(crate) cursor: Cursor,
+    pub(crate) cursor: ChannelCursor,
 }
 
-impl Default for Channel {
-    fn default() -> Self {
-        Channel {
-            scopes: Vec::new(),
-            total_items: 0,
-            cursor: Cursor::new(),
-        }
-    }
-}
-
-/** Item pushed into a [`Channel`] from the caller thread. */
 pub(crate) struct ChannelItem {
-    pub(crate) event: OwnedEvent,
+    pub(crate) event: ChannelEvent,
 }
+
+pub(crate) type ChannelEvent = emit::Event<'static, emit::props::OwnedProps>;
 
 impl emit_batcher::Channel for Channel {
     type Item = ChannelItem;
@@ -183,12 +100,15 @@ impl emit_batcher::Channel for Channel {
     }
 
     fn push(&mut self, item: Self::Item) {
-        let scope = item.event.mdl().to_owned();
+        let scope = item.event.mdl();
+
+        // TODO: Binary search or secondary hashmap
         if let Some(entry) = self.scopes.iter_mut().find(|(s, _)| *s == scope) {
             entry.1.push(item.event);
         } else {
-            self.scopes.push((scope, vec![item.event]));
+            self.scopes.push((scope.to_owned(), vec![item.event]));
         }
+
         self.total_items += 1;
     }
 
@@ -197,38 +117,15 @@ impl emit_batcher::Channel for Channel {
     }
 
     fn clear(&mut self) {
-        self.scopes.clear();
-        self.total_items = 0;
-        self.cursor = Cursor::new();
-    }
-}
+        let Channel {
+            scopes,
+            total_items,
+            cursor,
+        } = self;
 
-/**
-Bundles the transport and batcher receiver for a single signal.
-
-The transport is shared via [`Arc`] so the batcher callback
-can access it without requiring `Clone`. The receiver is
-consumed by [`SignalWorker::into_receiver`].
-*/
-pub(crate) struct SignalWorker<S, E, R> {
-    transport: Arc<OtlpTransport<S, E, R>>,
-    receiver: emit_batcher::Receiver<Channel>,
-}
-
-impl<S, E, R> SignalWorker<S, E, R> {
-    pub fn new(
-        transport: OtlpTransport<S, E, R>,
-        receiver: emit_batcher::Receiver<Channel>,
-    ) -> Self {
-        SignalWorker {
-            transport: Arc::new(transport),
-            receiver,
-        }
-    }
-
-    /** Consume the worker, returning the `Arc` transport (for the callback) and the receiver (for the batcher). */
-    pub fn into_receiver(self) -> (Arc<OtlpTransport<S, E, R>>, emit_batcher::Receiver<Channel>) {
-        (self.transport, self.receiver)
+        scopes.clear();
+        *total_items = 0;
+        *cursor = ChannelCursor::default();
     }
 }
 
@@ -239,297 +136,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn channel_groups_by_scope() {
-        let mut channel = Channel::new();
-
-        channel.push(ChannelItem {
-            event: emit::event::Event::new(
-                emit::path!("app::module_a"),
-                emit::template::Template::literal("event 1"),
-                emit::empty::Empty,
-                emit::empty::Empty,
-            )
-            .to_owned(),
-        });
-
-        channel.push(ChannelItem {
-            event: emit::event::Event::new(
-                emit::path!("app::module_b"),
-                emit::template::Template::literal("event 2"),
-                emit::empty::Empty,
-                emit::empty::Empty,
-            )
-            .to_owned(),
-        });
-
-        channel.push(ChannelItem {
-            event: emit::event::Event::new(
-                emit::path!("app::module_a"),
-                emit::template::Template::literal("event 3"),
-                emit::empty::Empty,
-                emit::empty::Empty,
-            )
-            .to_owned(),
-        });
-
-        assert_eq!(3, channel.len());
-        assert_eq!(2, channel.scopes.len());
-        assert_eq!(2, channel.scopes[0].1.len()); // module_a: 2 events
-        assert_eq!(1, channel.scopes[1].1.len()); // module_b: 1 event
-        assert_eq!(Cursor::new(), channel.cursor);
-    }
-
-    #[test]
-    fn channel_clear_resets_cursor() {
-        let mut channel = Channel::new();
-
-        channel.push(ChannelItem {
-            event: emit::event::Event::new(
-                emit::path!("app::module_a"),
-                emit::template::Template::literal("event 1"),
-                emit::empty::Empty,
-                emit::empty::Empty,
-            )
-            .to_owned(),
-        });
-
-        channel.clear();
-
-        assert_eq!(0, channel.len());
-        assert_eq!(0, channel.scopes.len());
-        assert_eq!(Cursor::new(), channel.cursor);
-    }
-
-    #[test]
-    fn cursor_construction() {
-        let c = Cursor::new();
-        assert_eq!(0, c.scope_index());
-        assert_eq!(0, c.event_index());
-
-        let c = Cursor::at(3, 7);
-        assert_eq!(3, c.scope_index());
-        assert_eq!(7, c.event_index());
-    }
-
-    // ---- execute tests ----
-
-    use crate::data::EncodedPayload;
-
-    fn make_event(path: emit::Path<'static>) -> OwnedEvent {
-        emit::event::Event::new(
-            path,
-            emit::template::Template::literal("event"),
-            emit::empty::Empty,
-            emit::empty::Empty,
-        )
-        .to_owned()
-    }
-
-    /** Build a mock encoded event with a payload of the given byte length. */
-    fn mock_encoded(scope: emit::Path<'static>, payload_size: usize) -> EncodedEvent {
-        EncodedEvent {
-            scope,
-            payload: EncodedPayload::Json(sval_json::JsonStr::boxed("x".repeat(payload_size))),
-        }
-    }
-
-    #[tokio::test]
-    async fn execute_sends_all_events_in_single_batch() {
-        let mut channel = Channel::new();
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::a")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::b")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::c")),
-        });
-
-        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-
-        let result = execute(
-            channel,
-            usize::MAX,
-            |evt| Some(mock_encoded(evt.mdl().to_owned(), 10)),
-            |batch| {
-                let items = batch.total_items();
-                let sent = sent_batches.clone();
-                async move {
-                    sent.lock().unwrap().push(items);
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_ok());
-        assert_eq!(vec![3], *sent_batches.lock().unwrap());
-    }
-
-    #[tokio::test]
-    async fn execute_chunks_by_size() {
-        let mut channel = Channel::new();
-        for _ in 0..5 {
-            channel.push(ChannelItem {
-                event: make_event(emit::path!("mod::e")),
-            });
-        }
-
-        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-        // Each payload is 20 bytes; limit of 45 forces splits: 2+2+1
-        let result = execute(
-            channel,
-            45,
-            |evt| Some(mock_encoded(evt.mdl().to_owned(), 20)),
-            |batch| {
-                let items = batch.total_items();
-                let sent = sent_batches.clone();
-                async move {
-                    sent.lock().unwrap().push(items);
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_ok());
-        assert_eq!(vec![2, 2, 1], *sent_batches.lock().unwrap());
-    }
-
-    #[tokio::test]
-    async fn execute_resets_cursor_on_failure() {
-        let mut channel = Channel::new();
-        for _ in 0..4 {
-            channel.push(ChannelItem {
-                event: make_event(emit::path!("mod::e")),
-            });
-        }
-
-        let send_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-        let result = execute(
-            channel,
-            45,
-            |evt| Some(mock_encoded(evt.mdl().to_owned(), 20)),
-            |_batch| {
-                let count = send_count.clone();
-                async move {
-                    let n = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
-                    if n == 1 {
-                        Ok(())
-                    } else {
-                        Err(BatchError::retry(crate::Error::msg("fail"), ()))
-                    }
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_err());
-        assert_eq!(2, send_count.load(std::sync::atomic::Ordering::SeqCst));
-    }
-
-    #[tokio::test]
-    async fn execute_skips_encoding_failures() {
-        let mut channel = Channel::new();
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::a")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::b")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::c")),
-        });
-
-        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-        let encode_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-        let result = execute(
-            channel,
-            usize::MAX,
-            |evt| {
-                let count = encode_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
-                if count == 2 {
-                    None // skip the second event
-                } else {
-                    Some(mock_encoded(evt.mdl().to_owned(), 10))
-                }
-            },
-            |batch| {
-                let items = batch.total_items();
-                let sent = sent_batches.clone();
-                async move {
-                    sent.lock().unwrap().push(items);
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_ok());
-        assert_eq!(3, encode_count.load(std::sync::atomic::Ordering::SeqCst));
-        assert_eq!(vec![2], *sent_batches.lock().unwrap());
-    }
-
-    #[tokio::test]
-    async fn execute_resumes_from_cursor() {
-        let mut channel = Channel::new();
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::a")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::b")),
-        });
-        channel.push(ChannelItem {
-            event: make_event(emit::path!("mod::c")),
-        });
-
-        // Advance cursor to skip first event
-        channel.cursor = Cursor::at(0, 1);
-
-        let sent_batches = std::sync::Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-
-        let result = execute(
-            channel,
-            usize::MAX,
-            |evt| Some(mock_encoded(evt.mdl().to_owned(), 10)),
-            |batch| {
-                let items = batch.total_items();
-                let sent = sent_batches.clone();
-                async move {
-                    sent.lock().unwrap().push(items);
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_ok());
-        assert_eq!(vec![2], *sent_batches.lock().unwrap());
-    }
-
-    #[tokio::test]
-    async fn execute_empty_channel() {
-        let channel = Channel::new();
-        let sent = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-        let result = execute(
-            channel,
-            usize::MAX,
-            |_| Some(mock_encoded(emit::path!("mod"), 10)),
-            |_batch| {
-                let s = sent.clone();
-                async move {
-                    s.store(true, std::sync::atomic::Ordering::SeqCst);
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(result.is_ok());
-        assert!(!sent.load(std::sync::atomic::Ordering::SeqCst));
+    fn it_works() {
+        todo!()
     }
 }

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -132,6 +132,7 @@ pub(crate) struct ChannelEvent(emit::Event<'static, ChannelProps>);
 
 #[derive(Clone, Default)]
 pub(crate) struct ChannelProps {
+    evt_kind: Option<emit::Kind>,
     lvl: Option<emit::Level>,
     trace_id: Option<emit::TraceId>,
     span_parent: Option<emit::SpanId>,
@@ -197,8 +198,13 @@ impl<'kv> emit::props::FromProps<'kv> for ChannelProps {
                         return ControlFlow::Continue(());
                     }
                 }
-                // Ignored
-                emit::well_known::KEY_EVT_KIND => return ControlFlow::Continue(()),
+                emit::well_known::KEY_EVT_KIND => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.evt_kind = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
                 _ => (),
             }
 
@@ -220,6 +226,7 @@ impl emit::Props for ChannelProps {
         use emit::{str::ToStr as _, value::ToValue as _};
 
         let ChannelProps {
+            evt_kind,
             lvl,
             trace_id,
             span_parent,
@@ -228,6 +235,9 @@ impl emit::Props for ChannelProps {
             rest,
         } = self;
 
+        if let Some(evt_kind) = evt_kind {
+            for_each(emit::well_known::KEY_EVT_KIND.to_str(), evt_kind.to_value())?;
+        }
         if let Some(lvl) = lvl {
             for_each(emit::well_known::KEY_LVL.to_str(), lvl.to_value())?;
         }
@@ -257,6 +267,7 @@ impl emit::Props for ChannelProps {
         use emit::value::ToValue as _;
 
         let ChannelProps {
+            evt_kind,
             lvl,
             trace_id,
             span_parent,
@@ -266,6 +277,7 @@ impl emit::Props for ChannelProps {
         } = self;
 
         match key.to_str().get() {
+            emit::well_known::KEY_EVT_KIND => evt_kind.as_ref().map(|v| v.to_value()),
             emit::well_known::KEY_LVL => lvl.as_ref().map(|v| v.to_value()),
             emit::well_known::KEY_TRACE_ID => trace_id.as_ref().map(|v| v.to_value()),
             emit::well_known::KEY_SPAN_ID => span_id.as_ref().map(|v| v.to_value()),

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -5,33 +5,39 @@ Events are sent from the caller thread through a [`Channel`] to a background
 [`SignalWorker`], which serializes and ships them via HTTP.
 */
 
-use std::{collections::HashMap, future::Future, mem};
+use std::{
+    future::Future,
+    hash::{BuildHasher, Hash},
+};
+
+use fnv::FnvBuildHasher;
+use hashbrown::{HashTable, hash_table};
 
 use emit_batcher::BatchError;
 
-use crate::data::{EncodedEvent, EncodedScopeItems};
+use crate::{
+    InternalMetrics,
+    data::{EncodedEvent, EncodedScopeItems},
+};
 
 pub(crate) async fn batch<F>(
     mut channel: Channel,
     max_request_size: usize,
+    metrics: &InternalMetrics,
     mut encode_event: impl FnMut(&ChannelEvent) -> Option<EncodedEvent>,
     mut send_batch: impl FnMut(&EncodedScopeItems) -> F,
 ) -> Result<(), BatchError<Channel>>
 where
     F: Future<Output = Result<(), BatchError<()>>>,
 {
-    let state = channel.state.draining_mut();
-
-    emit::debug!("processing channel: {#[emit::as_debug] state}");
-
     let mut batch = EncodedScopeItems::new();
 
-    let mut scope_index = state.cursor.scope_index;
-    let mut event_index = state.cursor.event_index;
-    let mut remaining_items = state.cursor.remaining_items;
+    let mut scope_index = channel.cursor.scope_index;
+    let mut event_index = channel.cursor.event_index;
+    let mut remaining_items = channel.cursor.remaining_items;
 
-    while scope_index < state.scopes.len() {
-        let events = &state.scopes[scope_index].1;
+    while scope_index < channel.scopes.len() {
+        let events = &channel.scopes[scope_index].1;
 
         while event_index < events.len() {
             let event = &events[event_index];
@@ -39,7 +45,7 @@ where
             remaining_items -= 1;
 
             let Some(encoded) = encode_event(event) else {
-                // TODO: metric
+                metrics.event_encoding_failed.increment();
                 continue;
             };
 
@@ -50,7 +56,7 @@ where
                 match send_batch(&batch).await {
                     Ok(()) => {
                         batch.clear();
-                        state.cursor = ChannelCursor {
+                        channel.cursor = ChannelCursor {
                             scope_index,
                             event_index,
                             remaining_items,
@@ -86,87 +92,21 @@ pub(crate) struct ChannelCursor {
 }
 
 pub(crate) struct Channel {
-    state: ChannelState,
+    scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
+    scopes_by_key: HashTable<usize>,
+    cursor: ChannelCursor,
 }
 
 impl Default for Channel {
     fn default() -> Self {
         Channel {
-            state: ChannelState::Filling(ChannelStateFilling {
-                scopes: HashMap::new(),
-                total_items: 0,
-            }),
-        }
-    }
-}
-
-#[derive(Debug)]
-enum ChannelState {
-    Filling(ChannelStateFilling),
-    Draining(ChannelStateDraining),
-    Poisoned,
-}
-
-#[derive(Debug)]
-struct ChannelStateFilling {
-    scopes: HashMap<emit::Path<'static>, Vec<ChannelEvent>>,
-    total_items: usize,
-}
-
-#[derive(Debug)]
-struct ChannelStateDraining {
-    scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
-    cursor: ChannelCursor,
-}
-
-impl ChannelState {
-    fn variant(&self) -> &'static str {
-        match self {
-            ChannelState::Filling(_) => "filling",
-            ChannelState::Draining(_) => "draining",
-            ChannelState::Poisoned => "poisoned",
-        }
-    }
-
-    fn filling_mut(&mut self) -> &mut ChannelStateFilling {
-        let ChannelState::Filling(state) = self else {
-            panic!("invalid channel state: {:?}", self.variant());
-        };
-
-        state
-    }
-
-    fn draining_mut(&mut self) -> &mut ChannelStateDraining {
-        match mem::replace(self, ChannelState::Poisoned) {
-            ChannelState::Filling(state) => {
-                // Convert a filling channel into a draining one
-                *self = ChannelState::Draining(ChannelStateDraining {
-                    scopes: state.scopes.into_iter().collect(),
-                    cursor: ChannelCursor {
-                        scope_index: 0,
-                        event_index: 0,
-                        remaining_items: state.total_items,
-                    },
-                });
-            }
-            ChannelState::Draining(state) => {
-                *self = ChannelState::Draining(state);
-            }
-            ChannelState::Poisoned => panic!("invalid channel state: {:?}", self.variant()),
-        }
-
-        let ChannelState::Draining(state) = self else {
-            unreachable!()
-        };
-
-        state
-    }
-
-    fn remaining(&self) -> usize {
-        match self {
-            ChannelState::Filling(state) => state.total_items,
-            ChannelState::Draining(state) => state.cursor.remaining_items,
-            ChannelState::Poisoned => panic!("invalid channel state: {:?}", self.variant()),
+            scopes: Default::default(),
+            scopes_by_key: Default::default(),
+            cursor: ChannelCursor {
+                scope_index: 0,
+                event_index: 0,
+                remaining_items: 0,
+            },
         }
     }
 }
@@ -184,24 +124,55 @@ impl emit_batcher::Channel for Channel {
         Default::default()
     }
 
+    fn with_capacity(capacity_hint: usize) -> Self {
+        let mut channel = Self::new();
+
+        channel.scopes = Vec::with_capacity(capacity_hint);
+
+        channel
+    }
+
     fn push(&mut self, item: Self::Item) {
-        let state = self.state.filling_mut();
+        assert_eq!(
+            0, self.cursor.scope_index,
+            "attempt to push to a channel that's already being drained"
+        );
+        assert_eq!(
+            0, self.cursor.event_index,
+            "attempt to push to a channel that's already being drained"
+        );
 
         let scope = item.event.mdl();
 
-        state
-            .scopes
-            .entry(scope.to_owned())
-            .or_insert_with(|| Vec::new())
-            .push(item.event);
-        state.total_items += 1;
+        match self.scopes_by_key.entry(
+            hash(&scope),
+            |idx| self.scopes[*idx].0 == scope,
+            |idx| hash(&self.scopes[*idx].0),
+        ) {
+            hash_table::Entry::Occupied(entry) => {
+                self.scopes[*entry.get()].1.push(item.event);
+            }
+            hash_table::Entry::Vacant(entry) => {
+                let idx = self.scopes.len();
+
+                self.scopes.push((scope.to_owned(), vec![item.event]));
+                entry.insert(idx);
+            }
+        }
+
+        self.cursor.remaining_items += 1;
     }
 
     fn len(&self) -> usize {
-        self.state.remaining()
+        self.cursor.remaining_items
     }
 
     fn clear(&mut self) {
         *self = Default::default();
     }
+}
+
+#[inline]
+fn hash(v: &(impl Hash + ?Sized)) -> u64 {
+    FnvBuildHasher::default().hash_one(v)
 }

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -6,9 +6,11 @@ Events are sent from the caller thread through a [`Channel`] to a background
 */
 
 use std::{
+    collections::HashMap,
     fmt,
     future::Future,
     hash::{BuildHasher, Hash},
+    ops::ControlFlow,
 };
 
 use fnv::FnvBuildHasher;
@@ -127,7 +129,95 @@ pub(crate) struct ChannelItem {
     pub(crate) event: ChannelEvent,
 }
 
-pub(crate) type ChannelEvent = emit::Event<'static, emit::props::OwnedProps>;
+#[derive(Clone)]
+pub(crate) struct ChannelEvent(emit::Event<'static, ChannelProps>);
+
+#[derive(Clone)]
+pub(crate) struct ChannelProps(HashMap<emit::Str<'static>, ChannelValue>);
+
+#[derive(Clone)]
+enum ChannelValue {
+    SpanId(emit::SpanId),
+    TraceId(emit::TraceId),
+    Any(emit::value::OwnedValue),
+}
+
+impl ChannelEvent {
+    pub(crate) fn from_evt(evt: emit::Event<impl emit::Props>) -> Self {
+        ChannelEvent(emit::Event::new(
+            evt.mdl().to_owned(),
+            evt.tpl().to_owned(),
+            evt.extent().cloned(),
+            evt.props().collect(),
+        ))
+    }
+
+    pub(crate) fn get<'a>(&'a self) -> &'a emit::Event<'a, impl emit::Props> {
+        &self.0
+    }
+}
+
+impl ChannelValue {
+    fn from_value(value: emit::Value) -> Self {
+        // Specialize a few common value types
+
+        if let Some(trace_id) = value.downcast_ref() {
+            return ChannelValue::TraceId(*trace_id);
+        }
+
+        if let Some(span_id) = value.downcast_ref() {
+            return ChannelValue::SpanId(*span_id);
+        }
+
+        // Fall back to buffering
+        ChannelValue::Any(value.to_shared())
+    }
+}
+
+impl emit::value::ToValue for ChannelValue {
+    fn to_value(&self) -> emit::Value<'_> {
+        match self {
+            ChannelValue::TraceId(value) => value.to_value(),
+            ChannelValue::SpanId(value) => value.to_value(),
+            ChannelValue::Any(value) => value.to_value(),
+        }
+    }
+}
+
+impl<'kv> emit::props::FromProps<'kv> for ChannelProps {
+    fn from_props<P: emit::Props + ?Sized>(props: &'kv P) -> Self {
+        let mut owned = HashMap::new();
+
+        let _ = props.for_each(|k, v| {
+            owned.insert(k.to_owned(), ChannelValue::from_value(v));
+
+            ControlFlow::Continue(())
+        });
+
+        ChannelProps(owned)
+    }
+}
+
+impl emit::Props for ChannelProps {
+    fn for_each<'a, F: FnMut(emit::Str<'a>, emit::Value<'a>) -> ControlFlow<()>>(
+        &'a self,
+        for_each: F,
+    ) -> ControlFlow<()> {
+        emit::Props::for_each(&self.0, for_each)
+    }
+
+    fn get<'v, K: emit::str::ToStr>(&'v self, key: K) -> Option<emit::Value<'v>> {
+        emit::Props::get(&self.0, key)
+    }
+
+    fn is_unique(&self) -> bool {
+        true
+    }
+
+    fn size(&self) -> Option<usize> {
+        Some(self.0.len())
+    }
+}
 
 impl emit_batcher::Channel for Channel {
     type Item = ChannelItem;
@@ -154,7 +244,7 @@ impl emit_batcher::Channel for Channel {
             "attempt to push to a channel that's already being drained"
         );
 
-        let scope = item.event.mdl();
+        let scope = item.event.get().mdl();
 
         match self.scopes_by_key.entry(
             hash(&scope),
@@ -207,16 +297,16 @@ mod tests {
         let mut channel = Channel::default();
 
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("a"), "Event 1").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 1")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("a"), "Event 2").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 2")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("b"), "Event 3").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("b"), "Event 3")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("c"), "Event 4").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("c"), "Event 4")),
         });
 
         assert_eq!(4, channel.len());
@@ -243,7 +333,7 @@ mod tests {
                 channel,
                 case,
                 &Default::default(),
-                |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+                |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
                 |_| async {
                     *calls.lock().unwrap() += 1;
 
@@ -262,16 +352,16 @@ mod tests {
         let mut channel = Channel::default();
 
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("a"), "Event 1").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 1")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("a"), "Event 2").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 2")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("b"), "Event 3").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("b"), "Event 3")),
         });
         channel.push(ChannelItem {
-            event: emit::evt!(mdl: emit::path!("c"), "Event 4").to_owned(),
+            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("c"), "Event 4")),
         });
 
         assert_eq!(4, channel.len());
@@ -283,7 +373,7 @@ mod tests {
             channel,
             0,
             &Default::default(),
-            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
             |_| async {
                 let mut calls = calls.lock().unwrap();
 
@@ -314,7 +404,7 @@ mod tests {
             channel,
             0,
             &Default::default(),
-            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
             |_| async { Ok(()) },
         )
         .await

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -130,14 +130,14 @@ impl Default for Channel {
 #[derive(Clone)]
 pub(crate) struct ChannelEvent(emit::Event<'static, ChannelProps>);
 
-#[derive(Clone)]
-pub(crate) struct ChannelProps(HashMap<emit::Str<'static>, ChannelValue>);
-
-#[derive(Clone)]
-enum ChannelValue {
-    SpanId(emit::SpanId),
-    TraceId(emit::TraceId),
-    Any(emit::value::OwnedValue),
+#[derive(Clone, Default)]
+pub(crate) struct ChannelProps {
+    lvl: Option<emit::Level>,
+    trace_id: Option<emit::TraceId>,
+    span_parent: Option<emit::SpanId>,
+    span_id: Option<emit::SpanId>,
+    span_kind: Option<emit::SpanKind>,
+    rest: HashMap<emit::Str<'static>, emit::value::OwnedValue>,
 }
 
 impl ChannelEvent {
@@ -155,65 +155,118 @@ impl ChannelEvent {
     }
 }
 
-impl ChannelValue {
-    fn from_value(value: emit::Value) -> Self {
-        // Specialize a few common value types
-
-        if let Some(trace_id) = value.downcast_ref() {
-            return ChannelValue::TraceId(*trace_id);
-        }
-
-        if let Some(span_id) = value.downcast_ref() {
-            return ChannelValue::SpanId(*span_id);
-        }
-
-        // Fall back to buffering
-        ChannelValue::Any(value.to_shared())
-    }
-}
-
-impl emit::value::ToValue for ChannelValue {
-    fn to_value(&self) -> emit::Value<'_> {
-        match self {
-            ChannelValue::TraceId(value) => value.to_value(),
-            ChannelValue::SpanId(value) => value.to_value(),
-            ChannelValue::Any(value) => value.to_value(),
-        }
-    }
-}
-
 impl<'kv> emit::props::FromProps<'kv> for ChannelProps {
     fn from_props<P: emit::Props + ?Sized>(props: &'kv P) -> Self {
-        let mut owned = HashMap::new();
+        let mut owned = ChannelProps::default();
 
         let _ = props.for_each(|k, v| {
-            owned.insert(k.to_owned(), ChannelValue::from_value(v));
+            match k.get() {
+                // Well-known props
+                emit::well_known::KEY_LVL => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.lvl = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
+                emit::well_known::KEY_TRACE_ID => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.trace_id = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
+                emit::well_known::KEY_SPAN_ID => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.span_id = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
+                emit::well_known::KEY_SPAN_PARENT => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.span_parent = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
+                emit::well_known::KEY_SPAN_KIND => {
+                    if let Some(v) = v.by_ref().cast() {
+                        owned.span_kind = Some(v);
+
+                        return ControlFlow::Continue(());
+                    }
+                }
+                // Ignored
+                emit::well_known::KEY_EVT_KIND => return ControlFlow::Continue(()),
+                _ => (),
+            }
+
+            // Insert other values
+            owned.rest.insert(k.to_owned(), v.to_owned());
 
             ControlFlow::Continue(())
         });
 
-        ChannelProps(owned)
+        owned
     }
 }
 
 impl emit::Props for ChannelProps {
     fn for_each<'a, F: FnMut(emit::Str<'a>, emit::Value<'a>) -> ControlFlow<()>>(
         &'a self,
-        for_each: F,
+        mut for_each: F,
     ) -> ControlFlow<()> {
-        emit::Props::for_each(&self.0, for_each)
+        use emit::{str::ToStr as _, value::ToValue as _};
+
+        let ChannelProps {
+            lvl,
+            trace_id,
+            span_parent,
+            span_id,
+            span_kind,
+            rest,
+        } = self;
+
+        for_each(emit::well_known::KEY_LVL.to_str(), lvl.to_value())?;
+        for_each(emit::well_known::KEY_TRACE_ID.to_str(), trace_id.to_value())?;
+        for_each(
+            emit::well_known::KEY_SPAN_PARENT.to_str(),
+            span_parent.to_value(),
+        )?;
+        for_each(emit::well_known::KEY_SPAN_ID.to_str(), span_id.to_value())?;
+        for_each(
+            emit::well_known::KEY_SPAN_KIND.to_str(),
+            span_kind.to_value(),
+        )?;
+
+        emit::Props::for_each(rest, for_each)
     }
 
     fn get<'v, K: emit::str::ToStr>(&'v self, key: K) -> Option<emit::Value<'v>> {
-        emit::Props::get(&self.0, key)
+        use emit::value::ToValue as _;
+
+        let ChannelProps {
+            lvl,
+            trace_id,
+            span_parent,
+            span_id,
+            span_kind,
+            rest,
+        } = self;
+
+        match key.to_str().get() {
+            emit::well_known::KEY_LVL => lvl.as_ref().map(|v| v.to_value()),
+            emit::well_known::KEY_TRACE_ID => trace_id.as_ref().map(|v| v.to_value()),
+            emit::well_known::KEY_SPAN_ID => span_id.as_ref().map(|v| v.to_value()),
+            emit::well_known::KEY_SPAN_PARENT => span_parent.as_ref().map(|v| v.to_value()),
+            emit::well_known::KEY_SPAN_KIND => span_kind.as_ref().map(|v| v.to_value()),
+            key => emit::Props::get(rest, key),
+        }
     }
 
     fn is_unique(&self) -> bool {
         true
-    }
-
-    fn size(&self) -> Option<usize> {
-        Some(self.0.len())
     }
 }
 

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -22,10 +22,13 @@ where
 {
     let state = channel.state.draining_mut();
 
+    emit::debug!("processing channel: {#[emit::as_debug] state}");
+
     let mut batch = EncodedScopeItems::new();
 
     let mut scope_index = state.cursor.scope_index;
     let mut event_index = state.cursor.event_index;
+    let mut remaining_items = state.cursor.remaining_items;
 
     while scope_index < state.scopes.len() {
         let events = &state.scopes[scope_index].1;
@@ -33,6 +36,7 @@ where
         while event_index < events.len() {
             let event = &events[event_index];
             event_index += 1;
+            remaining_items -= 1;
 
             let Some(encoded) = encode_event(event) else {
                 // TODO: metric
@@ -49,6 +53,7 @@ where
                         state.cursor = ChannelCursor {
                             scope_index,
                             event_index,
+                            remaining_items,
                         };
                     }
                     Err(e) => return Err(e.map_retryable(|r| r.map(|_| channel))),
@@ -57,9 +62,6 @@ where
 
             batch.push(encoded);
         }
-
-        // Eagerly reclaim the completed scope's allocation
-        state.scopes[scope_index].1 = Vec::new();
 
         event_index = 0;
         scope_index += 1;
@@ -76,10 +78,11 @@ where
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ChannelCursor {
     scope_index: usize,
     event_index: usize,
+    remaining_items: usize,
 }
 
 pub(crate) struct Channel {
@@ -97,17 +100,20 @@ impl Default for Channel {
     }
 }
 
+#[derive(Debug)]
 enum ChannelState {
     Filling(ChannelStateFilling),
     Draining(ChannelStateDraining),
     Poisoned,
 }
 
+#[derive(Debug)]
 struct ChannelStateFilling {
     scopes: HashMap<emit::Path<'static>, Vec<ChannelEvent>>,
     total_items: usize,
 }
 
+#[derive(Debug)]
 struct ChannelStateDraining {
     scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
     cursor: ChannelCursor,
@@ -120,14 +126,6 @@ impl ChannelState {
             ChannelState::Draining(_) => "draining",
             ChannelState::Poisoned => "poisoned",
         }
-    }
-
-    fn filling(&self) -> &ChannelStateFilling {
-        let ChannelState::Filling(state) = self else {
-            panic!("invalid channel state: {:?}", self.variant());
-        };
-
-        state
     }
 
     fn filling_mut(&mut self) -> &mut ChannelStateFilling {
@@ -144,7 +142,11 @@ impl ChannelState {
                 // Convert a filling channel into a draining one
                 *self = ChannelState::Draining(ChannelStateDraining {
                     scopes: state.scopes.into_iter().collect(),
-                    cursor: ChannelCursor::default(),
+                    cursor: ChannelCursor {
+                        scope_index: 0,
+                        event_index: 0,
+                        remaining_items: state.total_items,
+                    },
                 });
             }
             ChannelState::Draining(state) => {
@@ -159,6 +161,14 @@ impl ChannelState {
 
         state
     }
+
+    fn remaining(&self) -> usize {
+        match self {
+            ChannelState::Filling(state) => state.total_items,
+            ChannelState::Draining(state) => state.cursor.remaining_items,
+            ChannelState::Poisoned => panic!("invalid channel state: {:?}", self.variant()),
+        }
+    }
 }
 
 pub(crate) struct ChannelItem {
@@ -171,7 +181,7 @@ impl emit_batcher::Channel for Channel {
     type Item = ChannelItem;
 
     fn new() -> Self {
-        Channel::default()
+        Default::default()
     }
 
     fn push(&mut self, item: Self::Item) {
@@ -188,26 +198,10 @@ impl emit_batcher::Channel for Channel {
     }
 
     fn len(&self) -> usize {
-        self.state.filling().total_items
+        self.state.remaining()
     }
 
     fn clear(&mut self) {
-        if let ChannelState::Filling(state) = &mut self.state {
-            state.total_items = 0;
-            state.scopes.retain(|_, v| {
-                if v.len() == 0 {
-                    // Remove any entries with no values in them
-                    false
-                } else {
-                    // Retain allocations of entries that had values
-                    v.clear();
-                    true
-                }
-            });
-
-            return;
-        };
-
         *self = Default::default();
     }
 }

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -6,6 +6,7 @@ Events are sent from the caller thread through a [`Channel`] to a background
 */
 
 use std::{
+    fmt,
     future::Future,
     hash::{BuildHasher, Hash},
 };
@@ -91,10 +92,19 @@ pub(crate) struct ChannelCursor {
     remaining_items: usize,
 }
 
+#[derive(Clone)]
 pub(crate) struct Channel {
     scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
     scopes_by_key: HashTable<usize>,
     cursor: ChannelCursor,
+}
+
+impl fmt::Debug for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Channel")
+            .field("cursor", &self.cursor)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for Channel {
@@ -175,4 +185,137 @@ impl emit_batcher::Channel for Channel {
 #[inline]
 fn hash(v: &(impl Hash + ?Sized)) -> u64 {
     FnvBuildHasher::default().hash_one(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use crate::data::{EventEncoder, Json, logs};
+
+    use emit_batcher::Channel as _;
+
+    #[tokio::test]
+    async fn channel_splits_batches_by_size() {
+        let mut channel = Channel::default();
+
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("a"), "Event 1").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("a"), "Event 2").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("b"), "Event 3").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("c"), "Event 4").to_owned(),
+        });
+
+        assert_eq!(4, channel.len());
+
+        for (case, expected) in [
+            (0, 4),
+            (
+                {
+                    logs::LogsEventEncoder::default()
+                        .encode_event::<Json>(&emit::evt!(mdl: emit::path!("a"), "Event 1"))
+                        .unwrap()
+                        .size_bytes()
+                        * 2
+                },
+                2,
+            ),
+            (usize::MAX, 1),
+        ] {
+            let channel = channel.clone();
+
+            let calls = Arc::new(Mutex::new(0));
+
+            batch(
+                channel,
+                case,
+                &Default::default(),
+                |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+                |_| async {
+                    *calls.lock().unwrap() += 1;
+
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(expected, *calls.lock().unwrap(), "max batch size {case}");
+        }
+    }
+
+    #[tokio::test]
+    async fn channel_retry_resumes_from_cursor() {
+        let mut channel = Channel::default();
+
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("a"), "Event 1").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("a"), "Event 2").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("b"), "Event 3").to_owned(),
+        });
+        channel.push(ChannelItem {
+            event: emit::evt!(mdl: emit::path!("c"), "Event 4").to_owned(),
+        });
+
+        assert_eq!(4, channel.len());
+
+        let calls = Arc::new(Mutex::new(0));
+
+        // This first call will fail
+        let channel = batch(
+            channel,
+            0,
+            &Default::default(),
+            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+            |_| async {
+                let mut calls = calls.lock().unwrap();
+
+                *calls += 1;
+
+                if *calls == 2 {
+                    return Err(BatchError::retry(
+                        io::Error::new(io::ErrorKind::Other, "explicit failure"),
+                        (),
+                    ));
+                }
+
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err()
+        .into_retryable()
+        .unwrap();
+
+        assert_eq!(0, channel.cursor.scope_index);
+        assert_eq!(2, channel.cursor.event_index);
+
+        assert_eq!(2, channel.len());
+
+        // This second call will succeed
+        batch(
+            channel,
+            0,
+            &Default::default(),
+            |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt),
+            |_| async { Ok(()) },
+        )
+        .await
+        .unwrap();
+    }
 }

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -42,6 +42,7 @@ where
 
         while event_index < events.len() {
             let event = &events[event_index];
+
             event_index += 1;
             remaining_items -= 1;
 
@@ -57,6 +58,7 @@ where
                 match send_batch(&batch).await {
                     Ok(()) => {
                         batch.clear();
+
                         channel.cursor = ChannelCursor {
                             scope_index,
                             event_index,

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -39,6 +39,8 @@ where
     let mut event_index = channel.cursor.event_index;
     let mut remaining_items = channel.cursor.remaining_items;
 
+    // Split our channel into batches roughly by request size
+    // OTLP requires we collect events under the same scope together so we work a scope at a time
     while scope_index < channel.scopes.len() {
         let events = &channel.scopes[scope_index].1;
 
@@ -123,10 +125,6 @@ impl Default for Channel {
             },
         }
     }
-}
-
-pub(crate) struct ChannelItem {
-    pub(crate) event: ChannelEvent,
 }
 
 #[derive(Clone)]
@@ -220,7 +218,7 @@ impl emit::Props for ChannelProps {
 }
 
 impl emit_batcher::Channel for Channel {
-    type Item = ChannelItem;
+    type Item = ChannelEvent;
 
     fn new() -> Self {
         Default::default()
@@ -244,7 +242,7 @@ impl emit_batcher::Channel for Channel {
             "attempt to push to a channel that's already being drained"
         );
 
-        let scope = item.event.get().mdl();
+        let scope = item.get().mdl();
 
         match self.scopes_by_key.entry(
             hash(&scope),
@@ -252,12 +250,12 @@ impl emit_batcher::Channel for Channel {
             |idx| hash(&self.scopes[*idx].0),
         ) {
             hash_table::Entry::Occupied(entry) => {
-                self.scopes[*entry.get()].1.push(item.event);
+                self.scopes[*entry.get()].1.push(item);
             }
             hash_table::Entry::Vacant(entry) => {
                 let idx = self.scopes.len();
 
-                self.scopes.push((scope.to_owned(), vec![item.event]));
+                self.scopes.push((scope.to_owned(), vec![item]));
                 entry.insert(idx);
             }
         }
@@ -296,18 +294,18 @@ mod tests {
     async fn channel_splits_batches_by_size() {
         let mut channel = Channel::default();
 
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 1")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 2")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("b"), "Event 3")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("c"), "Event 4")),
-        });
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("a"), "Event 1"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("a"), "Event 2"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("b"), "Event 3"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("c"), "Event 4"),
+        ));
 
         assert_eq!(4, channel.len());
 
@@ -351,18 +349,18 @@ mod tests {
     async fn channel_retry_resumes_from_cursor() {
         let mut channel = Channel::default();
 
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 1")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("a"), "Event 2")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("b"), "Event 3")),
-        });
-        channel.push(ChannelItem {
-            event: ChannelEvent::from_evt(emit::evt!(mdl: emit::path!("c"), "Event 4")),
-        });
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("a"), "Event 1"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("a"), "Event 2"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("b"), "Event 3"),
+        ));
+        channel.push(ChannelEvent::from_evt(
+            emit::evt!(mdl: emit::path!("c"), "Event 4"),
+        ));
 
         assert_eq!(4, channel.len());
 

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -228,17 +228,27 @@ impl emit::Props for ChannelProps {
             rest,
         } = self;
 
-        for_each(emit::well_known::KEY_LVL.to_str(), lvl.to_value())?;
-        for_each(emit::well_known::KEY_TRACE_ID.to_str(), trace_id.to_value())?;
-        for_each(
-            emit::well_known::KEY_SPAN_PARENT.to_str(),
-            span_parent.to_value(),
-        )?;
-        for_each(emit::well_known::KEY_SPAN_ID.to_str(), span_id.to_value())?;
-        for_each(
-            emit::well_known::KEY_SPAN_KIND.to_str(),
-            span_kind.to_value(),
-        )?;
+        if let Some(lvl) = lvl {
+            for_each(emit::well_known::KEY_LVL.to_str(), lvl.to_value())?;
+        }
+        if let Some(trace_id) = trace_id {
+            for_each(emit::well_known::KEY_TRACE_ID.to_str(), trace_id.to_value())?;
+        }
+        if let Some(span_parent) = span_parent {
+            for_each(
+                emit::well_known::KEY_SPAN_PARENT.to_str(),
+                span_parent.to_value(),
+            )?;
+        }
+        if let Some(span_id) = span_id {
+            for_each(emit::well_known::KEY_SPAN_ID.to_str(), span_id.to_value())?;
+        }
+        if let Some(span_kind) = span_kind {
+            for_each(
+                emit::well_known::KEY_SPAN_KIND.to_str(),
+                span_kind.to_value(),
+            )?;
+        }
 
         emit::Props::for_each(rest, for_each)
     }

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -5,13 +5,13 @@ Events are sent from the caller thread through a [`Channel`] to a background
 [`SignalWorker`], which serializes and ships them via HTTP.
 */
 
-use std::future::Future;
+use std::{collections::HashMap, future::Future, mem};
 
 use emit_batcher::BatchError;
 
 use crate::data::{EncodedEvent, EncodedScopeItems};
 
-pub(crate) async fn execute<F>(
+pub(crate) async fn batch<F>(
     mut channel: Channel,
     max_request_size: usize,
     mut encode_event: impl FnMut(&ChannelEvent) -> Option<EncodedEvent>,
@@ -20,15 +20,15 @@ pub(crate) async fn execute<F>(
 where
     F: Future<Output = Result<(), BatchError<()>>>,
 {
-    // TODO: Clear out events as they're processed
-    // TODO: Review this more thoroughly
+    let state = channel.state.draining_mut();
+
     let mut batch = EncodedScopeItems::new();
 
-    let mut scope_index = channel.cursor.scope_index;
-    let mut event_index = channel.cursor.event_index;
+    let mut scope_index = state.cursor.scope_index;
+    let mut event_index = state.cursor.event_index;
 
-    while scope_index < channel.scopes.len() {
-        let events = &channel.scopes[scope_index].1;
+    while scope_index < state.scopes.len() {
+        let events = &state.scopes[scope_index].1;
 
         while event_index < events.len() {
             let event = &events[event_index];
@@ -42,11 +42,11 @@ where
             if batch.total_items() > 0
                 && batch.total_size_bytes() + encoded.size_bytes() > max_request_size
             {
-                // We've reached the maximum size of a single batcg; send it then start a new one
+                // We've reached the maximum size of a single batch; send it then start a new one
                 match send_batch(&batch).await {
                     Ok(()) => {
-                        batch = EncodedScopeItems::new();
-                        channel.cursor = ChannelCursor {
+                        batch.clear();
+                        state.cursor = ChannelCursor {
                             scope_index,
                             event_index,
                         };
@@ -57,6 +57,9 @@ where
 
             batch.push(encoded);
         }
+
+        // Eagerly reclaim the completed scope's allocation
+        state.scopes[scope_index].1 = Vec::new();
 
         event_index = 0;
         scope_index += 1;
@@ -79,11 +82,83 @@ pub(crate) struct ChannelCursor {
     event_index: usize,
 }
 
-#[derive(Default)]
 pub(crate) struct Channel {
-    pub(crate) scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
-    pub(crate) total_items: usize,
-    pub(crate) cursor: ChannelCursor,
+    state: ChannelState,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Channel {
+            state: ChannelState::Filling(ChannelStateFilling {
+                scopes: HashMap::new(),
+                total_items: 0,
+            }),
+        }
+    }
+}
+
+enum ChannelState {
+    Filling(ChannelStateFilling),
+    Draining(ChannelStateDraining),
+    Poisoned,
+}
+
+struct ChannelStateFilling {
+    scopes: HashMap<emit::Path<'static>, Vec<ChannelEvent>>,
+    total_items: usize,
+}
+
+struct ChannelStateDraining {
+    scopes: Vec<(emit::Path<'static>, Vec<ChannelEvent>)>,
+    cursor: ChannelCursor,
+}
+
+impl ChannelState {
+    fn variant(&self) -> &'static str {
+        match self {
+            ChannelState::Filling(_) => "filling",
+            ChannelState::Draining(_) => "draining",
+            ChannelState::Poisoned => "poisoned",
+        }
+    }
+
+    fn filling(&self) -> &ChannelStateFilling {
+        let ChannelState::Filling(state) = self else {
+            panic!("invalid channel state: {:?}", self.variant());
+        };
+
+        state
+    }
+
+    fn filling_mut(&mut self) -> &mut ChannelStateFilling {
+        let ChannelState::Filling(state) = self else {
+            panic!("invalid channel state: {:?}", self.variant());
+        };
+
+        state
+    }
+
+    fn draining_mut(&mut self) -> &mut ChannelStateDraining {
+        match mem::replace(self, ChannelState::Poisoned) {
+            ChannelState::Filling(state) => {
+                // Convert a filling channel into a draining one
+                *self = ChannelState::Draining(ChannelStateDraining {
+                    scopes: state.scopes.into_iter().collect(),
+                    cursor: ChannelCursor::default(),
+                });
+            }
+            ChannelState::Draining(state) => {
+                *self = ChannelState::Draining(state);
+            }
+            ChannelState::Poisoned => panic!("invalid channel state: {:?}", self.variant()),
+        }
+
+        let ChannelState::Draining(state) = self else {
+            unreachable!()
+        };
+
+        state
+    }
 }
 
 pub(crate) struct ChannelItem {
@@ -100,43 +175,39 @@ impl emit_batcher::Channel for Channel {
     }
 
     fn push(&mut self, item: Self::Item) {
+        let state = self.state.filling_mut();
+
         let scope = item.event.mdl();
 
-        // TODO: Binary search or secondary hashmap
-        if let Some(entry) = self.scopes.iter_mut().find(|(s, _)| *s == scope) {
-            entry.1.push(item.event);
-        } else {
-            self.scopes.push((scope.to_owned(), vec![item.event]));
-        }
-
-        self.total_items += 1;
+        state
+            .scopes
+            .entry(scope.to_owned())
+            .or_insert_with(|| Vec::new())
+            .push(item.event);
+        state.total_items += 1;
     }
 
     fn len(&self) -> usize {
-        self.total_items
+        self.state.filling().total_items
     }
 
     fn clear(&mut self) {
-        let Channel {
-            scopes,
-            total_items,
-            cursor,
-        } = self;
+        if let ChannelState::Filling(state) = &mut self.state {
+            state.total_items = 0;
+            state.scopes.retain(|_, v| {
+                if v.len() == 0 {
+                    // Remove any entries with no values in them
+                    false
+                } else {
+                    // Retain allocations of entries that had values
+                    v.clear();
+                    true
+                }
+            });
 
-        scopes.clear();
-        *total_items = 0;
-        *cursor = ChannelCursor::default();
-    }
-}
+            return;
+        };
 
-#[cfg(test)]
-mod tests {
-    use emit_batcher::Channel as _;
-
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        todo!()
+        *self = Default::default();
     }
 }

--- a/emitter/otlp/src/client/http.rs
+++ b/emitter/otlp/src/client/http.rs
@@ -351,6 +351,8 @@ impl Buf for HttpContentCursor {
     }
 }
 
+pub(crate) use super::ClientRequestSender;
+
 fn outgoing_traceparent_header() -> Option<(&'static str, String)> {
     let (trace_id, span_id) = emit::runtime::internal().ctxt().with_current(|props| {
         (

--- a/emitter/otlp/src/client/http/stub.rs
+++ b/emitter/otlp/src/client/http/stub.rs
@@ -4,7 +4,7 @@ use std::{fmt, future::Future, sync::Arc, time::Duration};
 
 use crate::{
     Error,
-    client::http::{HttpContent, HttpVersion},
+    client::http::{ClientRequestSender, HttpContent, HttpVersion},
     data::EncodedPayload,
     internal_metrics::InternalMetrics,
 };
@@ -29,6 +29,20 @@ impl HttpConnection {
     }
 
     pub async fn send(&self, _body: EncodedPayload, _timeout: Duration) -> Result<(), Error> {
+        unreachable!()
+    }
+}
+
+impl ClientRequestSender for HttpConnection {
+    fn uri(&self) -> &(impl fmt::Display + 'static) {
+        unreachable!()
+    }
+
+    fn send(
+        &self,
+        _body: EncodedPayload,
+        _timeout: Duration,
+    ) -> impl Future<Output = Result<(), Error>> + Send {
         unreachable!()
     }
 }

--- a/emitter/otlp/src/client/http/tokio.rs
+++ b/emitter/otlp/src/client/http/tokio.rs
@@ -5,6 +5,7 @@ This transport supports HTTP1 and gRPC via HTTP2.
 */
 
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     sync::{Arc, LazyLock, Mutex},
@@ -21,7 +22,8 @@ use hyper::{
 use crate::{
     Error,
     client::http::{
-        HttpContent, HttpContentCursor, HttpUri, HttpVersion, outgoing_traceparent_header,
+        ClientRequestSender, HttpContent, HttpContentCursor, HttpUri, HttpVersion,
+        outgoing_traceparent_header,
     },
     data::EncodedPayload,
     internal_metrics::InternalMetrics,
@@ -268,7 +270,7 @@ pub(crate) struct HttpResponse {
 }
 
 impl HttpConnection {
-    pub fn new<F: Future<Output = Result<(), Error>> + Send + 'static>(
+    pub(crate) fn new<F: Future<Output = Result<(), Error>> + Send + 'static>(
         version: HttpVersion,
         metrics: Arc<InternalMetrics>,
         url: impl AsRef<str>,
@@ -299,11 +301,11 @@ impl HttpConnection {
         *self.sender.lock().unwrap() = Some(sender);
     }
 
-    pub fn uri(&self) -> &HttpUri {
+    fn uri(&self) -> &HttpUri {
         &self.uri
     }
 
-    pub async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
+    async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
         let res = tokio::time::timeout(timeout, async {
             let mut sender = match self.poison() {
                 Some(sender) => sender,
@@ -330,6 +332,20 @@ impl HttpConnection {
         .map_err(|e| Error::new("failed to send request within its timeout", e))?;
 
         res
+    }
+}
+
+impl ClientRequestSender for HttpConnection {
+    fn uri(&self) -> &(impl fmt::Display + 'static) {
+        self.uri()
+    }
+
+    fn send(
+        &self,
+        body: EncodedPayload,
+        timeout: Duration,
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        self.send(body, timeout)
     }
 }
 

--- a/emitter/otlp/src/client/http/tokio.rs
+++ b/emitter/otlp/src/client/http/tokio.rs
@@ -344,7 +344,7 @@ impl ClientRequestSender for HttpConnection {
         &self,
         body: EncodedPayload,
         timeout: Duration,
-    ) -> impl Future<Output = Result<(), Error>> + Send {
+    ) -> impl Future<Output = Result<(), Error>> {
         self.send(body, timeout)
     }
 }

--- a/emitter/otlp/src/client/http/web.rs
+++ b/emitter/otlp/src/client/http/web.rs
@@ -12,7 +12,9 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     Error,
-    client::http::{HttpContent, HttpUri, HttpVersion, outgoing_traceparent_header},
+    client::http::{
+        ClientRequestSender, HttpContent, HttpUri, HttpVersion, outgoing_traceparent_header,
+    },
     data::EncodedPayload,
     internal_metrics::InternalMetrics,
 };
@@ -31,7 +33,7 @@ pub(crate) struct HttpConnection {
 }
 
 impl HttpConnection {
-    pub fn new<F: Future<Output = Result<(), Error>> + Send + 'static>(
+    pub(crate) fn new<F: Future<Output = Result<(), Error>> + Send + 'static>(
         version: HttpVersion,
         metrics: Arc<InternalMetrics>,
         url: impl AsRef<str>,
@@ -56,11 +58,11 @@ impl HttpConnection {
         })
     }
 
-    pub fn uri(&self) -> &HttpUri {
+    fn uri(&self) -> &HttpUri {
         &self.uri
     }
 
-    pub async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
+    async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
         let resource = self.uri.to_string();
 
         let content = HttpContent::new(self.allow_compression, &self.request, &self.metrics, body)?;
@@ -92,6 +94,20 @@ impl HttpConnection {
             status: js_status(&res)?,
         })
         .await
+    }
+}
+
+impl ClientRequestSender for HttpConnection {
+    fn uri(&self) -> &(impl fmt::Display + 'static) {
+        self.uri()
+    }
+
+    fn send(
+        &self,
+        body: EncodedPayload,
+        timeout: Duration,
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        self.send(body, timeout)
     }
 }
 

--- a/emitter/otlp/src/client/http/web.rs
+++ b/emitter/otlp/src/client/http/web.rs
@@ -106,7 +106,7 @@ impl ClientRequestSender for HttpConnection {
         &self,
         body: EncodedPayload,
         timeout: Duration,
-    ) -> impl Future<Output = Result<(), Error>> + Send {
+    ) -> impl Future<Output = Result<(), Error>> {
         self.send(body, timeout)
     }
 }

--- a/emitter/otlp/src/client/logs.rs
+++ b/emitter/otlp/src/client/logs.rs
@@ -6,6 +6,7 @@ use crate::{
     internal_metrics::InternalMetrics,
 };
 
+use super::http::HttpConnection;
 use super::{
     ClientEventEncoder, ClientRequestEncoder, OtlpTransport, Protocol, Resource, encode_resource,
 };
@@ -98,22 +99,14 @@ impl OtlpLogsBuilder {
         self,
         metrics: Arc<InternalMetrics>,
         resource: Option<&Resource>,
-    ) -> Result<
-        (
-            ClientEventEncoder<LogsEventEncoder>,
-            OtlpTransport<LogsRequestEncoder>,
-        ),
-        Error,
-    > {
-        Ok((
+    ) -> Result<OtlpTransport<HttpConnection, LogsEventEncoder, LogsRequestEncoder>, Error> {
+        self.transport.build(
+            metrics.clone(),
             ClientEventEncoder::new(self.encoding, self.event_encoder),
-            self.transport.build(
-                metrics.clone(),
-                resource
-                    .as_ref()
-                    .map(|resource| encode_resource(self.encoding, resource)),
-                ClientRequestEncoder::new(self.encoding, self.request_encoder),
-            )?,
-        ))
+            resource
+                .as_ref()
+                .map(|resource| encode_resource(self.encoding, resource)),
+            ClientRequestEncoder::new(self.encoding, self.request_encoder),
+        )
     }
 }

--- a/emitter/otlp/src/client/metrics.rs
+++ b/emitter/otlp/src/client/metrics.rs
@@ -6,6 +6,7 @@ use crate::{
     internal_metrics::InternalMetrics,
 };
 
+use super::http::HttpConnection;
 use super::{
     ClientEventEncoder, ClientRequestEncoder, OtlpTransport, Protocol, Resource, encode_resource,
 };
@@ -99,22 +100,15 @@ impl OtlpMetricsBuilder {
         self,
         metrics: Arc<InternalMetrics>,
         resource: Option<&Resource>,
-    ) -> Result<
-        (
-            ClientEventEncoder<MetricsEventEncoder>,
-            OtlpTransport<MetricsRequestEncoder>,
-        ),
-        Error,
-    > {
-        Ok((
+    ) -> Result<OtlpTransport<HttpConnection, MetricsEventEncoder, MetricsRequestEncoder>, Error>
+    {
+        self.transport.build(
+            metrics.clone(),
             ClientEventEncoder::new(self.encoding, self.event_encoder),
-            self.transport.build(
-                metrics.clone(),
-                resource
-                    .as_ref()
-                    .map(|resource| encode_resource(self.encoding, resource)),
-                ClientRequestEncoder::new(self.encoding, self.request_encoder),
-            )?,
-        ))
+            resource
+                .as_ref()
+                .map(|resource| encode_resource(self.encoding, resource)),
+            ClientRequestEncoder::new(self.encoding, self.request_encoder),
+        )
     }
 }

--- a/emitter/otlp/src/client/stub.rs
+++ b/emitter/otlp/src/client/stub.rs
@@ -4,6 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{
     Error,
+    client::http::HttpConnection,
     client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
@@ -18,11 +19,15 @@ pub(super) type Handle = ();
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
         _otlp_logs: Option<emit_batcher::Sender<Channel>>,
-        _worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        _worker_logs: Option<SignalWorker<HttpConnection, LogsEventEncoder, LogsRequestEncoder>>,
         _otlp_traces: Option<emit_batcher::Sender<Channel>>,
-        _worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        _worker_traces: Option<
+            SignalWorker<HttpConnection, TracesEventEncoder, TracesRequestEncoder>,
+        >,
         _otlp_metrics: Option<emit_batcher::Sender<Channel>>,
-        _worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
+        _worker_metrics: Option<
+            SignalWorker<HttpConnection, MetricsEventEncoder, MetricsRequestEncoder>,
+        >,
         _metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         unreachable!()

--- a/emitter/otlp/src/client/stub.rs
+++ b/emitter/otlp/src/client/stub.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{
     Error,
-    client::{Channel, ClientEventEncoder, OtlpBuilder, OtlpInner, OtlpTransport},
+    client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
         metrics::{MetricsEventEncoder, MetricsRequestEncoder},
@@ -17,30 +17,12 @@ pub(super) type Handle = ();
 
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
-        _otlp_logs: Option<(
-            ClientEventEncoder<LogsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        _process_otlp_logs: Option<(
-            OtlpTransport<LogsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        _otlp_traces: Option<(
-            ClientEventEncoder<TracesEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        _process_otlp_traces: Option<(
-            OtlpTransport<TracesRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        _otlp_metrics: Option<(
-            ClientEventEncoder<MetricsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        _process_otlp_metrics: Option<(
-            OtlpTransport<MetricsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
+        _otlp_logs: Option<emit_batcher::Sender<Channel>>,
+        _worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        _otlp_traces: Option<emit_batcher::Sender<Channel>>,
+        _worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        _otlp_metrics: Option<emit_batcher::Sender<Channel>>,
+        _worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
         _metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         unreachable!()

--- a/emitter/otlp/src/client/tokio.rs
+++ b/emitter/otlp/src/client/tokio.rs
@@ -4,7 +4,7 @@ use futures_util::{StreamExt, stream::FuturesUnordered};
 
 use crate::{
     Error,
-    client::{Channel, ClientEventEncoder, OtlpBuilder, OtlpInner, OtlpTransport},
+    client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
         metrics::{MetricsEventEncoder, MetricsRequestEncoder},
@@ -17,84 +17,69 @@ pub(super) type Handle = std::thread::JoinHandle<()>;
 
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
-        otlp_logs: Option<(
-            ClientEventEncoder<LogsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_logs: Option<(
-            OtlpTransport<LogsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        otlp_traces: Option<(
-            ClientEventEncoder<TracesEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_traces: Option<(
-            OtlpTransport<TracesRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        otlp_metrics: Option<(
-            ClientEventEncoder<MetricsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_metrics: Option<(
-            OtlpTransport<MetricsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
+        otlp_logs: Option<emit_batcher::Sender<Channel>>,
+        worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        otlp_traces: Option<emit_batcher::Sender<Channel>>,
+        worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        otlp_metrics: Option<emit_batcher::Sender<Channel>>,
+        worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         let receive = async move {
             let processors =
                 FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
 
-            if let Some((transport, receiver)) = process_otlp_logs {
-                let transport = Arc::new(transport);
-
+            if let Some(worker) = worker_logs {
+                let (inner, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let transport = transport.clone();
-
-                        async move { transport.send(batch).await }
+                        let inner = inner.clone();
+                        async move {
+                            inner
+                                .transport
+                                .send::<LogsEventEncoder>(&inner.event_encoder, batch)
+                                .await
+                        }
                     },
                 )));
             }
 
-            if let Some((transport, receiver)) = process_otlp_traces {
-                let transport = Arc::new(transport);
-
+            if let Some(worker) = worker_traces {
+                let (inner, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let transport = transport.clone();
-
-                        async move { transport.send(batch).await }
+                        let inner = inner.clone();
+                        async move {
+                            inner
+                                .transport
+                                .send::<TracesEventEncoder>(&inner.event_encoder, batch)
+                                .await
+                        }
                     },
                 )));
             }
 
-            if let Some((transport, receiver)) = process_otlp_metrics {
-                let transport = Arc::new(transport);
-
+            if let Some(worker) = worker_metrics {
+                let (inner, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let transport = transport.clone();
-
-                        async move { transport.send(batch).await }
+                        let inner = inner.clone();
+                        async move {
+                            inner
+                                .transport
+                                .send::<MetricsEventEncoder>(&inner.event_encoder, batch)
+                                .await
+                        }
                     },
                 )));
             }
 
-            // Process batches from each signal independently
-            // This ensures one signal becoming unavailable doesn't
-            // block the others
             let _ = processors.into_future().await;
         };
 
-        // Spawn a background thread to process batches
-        // This is a safe way to ensure users of `Otlp` can never
-        // deadlock waiting on the processing of batches
         let handle = std::thread::Builder::new()
             .name("emit_otlp_worker".into())
             .spawn(move || {
@@ -107,11 +92,9 @@ impl OtlpBuilder {
             .map_err(|e| Error::new("failed to spawn background worker", e))?;
 
         Ok(OtlpInner {
-            otlp_logs,
-            otlp_traces,
-            otlp_metrics,
+            signals: SignalSenders::new(otlp_logs, otlp_traces, otlp_metrics),
             metrics,
-            _handle: handle,
+            handle: Some(handle),
         })
     }
 }

--- a/emitter/otlp/src/client/tokio.rs
+++ b/emitter/otlp/src/client/tokio.rs
@@ -4,6 +4,7 @@ use futures_util::{StreamExt, stream::FuturesUnordered};
 
 use crate::{
     Error,
+    client::http::HttpConnection,
     client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
@@ -18,11 +19,15 @@ pub(super) type Handle = std::thread::JoinHandle<()>;
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
         otlp_logs: Option<emit_batcher::Sender<Channel>>,
-        worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        worker_logs: Option<SignalWorker<HttpConnection, LogsEventEncoder, LogsRequestEncoder>>,
         otlp_traces: Option<emit_batcher::Sender<Channel>>,
-        worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        worker_traces: Option<
+            SignalWorker<HttpConnection, TracesEventEncoder, TracesRequestEncoder>,
+        >,
         otlp_metrics: Option<emit_batcher::Sender<Channel>>,
-        worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
+        worker_metrics: Option<
+            SignalWorker<HttpConnection, MetricsEventEncoder, MetricsRequestEncoder>,
+        >,
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         let receive = async move {
@@ -30,49 +35,34 @@ impl OtlpBuilder {
                 FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
 
             if let Some(worker) = worker_logs {
-                let (inner, receiver) = worker.into_receiver();
+                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let inner = inner.clone();
-                        async move {
-                            inner
-                                .transport
-                                .send::<LogsEventEncoder>(&inner.event_encoder, batch)
-                                .await
-                        }
+                        let transport = transport.clone();
+                        async move { transport.send(batch).await }
                     },
                 )));
             }
 
             if let Some(worker) = worker_traces {
-                let (inner, receiver) = worker.into_receiver();
+                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let inner = inner.clone();
-                        async move {
-                            inner
-                                .transport
-                                .send::<TracesEventEncoder>(&inner.event_encoder, batch)
-                                .await
-                        }
+                        let transport = transport.clone();
+                        async move { transport.send(batch).await }
                     },
                 )));
             }
 
             if let Some(worker) = worker_metrics {
-                let (inner, receiver) = worker.into_receiver();
+                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
                     receiver,
                     move |batch| {
-                        let inner = inner.clone();
-                        async move {
-                            inner
-                                .transport
-                                .send::<MetricsEventEncoder>(&inner.event_encoder, batch)
-                                .await
-                        }
+                        let transport = transport.clone();
+                        async move { transport.send(batch).await }
                     },
                 )));
             }

--- a/emitter/otlp/src/client/tokio.rs
+++ b/emitter/otlp/src/client/tokio.rs
@@ -5,7 +5,7 @@ use futures_util::{StreamExt, stream::FuturesUnordered};
 use crate::{
     Error,
     client::http::HttpConnection,
-    client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
+    client::{Channel, OtlpBuilder, OtlpInner, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
         metrics::{MetricsEventEncoder, MetricsRequestEncoder},
@@ -35,33 +35,30 @@ impl OtlpBuilder {
                 FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
 
             if let Some(worker) = worker_logs {
-                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
-                    receiver,
+                    worker.receiver,
                     move |batch| {
-                        let transport = transport.clone();
+                        let transport = worker.transport.clone();
                         async move { transport.send(batch).await }
                     },
                 )));
             }
 
             if let Some(worker) = worker_traces {
-                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
-                    receiver,
+                    worker.receiver,
                     move |batch| {
-                        let transport = transport.clone();
+                        let transport = worker.transport.clone();
                         async move { transport.send(batch).await }
                     },
                 )));
             }
 
             if let Some(worker) = worker_metrics {
-                let (transport, receiver) = worker.into_receiver();
                 processors.push(Box::pin(emit_batcher::tokio::exec(
-                    receiver,
+                    worker.receiver,
                     move |batch| {
-                        let transport = transport.clone();
+                        let transport = worker.transport.clone();
                         async move { transport.send(batch).await }
                     },
                 )));
@@ -82,7 +79,9 @@ impl OtlpBuilder {
             .map_err(|e| Error::new("failed to spawn background worker", e))?;
 
         Ok(OtlpInner {
-            signals: SignalSenders::new(otlp_logs, otlp_traces, otlp_metrics),
+            otlp_logs,
+            otlp_traces,
+            otlp_metrics,
             metrics,
             handle: Some(handle),
         })

--- a/emitter/otlp/src/client/tokio.rs
+++ b/emitter/otlp/src/client/tokio.rs
@@ -30,41 +30,54 @@ impl OtlpBuilder {
         >,
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
-        let receive = async move {
-            let processors =
-                FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
+        let receive = {
+            let metrics = metrics.clone();
 
-            if let Some(worker) = worker_logs {
-                processors.push(Box::pin(emit_batcher::tokio::exec(
-                    worker.receiver,
-                    move |batch| {
-                        let transport = worker.transport.clone();
-                        async move { transport.send(batch).await }
-                    },
-                )));
+            async move {
+                let processors =
+                    FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
+
+                if let Some(worker) = worker_logs {
+                    let metrics = metrics.clone();
+
+                    processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
+                        move |batch| {
+                            let transport = worker.transport.clone();
+                            let metrics = metrics.clone();
+
+                            async move { transport.send(batch, &metrics).await }
+                        }
+                    })));
+                }
+
+                if let Some(worker) = worker_traces {
+                    let metrics = metrics.clone();
+
+                    processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
+                        move |batch| {
+                            let transport = worker.transport.clone();
+                            let metrics = metrics.clone();
+
+                            async move { transport.send(batch, &metrics).await }
+                        }
+                    })));
+                }
+
+                if let Some(worker) = worker_metrics {
+                    let metrics = metrics.clone();
+
+                    processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
+                        move |batch| {
+                            let transport = worker.transport.clone();
+                            let metrics = metrics.clone();
+
+                            async move { transport.send(batch, &metrics).await }
+                        }
+                    })));
+                }
+
+                let _ = processors.into_future().await;
             }
-
-            if let Some(worker) = worker_traces {
-                processors.push(Box::pin(emit_batcher::tokio::exec(
-                    worker.receiver,
-                    move |batch| {
-                        let transport = worker.transport.clone();
-                        async move { transport.send(batch).await }
-                    },
-                )));
-            }
-
-            if let Some(worker) = worker_metrics {
-                processors.push(Box::pin(emit_batcher::tokio::exec(
-                    worker.receiver,
-                    move |batch| {
-                        let transport = worker.transport.clone();
-                        async move { transport.send(batch).await }
-                    },
-                )));
-            }
-
-            let _ = processors.into_future().await;
         };
 
         let handle = std::thread::Builder::new()

--- a/emitter/otlp/src/client/tokio.rs
+++ b/emitter/otlp/src/client/tokio.rs
@@ -31,19 +31,15 @@ impl OtlpBuilder {
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         let receive = {
-            let metrics = metrics.clone();
-
             async move {
                 let processors =
                     FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>::new();
 
                 if let Some(worker) = worker_logs {
-                    let metrics = metrics.clone();
-
                     processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
                         move |batch| {
                             let transport = worker.transport.clone();
-                            let metrics = metrics.clone();
+                            let metrics = worker.metrics.clone();
 
                             async move { transport.send(batch, &metrics).await }
                         }
@@ -51,12 +47,10 @@ impl OtlpBuilder {
                 }
 
                 if let Some(worker) = worker_traces {
-                    let metrics = metrics.clone();
-
                     processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
                         move |batch| {
                             let transport = worker.transport.clone();
-                            let metrics = metrics.clone();
+                            let metrics = worker.metrics.clone();
 
                             async move { transport.send(batch, &metrics).await }
                         }
@@ -64,12 +58,10 @@ impl OtlpBuilder {
                 }
 
                 if let Some(worker) = worker_metrics {
-                    let metrics = metrics.clone();
-
                     processors.push(Box::pin(emit_batcher::tokio::exec(worker.receiver, {
                         move |batch| {
                             let transport = worker.transport.clone();
-                            let metrics = metrics.clone();
+                            let metrics = worker.metrics.clone();
 
                             async move { transport.send(batch, &metrics).await }
                         }

--- a/emitter/otlp/src/client/traces.rs
+++ b/emitter/otlp/src/client/traces.rs
@@ -6,6 +6,7 @@ use crate::{
     internal_metrics::InternalMetrics,
 };
 
+use super::http::HttpConnection;
 use super::{
     ClientEventEncoder, ClientRequestEncoder, OtlpTransport, Protocol, Resource, encode_resource,
 };
@@ -114,22 +115,15 @@ impl OtlpTracesBuilder {
         self,
         metrics: Arc<InternalMetrics>,
         resource: Option<&Resource>,
-    ) -> Result<
-        (
-            ClientEventEncoder<TracesEventEncoder>,
-            OtlpTransport<TracesRequestEncoder>,
-        ),
-        Error,
-    > {
-        Ok((
+    ) -> Result<OtlpTransport<HttpConnection, TracesEventEncoder, TracesRequestEncoder>, Error>
+    {
+        self.transport.build(
+            metrics.clone(),
             ClientEventEncoder::new(self.encoding, self.event_encoder),
-            self.transport.build(
-                metrics.clone(),
-                resource
-                    .as_ref()
-                    .map(|resource| encode_resource(self.encoding, resource)),
-                ClientRequestEncoder::new(self.encoding, self.request_encoder),
-            )?,
-        ))
+            resource
+                .as_ref()
+                .map(|resource| encode_resource(self.encoding, resource)),
+            ClientRequestEncoder::new(self.encoding, self.request_encoder),
+        )
     }
 }

--- a/emitter/otlp/src/client/web.rs
+++ b/emitter/otlp/src/client/web.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     Error,
+    client::http::HttpConnection,
     client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
@@ -18,53 +19,42 @@ pub(super) type Handle = ();
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
         otlp_logs: Option<emit_batcher::Sender<Channel>>,
-        worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        worker_logs: Option<SignalWorker<HttpConnection, LogsEventEncoder, LogsRequestEncoder>>,
         otlp_traces: Option<emit_batcher::Sender<Channel>>,
-        worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        worker_traces: Option<
+            SignalWorker<HttpConnection, TracesEventEncoder, TracesRequestEncoder>,
+        >,
         otlp_metrics: Option<emit_batcher::Sender<Channel>>,
-        worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
+        worker_metrics: Option<
+            SignalWorker<HttpConnection, MetricsEventEncoder, MetricsRequestEncoder>,
+        >,
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
         let _ = metrics;
 
         if let Some(worker) = worker_logs {
-            let (inner, receiver) = worker.into_receiver();
+            let (transport, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let inner = inner.clone();
-                async move {
-                    inner
-                        .transport
-                        .send::<LogsEventEncoder>(&inner.event_encoder, batch)
-                        .await
-                }
+                let transport = transport.clone();
+                async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn logs transport", e))?;
         }
 
         if let Some(worker) = worker_traces {
-            let (inner, receiver) = worker.into_receiver();
+            let (transport, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let inner = inner.clone();
-                async move {
-                    inner
-                        .transport
-                        .send::<TracesEventEncoder>(&inner.event_encoder, batch)
-                        .await
-                }
+                let transport = transport.clone();
+                async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn traces transport", e))?;
         }
 
         if let Some(worker) = worker_metrics {
-            let (inner, receiver) = worker.into_receiver();
+            let (transport, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let inner = inner.clone();
-                async move {
-                    inner
-                        .transport
-                        .send::<MetricsEventEncoder>(&inner.event_encoder, batch)
-                        .await
-                }
+                let transport = transport.clone();
+                async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn metrics transport", e))?;
         }

--- a/emitter/otlp/src/client/web.rs
+++ b/emitter/otlp/src/client/web.rs
@@ -33,27 +33,24 @@ impl OtlpBuilder {
         let _ = metrics;
 
         if let Some(worker) = worker_logs {
-            let (transport, receiver) = worker.into_receiver();
-            emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
+            emit_batcher::web::spawn(worker.receiver, move |batch| {
+                let transport = worker.transport.clone();
                 async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn logs transport", e))?;
         }
 
         if let Some(worker) = worker_traces {
-            let (transport, receiver) = worker.into_receiver();
-            emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
+            emit_batcher::web::spawn(worker.receiver, move |batch| {
+                let transport = worker.transport.clone();
                 async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn traces transport", e))?;
         }
 
         if let Some(worker) = worker_metrics {
-            let (transport, receiver) = worker.into_receiver();
-            emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
+            emit_batcher::web::spawn(worker.receiver, move |batch| {
+                let transport = worker.transport.clone();
                 async move { transport.send(batch).await }
             })
             .map_err(|e| Error::new("failed to spawn metrics transport", e))?;

--- a/emitter/otlp/src/client/web.rs
+++ b/emitter/otlp/src/client/web.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     Error,
-    client::{Channel, ClientEventEncoder, OtlpBuilder, OtlpInner, OtlpTransport},
+    client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
         metrics::{MetricsEventEncoder, MetricsRequestEncoder},
@@ -17,72 +17,62 @@ pub(super) type Handle = ();
 
 impl OtlpBuilder {
     pub(super) fn try_spawn_inner_imp(
-        otlp_logs: Option<(
-            ClientEventEncoder<LogsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_logs: Option<(
-            OtlpTransport<LogsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        otlp_traces: Option<(
-            ClientEventEncoder<TracesEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_traces: Option<(
-            OtlpTransport<TracesRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
-        otlp_metrics: Option<(
-            ClientEventEncoder<MetricsEventEncoder>,
-            emit_batcher::Sender<Channel>,
-        )>,
-        process_otlp_metrics: Option<(
-            OtlpTransport<MetricsRequestEncoder>,
-            emit_batcher::Receiver<Channel>,
-        )>,
+        otlp_logs: Option<emit_batcher::Sender<Channel>>,
+        worker_logs: Option<SignalWorker<LogsEventEncoder, LogsRequestEncoder>>,
+        otlp_traces: Option<emit_batcher::Sender<Channel>>,
+        worker_traces: Option<SignalWorker<TracesEventEncoder, TracesRequestEncoder>>,
+        otlp_metrics: Option<emit_batcher::Sender<Channel>>,
+        worker_metrics: Option<SignalWorker<MetricsEventEncoder, MetricsRequestEncoder>>,
         metrics: Arc<InternalMetrics>,
     ) -> Result<OtlpInner, Error> {
-        // Spawn the processors as fire-and-forget promises
-        if let Some((transport, receiver)) = process_otlp_logs {
-            let transport = Arc::new(transport);
+        let _ = metrics;
 
+        if let Some(worker) = worker_logs {
+            let (inner, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
-
-                async move { transport.send(batch).await }
+                let inner = inner.clone();
+                async move {
+                    inner
+                        .transport
+                        .send::<LogsEventEncoder>(&inner.event_encoder, batch)
+                        .await
+                }
             })
             .map_err(|e| Error::new("failed to spawn logs transport", e))?;
         }
 
-        if let Some((transport, receiver)) = process_otlp_traces {
-            let transport = Arc::new(transport);
-
+        if let Some(worker) = worker_traces {
+            let (inner, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
-
-                async move { transport.send(batch).await }
+                let inner = inner.clone();
+                async move {
+                    inner
+                        .transport
+                        .send::<TracesEventEncoder>(&inner.event_encoder, batch)
+                        .await
+                }
             })
             .map_err(|e| Error::new("failed to spawn traces transport", e))?;
         }
 
-        if let Some((transport, receiver)) = process_otlp_metrics {
-            let transport = Arc::new(transport);
-
+        if let Some(worker) = worker_metrics {
+            let (inner, receiver) = worker.into_receiver();
             emit_batcher::web::spawn(receiver, move |batch| {
-                let transport = transport.clone();
-
-                async move { transport.send(batch).await }
+                let inner = inner.clone();
+                async move {
+                    inner
+                        .transport
+                        .send::<MetricsEventEncoder>(&inner.event_encoder, batch)
+                        .await
+                }
             })
             .map_err(|e| Error::new("failed to spawn metrics transport", e))?;
         }
 
         Ok(OtlpInner {
-            otlp_logs,
-            otlp_traces,
-            otlp_metrics,
+            signals: SignalSenders::new(otlp_logs, otlp_traces, otlp_metrics),
             metrics,
-            _handle: (),
+            handle: None,
         })
     }
 }

--- a/emitter/otlp/src/client/web.rs
+++ b/emitter/otlp/src/client/web.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     Error,
     client::http::HttpConnection,
-    client::{Channel, OtlpBuilder, OtlpInner, SignalSenders, SignalWorker},
+    client::{Channel, OtlpBuilder, OtlpInner, SignalWorker},
     data::{
         logs::{LogsEventEncoder, LogsRequestEncoder},
         metrics::{MetricsEventEncoder, MetricsRequestEncoder},
@@ -63,7 +63,9 @@ impl OtlpBuilder {
         }
 
         Ok(OtlpInner {
-            signals: SignalSenders::new(otlp_logs, otlp_traces, otlp_metrics),
+            otlp_logs,
+            otlp_traces,
+            otlp_metrics,
             metrics,
             handle: None,
         })

--- a/emitter/otlp/src/client/web.rs
+++ b/emitter/otlp/src/client/web.rs
@@ -35,7 +35,9 @@ impl OtlpBuilder {
         if let Some(worker) = worker_logs {
             emit_batcher::web::spawn(worker.receiver, move |batch| {
                 let transport = worker.transport.clone();
-                async move { transport.send(batch).await }
+                let metrics = worker.metrics.clone();
+
+                async move { transport.send(batch, &metrics).await }
             })
             .map_err(|e| Error::new("failed to spawn logs transport", e))?;
         }
@@ -43,7 +45,9 @@ impl OtlpBuilder {
         if let Some(worker) = worker_traces {
             emit_batcher::web::spawn(worker.receiver, move |batch| {
                 let transport = worker.transport.clone();
-                async move { transport.send(batch).await }
+                let metrics = worker.metrics.clone();
+
+                async move { transport.send(batch, &metrics).await }
             })
             .map_err(|e| Error::new("failed to spawn traces transport", e))?;
         }
@@ -51,7 +55,9 @@ impl OtlpBuilder {
         if let Some(worker) = worker_metrics {
             emit_batcher::web::spawn(worker.receiver, move |batch| {
                 let transport = worker.transport.clone();
-                async move { transport.send(batch).await }
+                let metrics = worker.metrics.clone();
+
+                async move { transport.send(batch, &metrics).await }
             })
             .map_err(|e| Error::new("failed to spawn metrics transport", e))?;
         }

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -34,14 +34,20 @@ pub use self::{any_value::*, instrumentation_scope::*, resource::*};
 
 #[derive(Clone)]
 pub(crate) struct EncodedEvent {
-    pub scope: emit::Path<'static>,
-    pub payload: EncodedPayload,
+    scope: emit::Path<'static>,
+    payload: EncodedPayload,
+}
+
+impl EncodedEvent {
+    pub fn size_bytes(&self) -> usize {
+        self.payload.len()
+    }
 }
 
 pub(crate) trait EventEncoder {
     fn encode_event<E: RawEncoder>(
         &self,
-        evt: &emit::event::Event<impl emit::props::Props>,
+        evt: &emit::Event<impl emit::Props>,
     ) -> Option<EncodedEvent>;
 }
 
@@ -63,17 +69,21 @@ pub(crate) trait RawEncoder {
 #[derive(Default, Clone)]
 pub(crate) struct EncodedScopeItems {
     items: HashMap<emit::Path<'static>, Vec<EncodedPayload>>,
+    size_bytes: usize,
 }
 
 impl EncodedScopeItems {
     pub fn new() -> Self {
         EncodedScopeItems {
             items: HashMap::new(),
+            size_bytes: 0,
         }
     }
 
     pub fn push(&mut self, evt: EncodedEvent) {
         let entry = self.items.entry(evt.scope).or_default();
+
+        self.size_bytes += evt.payload.len();
         entry.push(evt.payload);
     }
 
@@ -87,6 +97,10 @@ impl EncodedScopeItems {
 
     pub fn items(&self) -> impl Iterator<Item = (emit::Path<'_>, &[EncodedPayload])> {
         self.items.iter().map(|(k, v)| (k.by_ref(), &**v))
+    }
+
+    pub fn total_size_bytes(&self) -> usize {
+        self.size_bytes
     }
 }
 
@@ -338,7 +352,7 @@ pub(crate) fn stream_field<'sval, S: sval::Stream<'sval> + ?Sized>(
 
 pub(crate) fn stream_attributes<'sval, S: sval::Stream<'sval> + ?Sized>(
     stream: &mut S,
-    props: &'sval impl emit::props::Props,
+    props: &'sval impl emit::Props,
     mut for_each: impl FnMut(
         AttributeStream<'_, S>,
         emit::str::Str<'sval>,
@@ -396,16 +410,16 @@ impl<'a, 'sval, S: sval::Stream<'sval> + ?Sized> AttributeStream<'a, S> {
     }
 }
 
-pub(crate) type MessageFormatter = dyn Fn(&emit::event::Event<&dyn emit::props::ErasedProps>, &mut fmt::Formatter) -> fmt::Result
+pub(crate) type MessageFormatter = dyn Fn(&emit::Event<&dyn emit::props::ErasedProps>, &mut fmt::Formatter) -> fmt::Result
     + Send
     + Sync;
 
 pub(crate) struct MessageRenderer<'a, P> {
     pub fmt: &'a MessageFormatter,
-    pub evt: &'a emit::event::Event<'a, P>,
+    pub evt: &'a emit::Event<'a, P>,
 }
 
-impl<'a, P: emit::props::Props> fmt::Display for MessageRenderer<'a, P> {
+impl<'a, P: emit::Props> fmt::Display for MessageRenderer<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (self.fmt)(&self.evt.erase(), f)
     }

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -32,6 +32,7 @@ use crate::Error;
 
 pub use self::{any_value::*, instrumentation_scope::*, resource::*};
 
+#[derive(Clone)]
 pub(crate) struct EncodedEvent {
     pub scope: emit::Path<'static>,
     pub payload: EncodedPayload,
@@ -59,7 +60,7 @@ pub(crate) trait RawEncoder {
     fn encode<V: sval::Value>(value: V) -> EncodedPayload;
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct EncodedScopeItems {
     items: HashMap<emit::Path<'static>, Vec<EncodedPayload>>,
 }

--- a/emitter/otlp/src/data.rs
+++ b/emitter/otlp/src/data.rs
@@ -96,11 +96,28 @@ impl EncodedScopeItems {
     }
 
     pub fn items(&self) -> impl Iterator<Item = (emit::Path<'_>, &[EncodedPayload])> {
-        self.items.iter().map(|(k, v)| (k.by_ref(), &**v))
+        self.items
+            .iter()
+            .filter(|(_, v)| v.len() > 0)
+            .map(|(k, v)| (k.by_ref(), &**v))
     }
 
     pub fn total_size_bytes(&self) -> usize {
         self.size_bytes
+    }
+
+    pub fn clear(&mut self) {
+        self.items.retain(|_, v| {
+            if v.len() == 0 {
+                // Remove any entries with no values in them
+                false
+            } else {
+                // Retain allocations of entries that had values
+                v.clear();
+                true
+            }
+        });
+        self.size_bytes = 0;
     }
 }
 

--- a/emitter/otlp/src/internal_metrics.rs
+++ b/emitter/otlp/src/internal_metrics.rs
@@ -81,6 +81,10 @@ metrics!(
             */
             event_discarded: Counter -> usize,
             /**
+            An event failed to encode so was discarded.
+            */
+            event_encoding_failed: Counter -> usize,
+            /**
             A connection to a remote OTLP receiver was established successfully.
             */
             transport_conn_established: Counter -> usize,

--- a/emitter/otlp/test/integration/src/main.rs
+++ b/emitter/otlp/test/integration/src/main.rs
@@ -136,9 +136,9 @@ fn assert_emitter(
     let output = otelcol.output();
 
     // Ensure the collector received and accepted the events we emitted
-    assert_exporter(&output, "LogsExporter", &log_uuid);
-    assert_exporter(&output, "TracesExporter", &span_uuid);
-    assert_exporter(&output, "MetricsExporter", &metric_uuid);
+    assert_exporter(&output, "Logs", &log_uuid);
+    assert_exporter(&output, "Traces", &span_uuid);
+    assert_exporter(&output, "Metrics", &metric_uuid);
 }
 
 fn assert_exporter(output: &str, exporter: &str, id: &str) {

--- a/emitter/otlp/test/throughput-otel/Cargo.toml
+++ b/emitter/otlp/test/throughput-otel/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "emit_otlp_test_throughput_otel"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[dependencies.opentelemetry]
+version = "0.32"
+features = ["logs"]
+
+[dependencies.opentelemetry_sdk]
+version = "0.32"
+features = ["trace", "logs"]
+
+[dependencies.opentelemetry-otlp]
+version = "0.32"
+default-features = false
+features = ["grpc-tonic", "trace", "logs"]
+
+[dependencies.tokio]
+version = "1"
+features = ["rt-multi-thread", "macros"]

--- a/emitter/otlp/test/throughput-otel/config.yaml
+++ b/emitter/otlp/test/throughput-otel/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:44319"
+
+exporters:
+  debug:
+    verbosity: basic
+    sampling_initial: 1
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/emitter/otlp/test/throughput-otel/src/main.rs
+++ b/emitter/otlp/test/throughput-otel/src/main.rs
@@ -1,0 +1,139 @@
+/*!
+A throughput test for emitting events via the OpenTelemetry SDK + OTLP gRPC exporter.
+
+This creates the same shape and frequency of spans/logs as `emit_otlp_test_throughput`, providing a baseline.
+*/
+
+use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
+use opentelemetry::trace::{Span, Tracer, TracerProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    Resource,
+    logs::{BatchConfigBuilder, BatchLogProcessor},
+    trace::{BatchConfigBuilder as TraceBatchConfigBuilder, BatchSpanProcessor},
+};
+
+use std::{
+    env,
+    process::{Child, Command},
+    time::Instant,
+};
+
+#[tokio::main]
+async fn main() {
+    let spawn = env::args().any(|a| a == "--spawn");
+    let do_flush = env::args().any(|a| a == "--flush");
+
+    let resource = Resource::builder_empty().build();
+
+    let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint("http://localhost:44319")
+        .build()
+        .expect("Failed to create span exporter");
+
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_endpoint("http://localhost:44319")
+        .build()
+        .expect("Failed to create log exporter");
+
+    // Queue and batch large enough to hold all events so none are dropped
+    let capacity = 20_000;
+
+    let span_processor = BatchSpanProcessor::builder(span_exporter)
+        .with_batch_config(
+            TraceBatchConfigBuilder::default()
+                .with_max_queue_size(capacity)
+                .with_max_export_batch_size(capacity)
+                .build(),
+        )
+        .build();
+
+    let log_processor = BatchLogProcessor::builder(log_exporter)
+        .with_batch_config(
+            BatchConfigBuilder::default()
+                .with_max_queue_size(capacity)
+                .with_max_export_batch_size(capacity)
+                .build(),
+        )
+        .build();
+
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(resource.clone())
+        .with_span_processor(span_processor)
+        .build();
+
+    let logger_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_resource(resource)
+        .with_log_processor(log_processor)
+        .build();
+
+    let otelcol = if spawn { Some(OtelCol::spawn()) } else { None };
+
+    let tracer = tracer_provider.tracer("otel-throughput-test");
+    let logger = logger_provider.logger("otel-throughput-test");
+
+    // Emit events
+    let count = 10_000;
+    let start = Instant::now();
+
+    root(&tracer, &logger, count);
+
+    if do_flush {
+        tracer_provider.force_flush().unwrap();
+        logger_provider.force_flush().unwrap();
+    }
+
+    let elapsed = start.elapsed();
+    let per_iteration = elapsed.as_nanos() as f64 / count as f64;
+
+    println!(
+        "{count} iterations ({:.2}ns per iteration), spawn: {}, flush: {}",
+        per_iteration, spawn, do_flush,
+    );
+
+    tracer_provider.shutdown().unwrap();
+    logger_provider.shutdown().unwrap();
+
+    drop(otelcol);
+}
+
+fn root(tracer: &impl Tracer, logger: &impl Logger, count: usize) {
+    let mut root_span = tracer.start("test root");
+    for i in 0..count {
+        run(tracer, logger, i);
+    }
+    root_span.end();
+}
+
+fn run(tracer: &impl Tracer, logger: &impl Logger, i: usize) {
+    let mut span = tracer.start(format!("test span {i}"));
+
+    let mut log_record = logger.create_log_record();
+    log_record.set_severity_number(Severity::Info);
+    log_record.set_severity_text("INFO");
+    log_record.set_body(AnyValue::String(format!("test event {i}").into()));
+    logger.emit(log_record);
+
+    span.end();
+}
+
+struct OtelCol(Child);
+
+impl Drop for OtelCol {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+impl OtelCol {
+    fn spawn() -> Self {
+        OtelCol(
+            Command::new("otelcol")
+                .args(["--config", "./config.yaml"])
+                .spawn()
+                .expect("Failed to spawn otelcol"),
+        )
+    }
+}

--- a/emitter/otlp/test/throughput/src/main.rs
+++ b/emitter/otlp/test/throughput/src/main.rs
@@ -4,13 +4,37 @@ A throughput test for emitting events via OTLP.
 This project doesn't prove much except what the on-thread cost of event serialization is like.
 */
 
-use emit::Emitter;
+use emit::{Clock, Emitter};
+use std::sync::LazyLock;
 
 use std::{
     env,
     process::{Child, Command},
     time::Duration,
 };
+
+// Concrete runtime to make `perf` output easier to follow
+static RUNTIME: LazyLock<
+    emit::runtime::Runtime<
+        emit_otlp::Otlp,
+        emit::Empty,
+        emit::platform::DefaultCtxt,
+        emit::platform::DefaultClock,
+        emit::platform::DefaultRng,
+    >,
+> = LazyLock::new(|| {
+    let emitter = emit_otlp::Otlp::builder()
+        .traces(emit_otlp::traces_grpc_proto("http://localhost:44319"))
+        .logs(emit_otlp::logs_grpc_proto("http://localhost:44319"))
+        .spawn();
+    emit::runtime::Runtime::build(
+        emitter,
+        emit::Empty,
+        emit::platform::DefaultCtxt::shared(),
+        emit::platform::DefaultClock::new(),
+        emit::platform::DefaultRng::new(),
+    )
+});
 
 fn main() {
     let stdout = emit_term::stdout();
@@ -19,42 +43,28 @@ fn main() {
     let flush = env::args().any(|a| a == "--flush");
 
     let mut reporter = emit::metric::Reporter::new();
-
-    // Set up `emit_otlp`
-    let rt = emit::setup()
-        .emit_to({
-            let emitter = emit_otlp::new()
-                .traces(emit_otlp::traces_grpc_proto("http://localhost:44319"))
-                .logs(emit_otlp::logs_grpc_proto("http://localhost:44319"))
-                .spawn();
-
-            reporter.add_source(emitter.metric_source());
-
-            emitter
-        })
-        .init();
+    reporter.add_source(RUNTIME.emitter().metric_source());
 
     let otelcol = if spawn { Some(OtelCol::spawn()) } else { None };
 
     // Emit our events
     let count = 10_000;
-    let start = emit::clock().now().unwrap();
+    let start = RUNTIME.clock().now().unwrap();
 
     root(count);
 
     if flush {
-        rt.blocking_flush(Duration::from_secs(30));
+        RUNTIME.blocking_flush(Duration::from_secs(30));
     }
 
-    let end = emit::clock().now().unwrap();
+    let end = RUNTIME.clock().now().unwrap();
 
     // Write the results
-    let per_event = (end - start).as_nanos() as f64 / count as f64;
-
     stdout.emit(&emit::evt!(
         extent: start..end,
-        "emitted {count} events ({per_event}ns per run) with spawn {spawn} and flush {flush}",
+        "{count} iterations ({per_iteration}ns per iteration) with spawn {spawn} and flush {flush}",
         evt_kind: "span",
+        per_iteration: (end - start).as_nanos() as f64 / count as f64,
     ));
 
     reporter.emit_metrics(&stdout);
@@ -62,16 +72,16 @@ fn main() {
     drop(otelcol);
 }
 
-#[emit::span("test root")]
+#[emit::span(rt: &RUNTIME, "test root")]
 fn root(count: usize) {
     for i in 0..count {
         run(i);
     }
 }
 
-#[emit::span("test span {i}")]
+#[emit::span(rt: &RUNTIME, "test span {i}")]
 fn run(i: usize) {
-    emit::info!("test event {i}");
+    emit::info!(rt: &RUNTIME, "test event {i}");
 }
 
 struct OtelCol(Child);

--- a/macros/src/capture.rs
+++ b/macros/src/capture.rs
@@ -142,9 +142,7 @@ pub fn rename_hook_tokens(
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |hook_args: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/macros/src/nullable.rs
+++ b/macros/src/nullable.rs
@@ -25,9 +25,7 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -25,9 +25,7 @@ pub fn rename_hook_tokens(opts: RenameHookTokens) -> Result<TokenStream, syn::Er
         target: "values in `emit` macros",
         args: opts.args,
         expr: opts.expr,
-        predicate: |ident: &str| {
-            ident.starts_with("__private_capture")
-        },
+        predicate: |ident: &str| ident.starts_with("__private_capture"),
         to: move |_: &Args, ident: &Ident, args: &Punctuated<Expr, Comma>| {
             if ident == "__private_captured" {
                 return None;

--- a/macros/src/props.rs
+++ b/macros/src/props.rs
@@ -175,6 +175,8 @@ impl Props {
         let mut new_fvs = Vec::new();
         let mut new_ctor_args = Vec::new();
 
+        let nprops = self.key_values.len();
+
         for kv in self.key_values.values() {
             let input_field = kv.fv.key_ident()?;
 
@@ -305,6 +307,10 @@ impl Props {
                         #(#impl_for_each)*
 
                         emit::__private::core::ops::ControlFlow::Continue(())
+                    }
+
+                    fn size(&self) -> Option<usize> {
+                        Some(#nprops)
                     }
 
                     // TODO: detect `is_sorted` through `key_as()` calls

--- a/src/macro_hooks.rs
+++ b/src/macro_hooks.rs
@@ -1358,4 +1358,8 @@ impl<P: Props, T: Props> Props for __PrivateMacroExtendedProps<P, T> {
 
         self.1.get(key.by_ref()).or_else(|| self.0.get(key))
     }
+
+    fn size(&self) -> Option<usize> {
+        Some(self.0.size()? + self.1.size()?)
+    }
 }

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -131,6 +131,14 @@ impl Props for ThreadLocalCtxtFrame {
     fn is_unique(&self) -> bool {
         true
     }
+
+    fn size(&self) -> Option<usize> {
+        if let Some(ref props) = self.props {
+            Some(props.len())
+        } else {
+            Some(0)
+        }
+    }
 }
 
 impl Ctxt for ThreadLocalCtxt {

--- a/src/platform/thread_local_ctxt.rs
+++ b/src/platform/thread_local_ctxt.rs
@@ -14,8 +14,9 @@ use emit_core::{
     ctxt::Ctxt,
     props::Props,
     runtime::InternalCtxt,
-    str::Str,
-    value::{OwnedValue, ToValue, Value},
+    str::{Str, ToStr},
+    value::{FromValue, OwnedValue, ToValue, Value},
+    well_known,
 };
 
 use crate::span::{SpanId, TraceId};
@@ -55,58 +56,36 @@ impl ThreadLocalCtxt {
 /**
 A [`Ctxt::Frame`] on a [`ThreadLocalCtxt`].
 */
-#[derive(Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ThreadLocalCtxtFrame {
-    props: Option<Arc<HashMap<Str<'static>, ThreadLocalValue>>>,
+    // Store common contextual properties inline
+    trace_id: Option<TraceId>,
+    span_parent: Option<SpanId>,
+    span_id: Option<SpanId>,
+    generation: usize,
+    // Store other properties in a map
+    any_fallback: bool,
+    rest: Option<Arc<HashMap<Str<'static>, ThreadLocalValue<OwnedValue>>>>,
+}
+
+#[derive(Debug, Clone)]
+struct ThreadLocalValue<T> {
+    inner: T,
     generation: usize,
 }
 
-#[derive(Clone)]
-struct ThreadLocalValue {
-    inner: ThreadLocalValueInner,
-    generation: usize,
-}
-
-#[derive(Clone)]
-enum ThreadLocalValueInner {
-    TraceId(TraceId),
-    SpanId(SpanId),
-    Any(OwnedValue),
-}
-
-impl ThreadLocalValue {
+impl ThreadLocalValue<OwnedValue> {
     fn from_value(generation: usize, value: Value) -> Self {
-        // Specialize a few common value types
-
-        if let Some(trace_id) = value.downcast_ref() {
-            return ThreadLocalValue {
-                inner: ThreadLocalValueInner::TraceId(*trace_id),
-                generation,
-            };
-        }
-
-        if let Some(span_id) = value.downcast_ref() {
-            return ThreadLocalValue {
-                inner: ThreadLocalValueInner::SpanId(*span_id),
-                generation,
-            };
-        }
-
-        // Fall back to buffering
         ThreadLocalValue {
-            inner: ThreadLocalValueInner::Any(value.to_shared()),
+            inner: value.to_shared(),
             generation,
         }
     }
 }
 
-impl ToValue for ThreadLocalValue {
+impl<T: ToValue> ToValue for ThreadLocalValue<T> {
     fn to_value(&self) -> Value<'_> {
-        match self.inner {
-            ThreadLocalValueInner::TraceId(ref value) => value.to_value(),
-            ThreadLocalValueInner::SpanId(ref value) => value.to_value(),
-            ThreadLocalValueInner::Any(ref value) => value.to_value(),
-        }
+        self.inner.to_value()
     }
 }
 
@@ -115,8 +94,29 @@ impl Props for ThreadLocalCtxtFrame {
         &'a self,
         mut for_each: F,
     ) -> ControlFlow<()> {
-        if let Some(ref props) = self.props {
-            for (k, v) in &**props {
+        use ToValue as _;
+
+        let Self {
+            trace_id,
+            span_parent,
+            span_id,
+            rest,
+            any_fallback: _,
+            generation: _,
+        } = self;
+
+        if let Some(trace_id) = trace_id {
+            for_each(well_known::KEY_TRACE_ID.to_str(), trace_id.to_value())?;
+        }
+        if let Some(span_parent) = span_parent {
+            for_each(well_known::KEY_SPAN_PARENT.to_str(), span_parent.to_value())?;
+        }
+        if let Some(span_id) = span_id {
+            for_each(well_known::KEY_SPAN_ID.to_str(), span_id.to_value())?;
+        }
+
+        if let Some(rest) = rest {
+            for (k, v) in rest.iter() {
                 for_each(k.by_ref(), v.to_value())?;
             }
         }
@@ -124,20 +124,44 @@ impl Props for ThreadLocalCtxtFrame {
         ControlFlow::Continue(())
     }
 
-    fn get<'v, K: emit_core::str::ToStr>(&'v self, key: K) -> Option<Value<'v>> {
-        self.props.as_ref().and_then(|props| props.get(key))
+    fn get<'v, K: ToStr>(&'v self, key: K) -> Option<Value<'v>> {
+        use ToValue as _;
+
+        let Self {
+            trace_id,
+            span_parent,
+            span_id,
+            rest,
+            any_fallback: _,
+            generation: _,
+        } = self;
+
+        let key = key.to_str();
+
+        match key.get() {
+            well_known::KEY_TRACE_ID => {
+                if let Some(trace_id) = trace_id {
+                    return Some(trace_id.to_value());
+                }
+            }
+            well_known::KEY_SPAN_ID => {
+                if let Some(span_id) = span_id {
+                    return Some(span_id.to_value());
+                }
+            }
+            well_known::KEY_SPAN_PARENT => {
+                if let Some(span_parent) = span_parent {
+                    return Some(span_parent.to_value());
+                }
+            }
+            _ => (),
+        }
+
+        rest.as_ref().and_then(|rest| Props::get(&**rest, key))
     }
 
     fn is_unique(&self) -> bool {
         true
-    }
-
-    fn size(&self) -> Option<usize> {
-        if let Some(ref props) = self.props {
-            Some(props.len())
-        } else {
-            Some(0)
-        }
     }
 }
 
@@ -151,53 +175,18 @@ impl Ctxt for ThreadLocalCtxt {
     }
 
     fn open_root<P: Props>(&self, props: P) -> Self::Frame {
-        let mut span = HashMap::new();
-        let generation = 0;
+        let mut frame = ThreadLocalCtxtFrame::default();
 
-        let _ = props.for_each(|k, v| {
-            span.entry(k.to_shared())
-                .or_insert_with(|| ThreadLocalValue::from_value(generation, v));
+        open_frame(&mut frame, props);
 
-            ControlFlow::Continue(())
-        });
-
-        ThreadLocalCtxtFrame {
-            props: Some(Arc::new(span)),
-            generation,
-        }
+        frame
     }
 
     fn open_push<P: Props>(&self, props: P) -> Self::Frame {
         let mut span = current(self.id);
+        span.generation = span.generation.wrapping_add(1);
 
-        if span.props.is_none() {
-            span.props = Some(Arc::new(HashMap::new()));
-        }
-
-        let generation = span.generation.wrapping_add(1);
-        span.generation = generation;
-
-        let span_props = Arc::make_mut(span.props.as_mut().unwrap());
-
-        let _ = props.for_each(|k, v| {
-            match span_props.entry(k.to_shared()) {
-                hash_map::Entry::Vacant(entry) => {
-                    // If the map doesn't already contain this property then insert it
-                    entry.insert(ThreadLocalValue::from_value(generation, v));
-                }
-                hash_map::Entry::Occupied(mut entry) => {
-                    let entry = entry.get_mut();
-
-                    if entry.generation != generation {
-                        // If the map does contain this property, and it's from a different generation
-                        // then overwrite it, otherwise keep the value that's already there
-                        *entry = ThreadLocalValue::from_value(generation, v);
-                    }
-                }
-            }
-
-            ControlFlow::Continue(())
-        });
+        open_frame(&mut span, props);
 
         span
     }
@@ -215,6 +204,176 @@ impl Ctxt for ThreadLocalCtxt {
 
 impl InternalCtxt for ThreadLocalCtxt {}
 
+fn open_frame<P: Props>(span: &mut ThreadLocalCtxtFrame, props: P) {
+    struct InlineSetter<'a, T> {
+        seen: bool,
+        slot: &'a mut Option<T>,
+    }
+
+    impl<'a, 'b, T: FromValue<'b>> InlineSetter<'a, T> {
+        #[inline]
+        fn new(slot: &'a mut Option<T>) -> Self {
+            InlineSetter { seen: false, slot }
+        }
+
+        #[inline]
+        fn try_set(&mut self, v: Value<'b>) -> bool {
+            if self.seen {
+                // Short-circuit if we've already set the property
+                return true;
+            }
+
+            self.seen = true;
+
+            if let Some(val) = v.cast() {
+                *self.slot = Some(val);
+
+                true
+            } else {
+                *self.slot = None;
+
+                false
+            }
+        }
+
+        #[inline]
+        fn is_inline(&self) -> bool {
+            self.seen && self.slot.is_some()
+        }
+    }
+
+    struct RestSetter<'a> {
+        slot: &'a mut Option<Arc<HashMap<Str<'static>, ThreadLocalValue<OwnedValue>>>>,
+        incoming: Option<HashMap<Str<'static>, ThreadLocalValue<OwnedValue>>>,
+    }
+
+    impl<'a> RestSetter<'a> {
+        #[inline]
+        fn new(
+            slot: &'a mut Option<Arc<HashMap<Str<'static>, ThreadLocalValue<OwnedValue>>>>,
+        ) -> Self {
+            RestSetter {
+                slot,
+                incoming: None,
+            }
+        }
+
+        #[inline]
+        fn get_or_insert(&mut self) -> &mut HashMap<Str<'static>, ThreadLocalValue<OwnedValue>> {
+            self.incoming.get_or_insert_with(|| {
+                self.slot
+                    .take()
+                    .map(|slot| (*slot).clone())
+                    .unwrap_or_else(HashMap::new)
+            })
+        }
+
+        #[inline]
+        fn set(self) {
+            *self.slot = self
+                .incoming
+                .map(|incoming| Arc::new(incoming))
+                .or_else(|| self.slot.take())
+        }
+    }
+
+    let mut trace_id = InlineSetter::new(&mut span.trace_id);
+    let mut span_id = InlineSetter::new(&mut span.span_id);
+    let mut span_parent = InlineSetter::new(&mut span.span_parent);
+    let mut incoming = RestSetter::new(&mut span.rest);
+
+    let _ = props.for_each(|k, v| {
+        let mut fallback = false;
+
+        match k.get() {
+            // Set specialized properties inline
+            well_known::KEY_TRACE_ID => {
+                if trace_id.try_set(v.by_ref()) {
+                    return ControlFlow::Continue(());
+                } else {
+                    fallback = true;
+                }
+            }
+            well_known::KEY_SPAN_ID => {
+                if span_id.try_set(v.by_ref()) {
+                    return ControlFlow::Continue(());
+                } else {
+                    fallback = true;
+                }
+            }
+            well_known::KEY_SPAN_PARENT => {
+                if span_parent.try_set(v.by_ref()) {
+                    return ControlFlow::Continue(());
+                } else {
+                    fallback = true;
+                }
+            }
+            // Fall-through to buffering in `rest`
+            _ => (),
+        }
+
+        // NOTE: We only construct a map if we actually need one, but unconditionally clone the parent
+        // because we'll never hold the only strong reference to the `Arc`
+        let map = incoming.get_or_insert();
+
+        match map.entry(k.to_shared()) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(ThreadLocalValue::from_value(span.generation, v));
+                span.any_fallback |= fallback;
+            }
+            hash_map::Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+
+                // If the existing entry is for a previous generation then overwrite it
+                if entry.generation != span.generation {
+                    *entry = ThreadLocalValue::from_value(span.generation, v);
+                    span.any_fallback |= fallback;
+                }
+            }
+        }
+
+        ControlFlow::Continue(())
+    });
+
+    // Unset any inline properties in the fallback set
+    if span.any_fallback {
+        let map = incoming.get_or_insert();
+
+        let mut fallback = false;
+        map.retain(|k, _| match k.get() {
+            well_known::KEY_TRACE_ID => {
+                if !trace_id.is_inline() {
+                    fallback = true;
+                    true
+                } else {
+                    false
+                }
+            }
+            well_known::KEY_SPAN_ID => {
+                if !span_id.is_inline() {
+                    fallback = true;
+                    true
+                } else {
+                    false
+                }
+            }
+            well_known::KEY_SPAN_PARENT => {
+                if !span_parent.is_inline() {
+                    fallback = true;
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => true,
+        });
+
+        span.any_fallback = fallback;
+    }
+
+    incoming.set();
+}
+
 // Start this id from 1 so it doesn't intersect with the `shared` variant below
 static NEXT_CTXT_ID: Mutex<usize> = Mutex::new(1);
 
@@ -227,33 +386,39 @@ fn ctxt_id() -> usize {
 }
 
 thread_local! {
+    // Specialize the shared context to avoid unnecessary map lookups
+    static SHARED: RefCell<ThreadLocalCtxtFrame> = RefCell::new(ThreadLocalCtxtFrame::default());
     static ACTIVE: RefCell<HashMap<usize, ThreadLocalCtxtFrame>> = RefCell::new(HashMap::new());
 }
 
 fn current(id: usize) -> ThreadLocalCtxtFrame {
-    ACTIVE.with(|active| {
-        active
-            .borrow_mut()
-            .entry(id)
-            .or_insert_with(|| ThreadLocalCtxtFrame {
-                props: None,
-                generation: 0,
-            })
-            .clone()
-    })
+    if id == 0 {
+        SHARED.with(|f| f.borrow().clone())
+    } else {
+        ACTIVE.with(|active| {
+            active
+                .borrow_mut()
+                .entry(id)
+                .or_insert_with(ThreadLocalCtxtFrame::default)
+                .clone()
+        })
+    }
 }
 
 fn swap(id: usize, incoming: &mut ThreadLocalCtxtFrame) {
-    ACTIVE.with(|active| {
-        let mut active = active.borrow_mut();
+    if id == 0 {
+        SHARED.with(|f| mem::swap(&mut *f.borrow_mut(), incoming));
+    } else {
+        ACTIVE.with(|active| {
+            let mut active = active.borrow_mut();
 
-        let current = active.entry(id).or_insert_with(|| ThreadLocalCtxtFrame {
-            props: None,
-            generation: 0,
-        });
+            let current = active
+                .entry(id)
+                .or_insert_with(ThreadLocalCtxtFrame::default);
 
-        mem::swap(current, incoming);
-    })
+            mem::swap(current, incoming);
+        })
+    }
 }
 
 #[cfg(test)]
@@ -268,10 +433,10 @@ mod tests {
     use wasm_bindgen_test::*;
 
     impl ThreadLocalCtxtFrame {
-        fn props(&self) -> HashMap<Str<'static>, ThreadLocalValue> {
-            self.props
+        fn rest_props(&self) -> HashMap<Str<'static>, ThreadLocalValue<OwnedValue>> {
+            self.rest
                 .as_ref()
-                .map(|props| (**props).clone())
+                .map(|rest| (**rest).clone())
                 .unwrap_or_default()
         }
     }
@@ -305,24 +470,24 @@ mod tests {
         let ctxt = ThreadLocalCtxt::new();
 
         ctxt.clone().with_current(|props| {
-            assert_eq!(0, props.props().len());
+            assert_eq!(0, props.rest_props().len());
         });
 
         let mut frame = ctxt.clone().open_push(("a", 1));
 
-        assert_eq!(1, frame.props().len());
+        assert_eq!(1, frame.rest_props().len());
         ctxt.clone().with_current(|props| {
-            assert_eq!(0, props.props().len());
+            assert_eq!(0, props.rest_props().len());
         });
 
         ctxt.clone().enter(&mut frame);
 
-        assert_eq!(0, frame.props().len());
+        assert_eq!(0, frame.rest_props().len());
 
         let mut inner = ctxt.clone().open_push([("b", 1), ("a", 2)]);
 
         ctxt.clone().with_current(|props| {
-            let props = props.props();
+            let props = props.rest_props();
 
             assert_eq!(1, props.len());
             assert_eq!(1, props["a"].to_value().cast::<i32>().unwrap());
@@ -331,7 +496,7 @@ mod tests {
         ctxt.clone().enter(&mut inner);
 
         ctxt.clone().with_current(|props| {
-            let props = props.props();
+            let props = props.rest_props();
 
             assert_eq!(2, props.len());
             assert_eq!(2, props["a"].to_value().cast::<i32>().unwrap());
@@ -342,9 +507,9 @@ mod tests {
 
         ctxt.clone().exit(&mut frame);
 
-        assert_eq!(1, frame.props().len());
+        assert_eq!(1, frame.rest_props().len());
         ctxt.clone().with_current(|props| {
-            assert_eq!(0, props.props().len());
+            assert_eq!(0, props.rest_props().len());
         });
     }
 
@@ -353,24 +518,18 @@ mod tests {
         let ctxt = ThreadLocalCtxt::new();
 
         ctxt.clone().with_current(|props| {
-            assert_eq!(0, props.props().len());
+            assert_eq!(0, props.rest_props().len());
         });
 
         let mut frame = ctxt.clone().open_push([("a", 1), ("a", 2)]);
 
-        assert_eq!(
-            "1",
-            frame.props.as_ref().unwrap()["a"].to_value().to_string()
-        );
+        assert_eq!("1", frame.rest_props()["a"].to_value().to_string());
 
         ctxt.enter(&mut frame);
 
         let inner = ctxt.clone().open_push([("a", 2), ("a", 3)]);
 
-        assert_eq!(
-            "2",
-            inner.props.as_ref().unwrap()["a"].to_value().to_string()
-        );
+        assert_eq!("2", inner.rest_props()["a"].to_value().to_string());
 
         ctxt.exit(&mut frame);
     }
@@ -404,11 +563,11 @@ mod tests {
         ctxt_a.enter(&mut frame_a);
 
         ctxt_a.with_current(|props| {
-            assert_eq!(1, props.props().len());
+            assert_eq!(1, props.rest_props().len());
         });
 
         ctxt_b.with_current(|props| {
-            assert_eq!(0, props.props().len());
+            assert_eq!(0, props.rest_props().len());
         });
 
         ctxt_a.exit(&mut frame_a);
@@ -430,7 +589,7 @@ mod tests {
 
             move || {
                 ctxt.with_current(|props| {
-                    assert_eq!(0, props.props().len());
+                    assert_eq!(0, props.rest_props().len());
                 });
             }
         })
@@ -446,7 +605,7 @@ mod tests {
                 ctxt.enter(&mut current);
 
                 ctxt.with_current(|props| {
-                    assert_eq!(1, props.props().len());
+                    assert_eq!(1, props.rest_props().len());
                 });
 
                 ctxt.exit(&mut current);
@@ -454,5 +613,93 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn inline_props() {
+        use emit_core::props::Props as _;
+
+        let ctxt = ThreadLocalCtxt::new();
+
+        let mut frame = ctxt.clone().open_push(
+            (well_known::KEY_TRACE_ID, TraceId::from_u128(42).unwrap())
+                .and_props((well_known::KEY_SPAN_ID, SpanId::from_u64(1).unwrap()))
+                .and_props(("a", 1)),
+        );
+
+        assert_eq!(1, frame.rest_props().len());
+        assert_eq!(Some(TraceId::from_u128(42).unwrap()), frame.trace_id);
+        assert_eq!(Some(SpanId::from_u64(1).unwrap()), frame.span_id);
+
+        assert_eq!(
+            Some(TraceId::from_u128(42).unwrap()),
+            frame.pull::<TraceId, _>(well_known::KEY_TRACE_ID)
+        );
+        assert_eq!(
+            Some(SpanId::from_u64(1).unwrap()),
+            frame.pull::<SpanId, _>(well_known::KEY_SPAN_ID)
+        );
+        assert_eq!(Some(1), frame.pull::<i32, _>("a"));
+
+        assert!(!frame.any_fallback);
+
+        // Add more props
+        ctxt.enter(&mut frame);
+        {
+            let frame = ctxt.clone().open_push(
+                (well_known::KEY_TRACE_ID, TraceId::from_u128(43).unwrap())
+                    .and_props((well_known::KEY_SPAN_PARENT, SpanId::from_u64(1).unwrap()))
+                    .and_props(("b", 2)),
+            );
+
+            assert_eq!(2, frame.rest_props().len());
+            assert_eq!(Some(1), frame.pull::<i32, _>("a"));
+            assert_eq!(Some(2), frame.pull::<i32, _>("b"));
+
+            assert_eq!(Some(TraceId::from_u128(43).unwrap()), frame.trace_id);
+            assert_eq!(Some(SpanId::from_u64(1).unwrap()), frame.span_parent);
+            assert_eq!(Some(SpanId::from_u64(1).unwrap()), frame.span_id);
+
+            assert!(!frame.any_fallback);
+        }
+        ctxt.exit(&mut frame);
+
+        // Replace an inline prop with a fallback
+        ctxt.enter(&mut frame);
+        {
+            let mut frame = ctxt.clone().open_push(
+                (well_known::KEY_TRACE_ID, true)
+                    .and_props((well_known::KEY_SPAN_PARENT, SpanId::from_u64(1).unwrap())),
+            );
+
+            assert_eq!(2, frame.rest_props().len());
+            assert_eq!(Some(1), frame.pull::<i32, _>("a"));
+            assert_eq!(Some(true), frame.pull::<bool, _>(well_known::KEY_TRACE_ID));
+
+            assert_eq!(None, frame.trace_id);
+            assert_eq!(Some(SpanId::from_u64(1).unwrap()), frame.span_parent);
+
+            assert!(frame.any_fallback);
+
+            // Replace a fallback prop with an inline
+            ctxt.enter(&mut frame);
+            {
+                let frame = ctxt.clone().open_push(
+                    (well_known::KEY_TRACE_ID, TraceId::from_u128(43).unwrap())
+                        .and_props((well_known::KEY_SPAN_ID, SpanId::from_u64(2).unwrap())),
+                );
+
+                assert_eq!(1, frame.rest_props().len());
+                assert_eq!(Some(1), frame.pull::<i32, _>("a"));
+
+                assert_eq!(Some(TraceId::from_u128(43).unwrap()), frame.trace_id);
+                assert_eq!(Some(SpanId::from_u64(1).unwrap()), frame.span_parent);
+                assert_eq!(Some(SpanId::from_u64(2).unwrap()), frame.span_id);
+
+                assert!(!frame.any_fallback);
+            }
+            ctxt.exit(&mut frame);
+        }
+        ctxt.exit(&mut frame);
     }
 }


### PR DESCRIPTION
Closes #267 

This PR refactors `emit_otlp`'s channel to send owned events instead of pre-encoded buffers, deferring serialization to the background worker thread. This reduces the on-thread cost of `emit_otlp`, but increases the overall time to send and process events.

There's work to do to claw some of that perf back on the worker thread, by not throwing away previously serialized events on retries, re-using more allocations, improving the `HashMap` -> `Vec` conversion we do to go from cheap lookup to cheap iteration, etc.

The internals of `emit_otlp`'s client have also been refactored to make HTTP mocking easier, which we may expose as a public feature down the track.

-----

**AI Disclosure:** This work was assisted by local agentic tooling. I've reviewed and further modified the result.