### PR TITLE
Update to syn 3

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -29,7 +29,7 @@ version = "1"
 version = "1"
 
 [dependencies.syn]
-version = "2"
+version = "3"
 features = ["full", "extra-traits", "visit-mut"]
 
 [dependencies.emit_core]
@@ -37,4 +37,4 @@ version = "1.22.1"
 path = "../core"
 
 [dependencies.fv-template]
-version = "0.6"
+version = "0.7"

--- a/macros/src/hook.rs
+++ b/macros/src/hook.rs
@@ -116,8 +116,7 @@ impl Parse for Hook {
 
         let expr = items
             .pop()
-            .ok_or_else(|| syn::Error::new(input.span(), "missing expression"))?
-            .into_value();
+            .ok_or_else(|| syn::Error::new(input.span(), "missing expression"))?;
 
         if !items.is_empty() {
             return Err(syn::Error::new(


### PR DESCRIPTION
This PR updates to `syn` `3.0`, which doesn't require any breaking changes in `emit` itself.