### PR TITLE
Rework emit_otlp background thread infra for better responsiveness

### DIFF
--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -130,6 +130,7 @@ Use [`tokio::spawn`] or [`sync::spawn`] to run the receiver-side of the channel.
 pub fn bounded<T: Channel>(max_capacity: usize) -> (Sender<T>, Receiver<T>) {
     let shared = Arc::new(Shared {
         metrics: Default::default(),
+        receiver_notifier: ReceiverNotifier::new(),
         state: Mutex::new(State {
             next_batch: Batch::new(),
             is_open: true,
@@ -171,6 +172,11 @@ pub struct Sender<T> {
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         self.shared.state.lock().unwrap().is_open = false;
+
+        // Wake the receiver so it can process any last batch and shut down
+        // promptly instead of discovering the closed channel on its next
+        // scheduled wakeup
+        self.shared.receiver_notifier.notify();
     }
 }
 
@@ -197,6 +203,17 @@ impl<T: Channel> Sender<T> {
         }
 
         state.next_batch.channel.push(msg);
+
+        let len = state.next_batch.channel.len();
+        drop(state);
+
+        // If the channel is filling up then wake the receiver so it has a
+        // chance to process a batch before the channel overflows and truncates.
+        // This only fires once as the length crosses the threshold, so a receiver
+        // that can't keep up isn't repeatedly woken
+        if len == self.notify_threshold() {
+            self.shared.receiver_notifier.notify();
+        }
     }
 
     /**
@@ -215,10 +232,23 @@ impl<T: Channel> Sender<T> {
         if state.next_batch.channel.len() < self.max_capacity {
             state.next_batch.channel.push(msg);
 
+            let len = state.next_batch.channel.len();
+            drop(state);
+
+            // If the channel is filling up then wake the receiver so it has a
+            // chance to process a batch before the channel fills completely
+            if len == self.notify_threshold() {
+                self.shared.receiver_notifier.notify();
+            }
+
             Ok(())
         } else {
             Err(BatchError::retry(TrySendError("the channel is full"), msg))
         }
+    }
+
+    fn notify_threshold(&self) -> usize {
+        cmp::max(1, self.max_capacity / 2)
     }
 
     async fn send_or_wait<'a, FWait: Future<Output = ()> + 'a>(
@@ -260,47 +290,76 @@ impl<T: Channel> Sender<T> {
     /**
     Set a callback to fire when the next batch is taken.
 
-    The watcher is guaranteed to trigger at a point where the current batch is empty.
+    The callback is guaranteed to trigger at a point where the current batch is empty, or when the channel is closed and the batch will never be taken.
     */
     pub fn when_empty(&self, f: impl FnOnce() + Send + 'static) {
         let mut state = self.shared.state.lock().unwrap();
 
         // If:
-        // - The next batch is empty
+        // - The next batch is empty (there's nothing to wait for) or
+        // - the channel is closed (the batch will never be taken)
         // Then:
-        // - Call the watcher without scheduling it; there's nothing to wait for
-        if state.next_batch.channel.is_empty() {
+        // - Call the callback without scheduling it
+        if state.next_batch.channel.is_empty() || !state.is_open {
             drop(state);
 
             f();
         } else {
-            state.next_batch.watchers.push_on_take(Box::new(f));
+            state.next_batch.notifiers.push_on_take(Box::new(f));
+            drop(state);
+
+            // Notify the receiver so the callback triggers as soon as the batch
+            // is taken rather than on the receiver's next scheduled wakeup
+            self.shared.receiver_notifier.notify();
         }
     }
 
     /**
     Set a callback to fire when all items in the active batch are processed by the [`Receiver`].
 
-    The watcher is guaranteed to trigger at a point where the batch that was processing at the time this call was made has completed.
+    The callback is guaranteed to trigger at a point where the batch that was processing at the time this call was made has completed, whether or not processing succeeded. To observe the outcome of the flush, use [`sync::blocking_flush`] or one of its asynchronous variants instead.
     */
     pub fn when_flushed(&self, f: impl FnOnce() + Send + 'static) {
+        self.when_flushed_inner(move |_| f())
+    }
+
+    fn when_flushed_inner(&self, f: impl FnOnce(bool) + Send + 'static) {
         let mut state = self.shared.state.lock().unwrap();
 
-        // If:
-        // - We're not in a batch and
-        //   - the next batch is empty (there's no data) or
-        //   - the state is closed
-        // Then:
-        // - Call the watcher without scheduling it; there's nothing to flush
-        if !state.is_in_batch && (state.next_batch.channel.is_empty() || !state.is_open) {
-            // Drop the lock before signalling the watcher
+        // If there's no batch being processed and nothing pending then
+        // there's nothing to flush; the flush is trivially successful
+        if !state.is_in_batch && state.next_batch.channel.is_empty() {
+            // Drop the lock before signaling the callback
             drop(state);
 
-            f();
+            f(true);
         }
-        // If there's active data to flush then schedule the watcher
+        // If the channel is closed then anything pending will never be
+        // processed; the flush has failed
+        else if !state.is_open {
+            // Drop the lock before signaling the callback
+            drop(state);
+
+            f(false);
+        }
+        // If there's active data to flush then schedule the callback
         else {
-            state.next_batch.watchers.push_on_flush(Box::new(f));
+            // If a batch is currently being processed then the caller's items
+            // may be split between it and the next batch, so the outcome needs
+            // to cover both
+            let requires_in_flight = state.is_in_batch;
+
+            state
+                .next_batch
+                .notifiers
+                .push_on_flush(requires_in_flight, Box::new(f));
+
+            // Drop the lock before signaling the receiver
+            drop(state);
+
+            // Wake the receiver so the flush starts immediately rather than
+            // on the receiver's next scheduled wakeup
+            self.shared.receiver_notifier.notify();
         }
     }
 
@@ -387,14 +446,28 @@ impl<T: Channel> Receiver<T> {
         FBatch: Future<Output = Result<(), BatchError<T>>>,
         FWait: Future<Output = ()>,
     >(
-        mut self,
+        self,
         mut wait: impl FnMut(Duration) -> FWait,
+        on_batch: impl FnMut(T) -> FBatch,
+    ) {
+        self.exec_inner(move |_, delay| wait(delay), on_batch).await
+    }
+
+    pub(crate) async fn exec_inner<
+        FBatch: Future<Output = Result<(), BatchError<T>>>,
+        FWait: Future<Output = ()>,
+    >(
+        mut self,
+        mut wait: impl FnMut(Wait, Duration) -> FWait,
         mut on_batch: impl FnMut(T) -> FBatch,
     ) {
         // This variable holds the "next" batch
         // Under the lock all we do is push onto a pre-allocated vec
         // and replace it with another pre-allocated vec
         let mut next_batch = Batch::new();
+
+        // Whether the last *non-empty* batch was processed successfully
+        let mut last_batch_flushed = true;
 
         loop {
             // Pre-take barrier: wait here before batch is taken
@@ -418,17 +491,17 @@ impl<T: Channel> Receiver<T> {
                         state.is_open,
                     )
                 }
-                // If there are no events to emit then mark that we're outside of a batch and take its watchers
+                // If there are no events to emit then mark that we're outside of a batch and take its notifiers
                 else {
                     state.is_in_batch = false;
 
-                    let watchers = mem::take(&mut state.next_batch.watchers);
+                    let notifiers = mem::take(&mut state.next_batch.notifiers);
                     let open = state.is_open;
 
                     (
                         Batch {
                             channel: T::new(),
-                            watchers,
+                            notifiers,
                         },
                         open,
                     )
@@ -436,7 +509,7 @@ impl<T: Channel> Receiver<T> {
             };
 
             // Run outside of the lock
-            current_batch.watchers.notify_on_take();
+            current_batch.notifiers.notify_on_take();
 
             // Post-take barrier: wait here after batch is taken
             #[cfg(all(not(target_arch = "wasm32"), test))]
@@ -450,8 +523,12 @@ impl<T: Channel> Receiver<T> {
                 // Re-allocate our next buffer outside of the lock
                 next_batch = Batch {
                     channel: T::with_capacity(self.capacity.next(current_batch.channel.len())),
-                    watchers: Watchers::new(),
+                    notifiers: SenderNotifiers::new(),
                 };
+
+                // Track whether the batch completed successfully or was abandoned
+                // Assume the batch was abandoned by default
+                let mut batch_flushed = false;
 
                 // Emit the batch, taking care not to panic
                 loop {
@@ -461,6 +538,7 @@ impl<T: Channel> Receiver<T> {
                             match CatchUnwind(AssertUnwindSafe(on_batch_future)).await {
                                 Ok(Ok(())) => {
                                     self.shared.metrics.queue_batch_processed.increment();
+                                    batch_flushed = true;
                                     break;
                                 }
                                 Ok(Err(BatchError { retryable })) => {
@@ -470,11 +548,11 @@ impl<T: Channel> Receiver<T> {
                                         if retryable.len() > 0 && self.retry.next() {
                                             // Delay a bit before trying again; this gives the external service
                                             // a chance to get itself together
-                                            wait(self.retry_delay.next()).await;
+                                            wait(Wait::Retry, self.retry_delay.next()).await;
 
                                             current_batch = Batch {
                                                 channel: retryable,
-                                                watchers: current_batch.watchers,
+                                                notifiers: current_batch.notifiers,
                                             };
 
                                             self.shared.metrics.queue_batch_retry.increment();
@@ -497,17 +575,24 @@ impl<T: Channel> Receiver<T> {
                     }
                 }
 
-                // After the batch has been emitted, notify any watchers
-                current_batch.watchers.notify_on_flush();
+                // After the batch has been emitted, notify any waiting senders
+                current_batch
+                    .notifiers
+                    .notify_on_flush(batch_flushed, last_batch_flushed);
+                last_batch_flushed = batch_flushed;
 
                 // Post-process barrier: wait here after batch is processed
                 #[cfg(all(not(target_arch = "wasm32"), test))]
                 self.test_barriers.wait_post_process().await;
             }
-            // If the batch was empty then notify any watchers (there was nothing to flush)
+            // If the batch was empty then notify any waiting senders (there was nothing to flush)
             // and wait before checking again
             else {
-                current_batch.watchers.notify_on_flush();
+                // Notifiers on an empty batch were scheduled while the previous
+                // batch was in flight; they get its outcome
+                current_batch
+                    .notifiers
+                    .notify_on_flush(true, last_batch_flushed);
 
                 // Post-process barrier: wait here after empty batch
                 #[cfg(all(not(target_arch = "wasm32"), test))]
@@ -520,7 +605,9 @@ impl<T: Channel> Receiver<T> {
                 }
 
                 // If we didn't see any events, then sleep for a bit
-                wait(self.idle_delay.next()).await;
+                // Idle waits may be cut short by a sender wake (a flush,
+                // channel pressure, or the channel closing)
+                wait(Wait::Idle, self.idle_delay.next()).await;
             }
         }
     }
@@ -697,7 +784,17 @@ impl Retry {
 
 struct Shared<T> {
     metrics: InternalMetrics,
+    receiver_notifier: ReceiverNotifier,
     state: Mutex<State<T>>,
+}
+
+/**
+Whether the receiver is waiting because there's nothing to do, or because it's applying backoff.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Wait {
+    Idle,
+    Retry,
 }
 
 /**
@@ -736,14 +833,14 @@ struct State<T> {
 
 struct Batch<T> {
     channel: T,
-    watchers: Watchers,
+    notifiers: SenderNotifiers,
 }
 
 impl<T: Channel> Batch<T> {
     fn new() -> Self {
         Batch {
             channel: T::new(),
-            watchers: Watchers::new(),
+            notifiers: SenderNotifiers::new(),
         }
     }
 }
@@ -754,44 +851,109 @@ impl<T: Channel> Default for Batch<T> {
     }
 }
 
-struct Watchers {
-    on_take: Vec<Watcher>,
-    on_flush: Vec<Watcher>,
+/**
+A notification channel from the [`Receiver`] to [`Sender`]s.
+*/
+struct SenderNotifiers {
+    on_take: Vec<SenderNotifier>,
+    on_flush: Vec<SenderFlushNotifier>,
 }
 
-type Watcher = Box<dyn FnOnce() + Send>;
+type SenderNotifier = Box<dyn FnOnce() + Send>;
 
-impl Default for Watchers {
+struct SenderFlushNotifier {
+    chain_with_last_batch: bool,
+    notify: Box<dyn FnOnce(bool) + Send>,
+}
+
+impl Default for SenderNotifiers {
     fn default() -> Self {
-        Watchers::new()
+        SenderNotifiers::new()
     }
 }
 
-impl Watchers {
+impl SenderNotifiers {
     fn new() -> Self {
-        Watchers {
+        SenderNotifiers {
             on_take: Vec::new(),
             on_flush: Vec::new(),
         }
     }
 
-    fn push_on_flush(&mut self, watcher: Watcher) {
-        self.on_flush.push(watcher);
+    fn push_on_flush(&mut self, chain_with_last_batch: bool, notify: Box<dyn FnOnce(bool) + Send>) {
+        self.on_flush.push(SenderFlushNotifier {
+            chain_with_last_batch,
+            notify,
+        });
     }
 
-    fn notify_on_flush(&mut self) {
-        for watcher in mem::take(&mut self.on_flush) {
-            let _ = panic::catch_unwind(AssertUnwindSafe(watcher));
+    fn notify_on_flush(&mut self, target_batch_flushed: bool, last_batch_flushed: bool) {
+        for notifier in mem::take(&mut self.on_flush) {
+            let flushed = if notifier.chain_with_last_batch {
+                // Success depends on both the batch this notifier was attached to,
+                // and the batch that preceded it
+                target_batch_flushed && last_batch_flushed
+            } else {
+                // Success depends only on the batch this notifier was attached to
+                target_batch_flushed
+            };
+
+            let notify = notifier.notify;
+
+            let _ = panic::catch_unwind(AssertUnwindSafe(move || notify(flushed)));
         }
     }
 
-    fn push_on_take(&mut self, watcher: Watcher) {
-        self.on_take.push(watcher);
+    fn push_on_take(&mut self, notifier: SenderNotifier) {
+        self.on_take.push(notifier);
     }
 
     fn notify_on_take(&mut self) {
-        for watcher in mem::take(&mut self.on_take) {
-            let _ = panic::catch_unwind(AssertUnwindSafe(watcher));
+        for notifier in mem::take(&mut self.on_take) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(notifier));
+        }
+    }
+}
+
+/**
+A notification channel from [`Sender`]s to the [`Receiver`].
+*/
+struct ReceiverNotifier {
+    state: Mutex<ReceiverNotifierState>,
+    sync: sync::Trigger,
+    #[cfg(feature = "tokio")]
+    tokio: tokio::Trigger,
+}
+
+struct ReceiverNotifierState {
+    notified: bool,
+}
+
+impl ReceiverNotifier {
+    fn new() -> Self {
+        ReceiverNotifier {
+            state: Mutex::new(ReceiverNotifierState { notified: false }),
+            sync: sync::Trigger::new(),
+            #[cfg(feature = "tokio")]
+            tokio: tokio::Trigger::new(),
+        }
+    }
+
+    fn notify(&self) {
+        let mut state = self.state.lock().unwrap();
+
+        // If a notification is already pending then any waiter has already been woken
+        if state.notified {
+            return;
+        }
+
+        state.notified = true;
+
+        self.sync.trigger(true);
+
+        #[cfg(feature = "tokio")]
+        {
+            self.tokio.trigger(true);
         }
     }
 }

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -52,8 +52,8 @@ where
             let shared = receiver.shared.clone();
 
             block_on(receiver.exec_inner(
-                move |reason, delay| {
-                    future::ready(match reason {
+                move |wait, delay| {
+                    future::ready(match wait {
                         // Idle waits can be cut short by a sender notification
                         Wait::Idle => {
                             shared.receiver_notifier.sync.wait_timeout(delay);

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{BatchError, Channel, Receiver, Sender};
+use crate::{BatchError, Channel, Receiver, Sender, Wait};
 
 /**
 Run the receiver synchronously.
@@ -49,8 +49,19 @@ where
     thread::Builder::new()
         .name(thread_name.into())
         .spawn(move || {
-            block_on(receiver.exec(
-                |delay| future::ready(thread::sleep(delay)),
+            let shared = receiver.shared.clone();
+
+            block_on(receiver.exec_inner(
+                move |reason, delay| {
+                    future::ready(match reason {
+                        // Idle waits can be cut short by a sender notification
+                        Wait::Idle => {
+                            shared.receiver_notifier.sync.wait_timeout(delay);
+                        }
+                        // Retry waits are backoff on a failing batch; don't cut them short
+                        Wait::Retry => thread::sleep(delay),
+                    })
+                },
                 move |batch| future::ready(on_batch(batch)),
             ))
         })
@@ -80,11 +91,11 @@ pub fn blocking_flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool
 
     let notifier = Trigger::new();
 
-    sender.when_flushed({
+    sender.when_flushed_inner({
         let notifier = notifier.clone();
 
-        move || {
-            notifier.trigger();
+        move |flushed| {
+            notifier.trigger(flushed);
         }
     });
 
@@ -130,7 +141,7 @@ pub fn blocking_send<T: Channel>(
                 let notifier = notifier.clone();
 
                 move || {
-                    let _ = notifier.trigger();
+                    let _ = notifier.trigger(true);
                 }
             });
 
@@ -142,25 +153,25 @@ pub fn blocking_send<T: Channel>(
 }
 
 #[derive(Clone)]
-struct Trigger(Arc<(Mutex<bool>, Condvar)>);
+pub(crate) struct Trigger(Arc<(Mutex<Option<bool>>, Condvar)>);
 
 impl Trigger {
     pub fn new() -> Self {
-        Trigger(Arc::new((Mutex::new(false), Condvar::new())))
+        Trigger(Arc::new((Mutex::new(None), Condvar::new())))
     }
 
-    pub fn trigger(self) {
-        *(self.0).0.lock().unwrap() = true;
+    pub fn trigger(&self, value: bool) {
+        *(self.0).0.lock().unwrap() = Some(value);
         (self.0).1.notify_all();
     }
 
     pub fn wait_timeout(&self, mut timeout: Duration) -> bool {
-        let mut flushed_slot = (self.0).0.lock().unwrap();
+        let mut triggered_slot = (self.0).0.lock().unwrap();
         loop {
-            // If we flushed then return
-            // This condition may already be set before we start waiting
-            if *flushed_slot {
-                return true;
+            // If we were triggered then return the value we were triggered with
+            // This may already be set before we start waiting
+            if let Some(triggered) = triggered_slot.take() {
+                return triggered;
             }
 
             // If the timeout is 0 then return
@@ -170,9 +181,9 @@ impl Trigger {
             }
 
             let now = Instant::now();
-            match (self.0).1.wait_timeout(flushed_slot, timeout).unwrap() {
-                (flushed, r) if !r.timed_out() => {
-                    flushed_slot = flushed;
+            match (self.0).1.wait_timeout(triggered_slot, timeout).unwrap() {
+                (triggered, r) if !r.timed_out() => {
+                    triggered_slot = triggered;
 
                     // Reduce the remaining timeout just in case we didn't time out,
                     // but woke up spuriously for some reason
@@ -180,15 +191,15 @@ impl Trigger {
                         Some(timeout) => timeout,
                         // We didn't time out, but got close enough that we should now anyways
                         None => {
-                            return *flushed_slot;
+                            return triggered_slot.take().unwrap_or(false);
                         }
                     };
 
                     continue;
                 }
                 // Timed out
-                (flushed, _) => {
-                    return *flushed;
+                (mut triggered_slot, _) => {
+                    return triggered_slot.take().unwrap_or(false);
                 }
             }
         }
@@ -459,6 +470,171 @@ mod tests {
         // Verify the error is non-retryable (no messages to retry)
         let err = result.err().unwrap();
         assert!(err.into_retryable().is_none());
+    }
+
+    #[test]
+    fn flush_reports_failed_batch() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let handle = spawn("test_receiver", receiver, |_| {
+            Err(BatchError::no_retry(io::Error::new(
+                io::ErrorKind::Other,
+                "explicit failure",
+            )))
+        })
+        .unwrap();
+
+        sender.send(1);
+
+        // The batch is dropped after failing, so the flush must not report success
+        assert!(!blocking_flush(&sender, Duration::from_secs(5)));
+
+        drop(sender);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn flush_reports_closed_channel() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        sender.send(1);
+
+        // Drop the receiver without processing anything; the pending item
+        // will never be flushed
+        drop(receiver);
+
+        assert!(!blocking_flush(&sender, Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn flush_reports_target_batch_outcome() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (continue_tx, continue_rx) = mpsc::channel();
+
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let handle = spawn("test_receiver", receiver, move |_| {
+            started_tx.send(()).unwrap();
+
+            // Hold the batch in flight until the test says to continue
+            continue_rx.recv().unwrap();
+
+            Err(BatchError::no_retry(io::Error::new(
+                io::ErrorKind::Other,
+                "explicit failure",
+            )))
+        })
+        .unwrap();
+
+        sender.send(1);
+
+        // Wait until the batch is being processed
+        started_rx.recv().unwrap();
+
+        // Ask to be notified while the batch is in flight; the flush outcome
+        // must cover that batch even though nothing else is pending
+        let (flushed_tx, flushed_rx) = mpsc::channel();
+        sender.when_flushed_inner(move |flushed| {
+            flushed_tx.send(flushed).unwrap();
+        });
+
+        // Let the batch fail
+        continue_tx.send(()).unwrap();
+
+        assert!(!flushed_rx.recv().unwrap());
+
+        drop(sender);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn flush_wakes_idle_receiver() {
+        let received = Arc::new(Mutex::new(0));
+
+        let (sender, receiver) = crate::bounded(10);
+
+        let handle = spawn("test_receiver", receiver, {
+            let received = received.clone();
+
+            move |batch: Vec<()>| {
+                *received.lock().unwrap() += batch.len();
+
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        // Let the receiver's idle backoff grow towards its maximum (500ms);
+        // by 550ms in it's asleep inside a ~500ms delay
+        thread::sleep(Duration::from_millis(550));
+
+        sender.send(());
+
+        // Without a wake the flush would have to wait out the remainder of the
+        // receiver's idle delay, which is longer than this timeout
+        assert!(blocking_flush(&sender, Duration::from_millis(200)));
+        assert_eq!(1, *received.lock().unwrap());
+
+        drop(sender);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn drop_wakes_idle_receiver() {
+        let (sender, receiver) = crate::bounded::<Vec<()>>(10);
+
+        let handle = spawn("test_receiver", receiver, |_| Ok(())).unwrap();
+
+        // Let the receiver's idle backoff grow towards its maximum (500ms)
+        thread::sleep(Duration::from_millis(550));
+
+        let dropped = Instant::now();
+        drop(sender);
+
+        // Without a wake the receiver would sleep out the remainder of its
+        // idle delay before noticing the channel is closed
+        handle.join().unwrap();
+        assert!(dropped.elapsed() < Duration::from_millis(250));
+    }
+
+    #[test]
+    fn channel_pressure_wakes_idle_receiver() {
+        let received = Arc::new(Mutex::new(0));
+
+        let (sender, receiver) = crate::bounded(10);
+
+        let handle = spawn("test_receiver", receiver, {
+            let received = received.clone();
+
+            move |batch: Vec<()>| {
+                *received.lock().unwrap() += batch.len();
+
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        // Let the receiver's idle backoff grow towards its maximum (500ms)
+        thread::sleep(Duration::from_millis(550));
+
+        // Crossing half the channel's capacity wakes the receiver
+        for _ in 0..5 {
+            sender.send(());
+        }
+
+        // Without a wake the receiver would sleep for longer than this deadline
+        let deadline = Instant::now() + Duration::from_millis(200);
+        while { *received.lock().unwrap() } < 5 {
+            assert!(
+                Instant::now() < deadline,
+                "receiver didn't wake on pressure"
+            );
+
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        drop(sender);
+        handle.join().unwrap();
     }
 
     #[test]

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -52,11 +52,11 @@ pub async fn exec<T: Channel, F: Future<Output = Result<(), BatchError<T>>>>(
 
     receiver
         .exec_inner(
-            move |reason, delay| {
+            move |wait, delay| {
                 let shared = shared.clone();
 
                 async move {
-                    match reason {
+                    match wait {
                         // Idle waits can be cut short by a sender notification
                         Wait::Idle => {
                             shared.receiver_notifier.tokio.wait_timeout(delay).await;

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -4,11 +4,13 @@ Run channels in a `tokio` runtime.
 
 use std::{
     future::Future,
-    io, thread,
+    io,
+    sync::Mutex,
+    thread,
     time::{Duration, Instant},
 };
 
-use crate::{BatchError, Channel, Receiver, Sender, sync};
+use crate::{BatchError, Channel, Receiver, Sender, Wait, sync};
 
 /**
 Run [`Receiver::exec`] on a `tokio` runtime in a dedicated background thread.
@@ -26,11 +28,7 @@ pub fn spawn<
 where
     T::Item: Send + 'static,
 {
-    let receive = async move {
-        receiver
-            .exec(|delay| tokio::time::sleep(delay), on_batch)
-            .await
-    };
+    let receive = exec(receiver, on_batch);
 
     thread::Builder::new()
         .name(thread_name.into())
@@ -50,9 +48,49 @@ pub async fn exec<T: Channel, F: Future<Output = Result<(), BatchError<T>>>>(
     receiver: Receiver<T>,
     on_batch: impl FnMut(T) -> F,
 ) {
+    let shared = receiver.shared.clone();
+
     receiver
-        .exec(|delay| tokio::time::sleep(delay), on_batch)
+        .exec_inner(
+            move |reason, delay| {
+                let shared = shared.clone();
+
+                async move {
+                    match reason {
+                        // Idle waits can be cut short by a sender notification
+                        Wait::Idle => {
+                            shared.receiver_notifier.tokio.wait_timeout(delay).await;
+                        }
+                        // Retry waits are backoff on a failing batch; don't cut them short
+                        Wait::Retry => tokio::time::sleep(delay).await,
+                    }
+                }
+            },
+            on_batch,
+        )
         .await
+}
+
+pub(crate) struct Trigger(tokio::sync::Notify, Mutex<Option<bool>>);
+
+impl Trigger {
+    pub fn new() -> Self {
+        Trigger(tokio::sync::Notify::new(), Mutex::new(None))
+    }
+
+    pub fn trigger(&self, value: bool) {
+        *self.1.lock().unwrap() = Some(value);
+        self.0.notify_waiters()
+    }
+
+    pub async fn wait_timeout(&self, timeout: Duration) -> bool {
+        match tokio::time::timeout(timeout, self.0.notified()).await {
+            Ok(()) => self.1.lock().unwrap().take().unwrap_or(false),
+            Err::<(), tokio::time::error::Elapsed>(_) => {
+                self.1.lock().unwrap().take().unwrap_or(false)
+            }
+        }
+    }
 }
 
 /**
@@ -77,8 +115,8 @@ This function is an asynchronous variant of [`blocking_send`].
 pub async fn flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
     let (notifier, notified) = tokio::sync::oneshot::channel();
 
-    sender.when_flushed(move || {
-        let _ = notifier.send(());
+    sender.when_flushed_inner(move |flushed| {
+        let _ = notifier.send(flushed);
     });
 
     wait(notified, timeout).await
@@ -121,7 +159,7 @@ pub async fn send<T: Channel>(
                 let (notifier, notified) = tokio::sync::oneshot::channel();
 
                 sender.when_empty(move || {
-                    let _ = notifier.send(());
+                    let _ = notifier.send(true);
                 });
 
                 wait(notified, timeout).await;
@@ -130,10 +168,10 @@ pub async fn send<T: Channel>(
         .await
 }
 
-async fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duration) -> bool {
-    // If the trigger has already fired then return immediately
-    if notified.try_recv().is_ok() {
-        return true;
+async fn wait(mut notified: tokio::sync::oneshot::Receiver<bool>, timeout: Duration) -> bool {
+    // If the trigger has already fired then return the value it fired with
+    if let Ok(value) = notified.try_recv() {
+        return value;
     }
 
     // If the timeout is 0 then return immediately
@@ -144,9 +182,10 @@ async fn wait(mut notified: tokio::sync::oneshot::Receiver<()>, timeout: Duratio
 
     match tokio::time::timeout(timeout, notified).await {
         // The notifier was triggered
-        Ok(Ok(())) => true,
-        // Unexpected hangup; this should mean the channel was closed
-        Ok(Err(_)) => true,
+        Ok(Ok(value)) => value,
+        // Unexpected hangup; the notifier was dropped without firing so
+        // the outcome is unknown; don't report success
+        Ok(Err(_)) => false,
         // The timeout was reached instead
         Err(_) => false,
     }
@@ -314,6 +353,57 @@ mod tests {
         // Clean up - abort the receiver task
         receiver_task.abort();
         let _ = receiver_task.await;
+    }
+
+    #[tokio::test]
+    async fn flush_reports_failed_batch() {
+        let (sender, receiver) = crate::bounded::<Vec<i32>>(10);
+
+        let _ = spawn("test_receiver", receiver, |_| async {
+            Err(BatchError::no_retry(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "explicit failure",
+            )))
+        })
+        .unwrap();
+
+        sender.send(1);
+
+        // The batch is dropped after failing, so the flush must not report success
+        assert!(!flush(&sender, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn flush_wakes_idle_receiver() {
+        let received = Arc::new(Mutex::new(0));
+
+        let (sender, receiver) = crate::bounded(10);
+
+        let _ = spawn("test_receiver", receiver, {
+            let received = received.clone();
+
+            move |batch: Vec<()>| {
+                let received = received.clone();
+
+                async move {
+                    *received.lock().unwrap() += batch.len();
+
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+        // Let the receiver's idle backoff grow towards its maximum (500ms);
+        // by 550ms in it's asleep inside a ~500ms delay
+        tokio::time::sleep(Duration::from_millis(550)).await;
+
+        sender.send(());
+
+        // Without a wake the flush would have to wait out the remainder of the
+        // receiver's idle delay, which is longer than this timeout
+        assert!(flush(&sender, Duration::from_millis(200)).await);
+        assert_eq!(1, *received.lock().unwrap());
     }
 
     #[tokio::test]
@@ -579,8 +669,11 @@ mod tests {
 
         let callback_fired_clone = callback_fired.clone();
         sender.when_flushed(move || {
-            when_flushed_tx.send(()).unwrap();
+            // Set the flag before signalling; the callback runs on the
+            // receiver's thread, and the test resumes as soon as the signal
+            // is sent
             *callback_fired_clone.lock().unwrap() = true;
+            when_flushed_tx.send(()).unwrap();
         });
 
         // Callback shouldn't fire yet (batch not processed)

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -98,7 +98,7 @@ Wait for a channel running in a JavaScript promise to process all items active a
 pub async fn flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
     let (notifier, notified) = futures::channel::oneshot::channel();
 
-    sender.when_flushed_result(move |flushed| {
+    sender.when_flushed_inner(move |flushed| {
         let _ = notifier.send(flushed);
     });
 
@@ -560,8 +560,6 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn park_zero_duration() {
-        let start = js_sys::Date::new_0().get_time();
-
         // Just ensure we don't panic
         Park::new(Duration::ZERO).await;
     }

--- a/batcher/src/web.rs
+++ b/batcher/src/web.rs
@@ -83,7 +83,7 @@ pub async fn send<T: Channel>(
                 let (notifier, notified) = futures::channel::oneshot::channel();
 
                 sender.when_empty(move || {
-                    let _ = notifier.send(());
+                    let _ = notifier.send(true);
                 });
 
                 wait(notified, timeout).await;
@@ -98,17 +98,17 @@ Wait for a channel running in a JavaScript promise to process all items active a
 pub async fn flush<T: Channel>(sender: &Sender<T>, timeout: Duration) -> bool {
     let (notifier, notified) = futures::channel::oneshot::channel();
 
-    sender.when_flushed(move || {
-        let _ = notifier.send(());
+    sender.when_flushed_result(move |flushed| {
+        let _ = notifier.send(flushed);
     });
 
     wait(notified, timeout).await
 }
 
-async fn wait(mut notified: futures::channel::oneshot::Receiver<()>, timeout: Duration) -> bool {
-    // If the trigger has already fired then return immediately
-    if let Ok(Some(())) = notified.try_recv() {
-        return true;
+async fn wait(mut notified: futures::channel::oneshot::Receiver<bool>, timeout: Duration) -> bool {
+    // If the trigger has already fired then return the value it fired with
+    if let Ok(Some(value)) = notified.try_recv() {
+        return value;
     }
 
     // If the timeout is 0 then return immediately
@@ -121,9 +121,10 @@ async fn wait(mut notified: futures::channel::oneshot::Receiver<()>, timeout: Du
 
     match futures::future::select(notified, timeout).await {
         // The notifier was triggered
-        futures::future::Either::Left((Ok(_), _)) => true,
-        // Unexpected hangup; this should mean the channel was closed
-        futures::future::Either::Left((Err(_), _)) => true,
+        futures::future::Either::Left((Ok(value), _)) => value,
+        // Unexpected hangup; the notifier was dropped without firing so
+        // the outcome is unknown; don't report success
+        futures::future::Either::Left((Err(_), _)) => false,
         // The timeout was reached instead
         futures::future::Either::Right(((), _)) => false,
     }

--- a/emitter/otlp/Cargo.toml
+++ b/emitter/otlp/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["test"]
 default = ["tls", "gzip", "web"]
 gzip = ["dep:flate2"]
 tls = ["dep:tokio-rustls", "dep:rustls-native-certs"]
-tls-native = ["tls", "dep:tokio-native-tls"]
+tls-native = ["tls", "dep:tokio-native-tls", "dep:native-tls"]
 web = ["emit/web", "emit_batcher/web", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
 [dependencies.emit]
@@ -82,6 +82,11 @@ optional = true
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies.tokio-native-tls]
 version = "0.3"
 optional = true
+
+[target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies.native-tls]
+version = "0.2"
+optional = true
+features = ["alpn"]
 
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies.emit_batcher]
 version = "2.22.2"

--- a/emitter/otlp/src/client.rs
+++ b/emitter/otlp/src/client.rs
@@ -390,8 +390,10 @@ impl OtlpTransportBuilder {
                     async move {
                         let status = res.http_status();
 
-                        // A request is considered successful if it returns 2xx status code
-                        if status >= 200 && status < 300 {
+                        // Drain any response body so the connection can be re-used
+                        let _ = res.drain().await;
+
+                        if http_is_success(status) {
                             metrics.http_batch_sent.increment();
 
                             Ok(())
@@ -428,7 +430,9 @@ impl OtlpTransportBuilder {
                     // Wrap the content in the gRPC frame protocol
                     // This is a simple length-prefixed format that uses
                     // 5 bytes to indicate the length and compression of the message
-                    let len = (u32::try_from(req.content_payload_len()).unwrap()).to_be_bytes();
+                    let len = u32::try_from(req.content_payload_len())
+                        .unwrap()
+                        .to_be_bytes();
 
                     Ok(
                         // If the content is compressed then set the gRPC compression header byte for it
@@ -436,7 +440,7 @@ impl OtlpTransportBuilder {
                             req.with_content_encoding_header(None)
                                 .with_content_type_header(content_type_header)
                                 .with_headers(match compression {
-                                    "gzip" => &[("grpc-encoding", "gzip")],
+                                    "gzip" => &[("grpc-encoding", "gzip"), ("te", "trailers")],
                                     compression => {
                                         return Err(Error::msg(format_args!(
                                             "unsupported compression '{compression}'"
@@ -448,6 +452,7 @@ impl OtlpTransportBuilder {
                         // If the content is not compressed then leave the gRPC compression header byte unset
                         else {
                             req.with_content_type_header(content_type_header)
+                                .with_headers(&[("te", "trailers")])
                                 .with_content_frame([0, len[0], len[1], len[2], len[3]])
                         },
                     )
@@ -456,38 +461,51 @@ impl OtlpTransportBuilder {
                     let metrics = metrics.clone();
 
                     async move {
-                        let mut status = 0;
-                        let mut msg = String::new();
+                        let status = res.http_status();
 
-                        res.stream_trailers(|k, v| match k {
-                            "grpc-status" => {
-                                status = v.parse().unwrap_or(0);
+                        // gRPC status may come from either response headers or trailers
+                        let mut grpc_status = res.header("grpc-status").map(str::to_owned);
+                        let mut grpc_message = res.header("grpc-message").map(str::to_owned);
+
+                        // If the request succeeded but there's no gRPC headers then read from trailers
+                        // We only do this on HTTP success because load-balancer failures are unlikely
+                        // to carry trailers or gRPC headers, so don't want to report that instead
+                        if http_is_success(status) && grpc_status.is_none() {
+                            let streamed = res
+                                .stream_trailers(|k, v| match k {
+                                    "grpc-status" => {
+                                        grpc_status = Some(v.into());
+                                    }
+                                    "grpc-message" => {
+                                        grpc_message = Some(v.into());
+                                    }
+                                    _ => {}
+                                })
+                                .await;
+
+                            if let Err(err) = streamed {
+                                metrics.grpc_batch_failed.increment();
+
+                                return Err(err);
                             }
-                            "grpc-message" => {
-                                msg = v.into();
-                            }
-                            _ => {}
-                        })
-                        .await?;
-
-                        // A request is considered successful if the grpc-status trailer is 0
-                        if status == 0 {
-                            metrics.grpc_batch_sent.increment();
-
-                            Ok(())
                         }
-                        // In any other case the request failed and may carry some diagnostic message
-                        else {
-                            metrics.grpc_batch_failed.increment();
 
-                            if msg.len() > 0 {
-                                Err(Error::msg(format_args!(
-                                    "OTLP gRPC server responded {status} {msg}"
-                                )))
-                            } else {
-                                Err(Error::msg(format_args!(
-                                    "OTLP gRPC server responded {status}"
-                                )))
+                        match grpc_is_success(
+                            status,
+                            grpc_status.as_deref(),
+                            grpc_message.as_deref(),
+                        ) {
+                            // The batch succeeded
+                            Ok(()) => {
+                                metrics.grpc_batch_sent.increment();
+
+                                Ok(())
+                            }
+                            // The batch failed
+                            Err(err) => {
+                                metrics.grpc_batch_failed.increment();
+
+                                Err(err)
                             }
                         }
                     }
@@ -527,7 +545,6 @@ impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
             metrics,
             |event| event_encoder.encode_event(event.get()),
             |batch| {
-                let batch = batch.clone();
                 async move {
                     #[emit::span(rt: emit::runtime::internal(), guard: span, "send OTLP batch of {batch_size} events to {uri}", batch_size: batch.total_items(), uri: request_sender.uri())]
                     async fn send_batch<S: ClientRequestSender, R: data::RequestEncoder>(
@@ -576,13 +593,15 @@ impl<S: ClientRequestSender, E: data::EventEncoder, R: data::RequestEncoder>
                         Ok(())
                     }
 
-                    send_batch(
+                    let result = send_batch(
                         &self.request_sender,
                         &self.resource,
                         &self.request_encoder,
                         &batch,
                     )
-                    .await
+                    .await;
+
+                    (batch, result)
                 }
             },
         )
@@ -798,6 +817,45 @@ impl<R: data::RequestEncoder> ClientRequestEncoder<R> {
     }
 }
 
+fn http_is_success(status: u16) -> bool {
+    // A request is considered successful if it returns 2xx status code
+    status >= 200 && status < 300
+}
+
+fn grpc_is_success(
+    http_status: u16,
+    grpc_status: Option<&str>,
+    grpc_message: Option<&str>,
+) -> Result<(), Error> {
+    if !http_is_success(http_status) {
+        return Err(Error::msg(format_args!(
+            "OTLP gRPC server responded HTTP {http_status}"
+        )));
+    }
+
+    match grpc_status.map(str::parse::<u64>) {
+        // A request is considered successful if the grpc-status is 0
+        Some(Ok(0)) => Ok(()),
+        // In any other case the request failed and may carry some diagnostic message
+        Some(Ok(status)) => match grpc_message.filter(|msg| !msg.is_empty()) {
+            Some(msg) => Err(Error::msg(format_args!(
+                "OTLP gRPC server responded {status} {msg}"
+            ))),
+            None => Err(Error::msg(format_args!(
+                "OTLP gRPC server responded {status}"
+            ))),
+        },
+        Some(Err(_)) => Err(Error::msg(
+            "OTLP gRPC server responded with an invalid grpc-status",
+        )),
+        // A gRPC response that never carried a status is invalid; don't
+        // assume the request was accepted
+        None => Err(Error::msg(
+            "OTLP gRPC server response did not include a grpc-status",
+        )),
+    }
+}
+
 fn encode_resource(encoding: Encoding, resource: &Resource) -> EncodedPayload {
     let attributes = data::PropsResourceAttributes(&resource.attributes);
 
@@ -813,6 +871,39 @@ fn encode_resource(encoding: Encoding, resource: &Resource) -> EncodedPayload {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn interpret_grpc_response_cases() {
+        for (case, err) in [
+            (grpc_is_success(200, Some("0"), None), None::<&str>),
+            (grpc_is_success(201, Some("0"), None), None::<&str>),
+            (grpc_is_success(200, Some("0"), Some("")), None::<&str>),
+            (
+                grpc_is_success(200, Some("16"), Some("unauthenticated")),
+                Some("OTLP gRPC server responded 16 unauthenticated"),
+            ),
+            (
+                grpc_is_success(200, None, None),
+                Some("OTLP gRPC server response did not include a grpc-status"),
+            ),
+            (
+                grpc_is_success(503, None, None),
+                Some("OTLP gRPC server responded HTTP 503"),
+            ),
+            (
+                grpc_is_success(200, Some("zero"), None),
+                Some("OTLP gRPC server responded with an invalid grpc-status"),
+            ),
+        ] {
+            if let Some(err) = err {
+                assert_eq!(err, case.unwrap_err().to_string());
+            } else {
+                assert!(case.is_ok());
+            }
+        }
+    }
+
     #[test]
     #[cfg(not(all(
         target_arch = "wasm32",

--- a/emitter/otlp/src/client/channel.rs
+++ b/emitter/otlp/src/client/channel.rs
@@ -28,11 +28,13 @@ pub(crate) async fn batch<F>(
     max_request_size: usize,
     metrics: &InternalMetrics,
     mut encode_event: impl FnMut(&ChannelEvent) -> Option<EncodedEvent>,
-    mut send_batch: impl FnMut(&EncodedScopeItems) -> F,
+    mut send_batch: impl FnMut(EncodedScopeItems) -> F,
 ) -> Result<(), BatchError<Channel>>
 where
-    F: Future<Output = Result<(), BatchError<()>>>,
+    F: Future<Output = (EncodedScopeItems, Result<(), BatchError<()>>)>,
 {
+    // The batch is moved into each send future and returned by it, so its
+    // allocations are re-used from one request to the next
     let mut batch = EncodedScopeItems::new();
 
     let mut scope_index = channel.cursor.scope_index;
@@ -59,7 +61,10 @@ where
                 && batch.total_size_bytes() + encoded.size_bytes() > max_request_size
             {
                 // We've reached the maximum size of a single batch; send it then start a new one
-                match send_batch(&batch).await {
+                let (sent, result) = send_batch(batch).await;
+                batch = sent;
+
+                match result {
                     Ok(()) => {
                         batch.clear();
 
@@ -82,7 +87,7 @@ where
 
     // Send the final batch
     if batch.total_items() > 0 {
-        match send_batch(&batch).await {
+        match send_batch(batch).await.1 {
             Ok(()) => Ok(()),
             Err(e) => Err(e.map_retryable(|r| r.map(|_| channel))),
         }
@@ -407,10 +412,10 @@ mod tests {
                 case,
                 &Default::default(),
                 |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
-                |_| async {
+                |batch| async {
                     *calls.lock().unwrap() += 1;
 
-                    Ok(())
+                    (batch, Ok(()))
                 },
             )
             .await
@@ -447,19 +452,22 @@ mod tests {
             0,
             &Default::default(),
             |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
-            |_| async {
+            |batch| async {
                 let mut calls = calls.lock().unwrap();
 
                 *calls += 1;
 
                 if *calls == 2 {
-                    return Err(BatchError::retry(
-                        io::Error::new(io::ErrorKind::Other, "explicit failure"),
-                        (),
-                    ));
+                    return (
+                        batch,
+                        Err(BatchError::retry(
+                            io::Error::new(io::ErrorKind::Other, "explicit failure"),
+                            (),
+                        )),
+                    );
                 }
 
-                Ok(())
+                (batch, Ok(()))
             },
         )
         .await
@@ -478,7 +486,7 @@ mod tests {
             0,
             &Default::default(),
             |evt| logs::LogsEventEncoder::default().encode_event::<Json>(evt.get()),
-            |_| async { Ok(()) },
+            |batch| async { (batch, Ok(())) },
         )
         .await
         .unwrap();

--- a/emitter/otlp/src/client/http/stub.rs
+++ b/emitter/otlp/src/client/http/stub.rs
@@ -80,6 +80,14 @@ impl HttpResponse {
         todo!()
     }
 
+    pub fn header(&self, _name: &str) -> Option<&str> {
+        todo!()
+    }
+
+    pub async fn drain(self) -> Result<(), Error> {
+        todo!()
+    }
+
     pub async fn stream_trailers(self, mut _trailer: impl FnMut(&str, &str)) -> Result<(), Error> {
         todo!()
     }

--- a/emitter/otlp/src/client/http/tokio.rs
+++ b/emitter/otlp/src/client/http/tokio.rs
@@ -46,12 +46,17 @@ async fn connect(
             Error::new("failed to connect TCP stream", e)
         })?;
 
+    // Disable Nagle's algorithm; requests are written in several small pieces
+    // (headers, framing, payload chunks), and coalescing them against delayed
+    // ACKs stalls each request by tens of milliseconds
+    let _ = io.set_nodelay(true);
+
     metrics.transport_conn_established.increment();
 
     if uri.is_https() {
         #[cfg(feature = "tls")]
         {
-            let io = tls_handshake(metrics, io, uri).await?;
+            let io = tls_handshake(metrics, io, uri, version).await?;
 
             http_handshake(metrics, version, io).await
         }
@@ -64,7 +69,18 @@ async fn connect(
     }
 }
 
-/*
+#[cfg(feature = "tls")]
+fn alpn_protocol(version: HttpVersion) -> &'static str {
+    // HTTP2 is commonly negotiated via ALPN during the TLS handshake
+    // We don't support protocol downgrades, so only advertise exactly the protocol
+    // we expect to communicate on
+    match version {
+        HttpVersion::Http1 => "http/1.1",
+        HttpVersion::Http2 => "h2",
+    }
+}
+
+/**
 TLS using the native platform
 */
 #[cfg(all(feature = "tls", feature = "tls-native"))]
@@ -72,17 +88,23 @@ async fn tls_handshake(
     metrics: &InternalMetrics,
     io: tokio::net::TcpStream,
     uri: &HttpUri,
+    version: HttpVersion,
 ) -> Result<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + Unpin + 'static, Error>
 {
     use tokio_native_tls::{TlsConnector, native_tls};
 
     let domain = uri.host();
 
-    let connector = TlsConnector::from(native_tls::TlsConnector::new().map_err(|e| {
-        metrics.transport_conn_tls_failed.increment();
+    let connector = TlsConnector::from(
+        native_tls::TlsConnector::builder()
+            .request_alpns(&[alpn_protocol(version)])
+            .build()
+            .map_err(|e| {
+                metrics.transport_conn_tls_failed.increment();
 
-        Error::new("failed to create TLS connector", e)
-    })?);
+                Error::new("failed to create TLS connector", e)
+            })?,
+    );
 
     let io = connector.connect(domain, io).await.map_err(|e| {
         metrics.transport_conn_tls_failed.increment();
@@ -95,7 +117,7 @@ async fn tls_handshake(
     Ok(io)
 }
 
-/*
+/**
 TLS using `rustls`
 */
 #[cfg(all(feature = "tls", not(feature = "tls-native")))]
@@ -103,9 +125,10 @@ async fn tls_handshake(
     metrics: &InternalMetrics,
     io: tokio::net::TcpStream,
     uri: &HttpUri,
+    version: HttpVersion,
 ) -> Result<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + Unpin + 'static, Error>
 {
-    use tokio_rustls::{TlsConnector, rustls};
+    use tokio_rustls::TlsConnector;
 
     let domain = uri.host().to_owned().try_into().map_err(|e| {
         metrics.transport_conn_tls_failed.increment();
@@ -113,7 +136,41 @@ async fn tls_handshake(
         Error::new(format_args!("could not extract a DNS name from {uri}"), e)
     })?;
 
-    let tls = {
+    let conn = TlsConnector::from(tls_client_config(metrics, version));
+
+    let io = conn.connect(domain, io).await.map_err(|e| {
+        metrics.transport_conn_tls_failed.increment();
+
+        Error::new("failed to connect TLS stream", e)
+    })?;
+
+    metrics.transport_conn_tls_handshake.increment();
+
+    Ok(io)
+}
+
+/**
+Get the shared `rustls` configuration for connections speaking `version`.
+*/
+#[cfg(all(feature = "tls", not(feature = "tls-native")))]
+fn tls_client_config(
+    metrics: &InternalMetrics,
+    version: HttpVersion,
+) -> Arc<tokio_rustls::rustls::ClientConfig> {
+    use std::sync::OnceLock;
+
+    use tokio_rustls::rustls;
+
+    // Cache and re-use configuration across connections; it's expensive to produce
+    static HTTP1: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    static HTTP2: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+
+    let slot = match version {
+        HttpVersion::Http1 => &HTTP1,
+        HttpVersion::Http2 => &HTTP2,
+    };
+
+    slot.get_or_init(|| {
         let mut root_store = rustls::RootCertStore::empty();
 
         let certs = rustls_native_certs::load_native_certs();
@@ -130,24 +187,15 @@ async fn tls_handshake(
             let _ = root_store.add(cert);
         }
 
-        Arc::new(
-            rustls::ClientConfig::builder()
-                .with_root_certificates(root_store)
-                .with_no_client_auth(),
-        )
-    };
+        let mut config = rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
 
-    let conn = TlsConnector::from(tls);
+        config.alpn_protocols = vec![alpn_protocol(version).into()];
 
-    let io = conn.connect(domain, io).await.map_err(|e| {
-        metrics.transport_conn_tls_failed.increment();
-
-        Error::new("failed to connect TLS stream", e)
-    })?;
-
-    metrics.transport_conn_tls_handshake.increment();
-
-    Ok(io)
+        Arc::new(config)
+    })
+    .clone()
 }
 
 async fn http_handshake(
@@ -205,7 +253,10 @@ async fn send_request<'a>(
     content: HttpContent,
 ) -> Result<HttpResponse, Error> {
     let res = sender
-        .send_request(metrics, http_request(metrics, uri, headers, content)?)
+        .send_request(
+            metrics,
+            http_request(metrics, sender.version(), uri, headers, content)?,
+        )
         .await?;
 
     Ok(res)
@@ -213,11 +264,28 @@ async fn send_request<'a>(
 
 fn http_request<'a>(
     metrics: &'a InternalMetrics,
+    version: HttpVersion,
     uri: &'a HttpUri,
     headers: impl Iterator<Item = (&'a str, &'a str)>,
     content: HttpContent,
 ) -> Result<Request<HttpContent>, Error> {
-    let mut req = Request::builder().uri(&uri.0).method(Method::POST);
+    let request_uri = match version {
+        // HTTP1 requests to origin servers carry an origin-form target
+        // with the authority in the host header
+        HttpVersion::Http1 => http::Uri::builder()
+            .path_and_query(
+                uri.0
+                    .path_and_query()
+                    .cloned()
+                    .unwrap_or_else(|| http::uri::PathAndQuery::from_static("/")),
+            )
+            .build()
+            .map_err(|e| Error::new("failed to construct request target", e))?,
+        // HTTP2 carries the full URI in its pseudo headers
+        HttpVersion::Http2 => uri.0.clone(),
+    };
+
+    let mut req = Request::builder().uri(request_uri).method(Method::POST);
 
     for (k, v) in content.custom_headers {
         req = req.header(*k, *v);
@@ -308,8 +376,10 @@ impl HttpConnection {
     async fn send(&self, body: EncodedPayload, timeout: Duration) -> Result<(), Error> {
         let res = tokio::time::timeout(timeout, async {
             let mut sender = match self.poison() {
-                Some(sender) => sender,
-                None => connect(&self.metrics, self.version, &self.uri).await?,
+                // Only re-use the previous connection if it's still open; servers
+                // and load balancers regularly close idle or long-lived connections
+                Some(sender) if !sender.is_closed() => sender,
+                _ => connect(&self.metrics, self.version, &self.uri).await?,
             };
 
             let body =
@@ -355,6 +425,20 @@ enum HttpSender {
 }
 
 impl HttpSender {
+    fn version(&self) -> HttpVersion {
+        match self {
+            HttpSender::Http1(_) => HttpVersion::Http1,
+            HttpSender::Http2(_) => HttpVersion::Http2,
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        match self {
+            HttpSender::Http1(sender) => sender.is_closed(),
+            HttpSender::Http2(sender) => sender.is_closed(),
+        }
+    }
+
     async fn send_request(
         &mut self,
         metrics: &InternalMetrics,
@@ -406,6 +490,15 @@ impl Body for HttpContent {
 impl HttpResponse {
     pub fn http_status(&self) -> u16 {
         self.res.status().as_u16()
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.res.headers().get(name).and_then(|v| v.to_str().ok())
+    }
+
+    pub async fn drain(self) -> Result<(), Error> {
+        // NOTE: Reading trailers requires reading the body too
+        self.stream_trailers(|_, _| {}).await
     }
 
     pub async fn stream_trailers(
@@ -530,6 +623,45 @@ mod tests {
     use crate::data::{Json, RawEncoder};
 
     #[test]
+    fn http1_request_target_is_origin_form() {
+        let metrics = InternalMetrics::default();
+        let uri = HttpUri::new("http://localhost:4718/v1/logs").unwrap();
+        let content =
+            HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
+
+        let req = http_request(
+            &metrics,
+            HttpVersion::Http1,
+            &uri,
+            ([] as [(&str, &str); 0]).into_iter(),
+            content,
+        )
+        .unwrap();
+
+        assert_eq!("/v1/logs", req.uri().to_string());
+        assert_eq!("localhost:4718", req.headers()["host"]);
+    }
+
+    #[test]
+    fn http2_request_target_is_absolute() {
+        let metrics = InternalMetrics::default();
+        let uri = HttpUri::new("http://localhost:4718/v1/logs").unwrap();
+        let content =
+            HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
+
+        let req = http_request(
+            &metrics,
+            HttpVersion::Http2,
+            &uri,
+            ([] as [(&str, &str); 0]).into_iter(),
+            content,
+        )
+        .unwrap();
+
+        assert_eq!("http://localhost:4718/v1/logs", req.uri().to_string());
+    }
+
+    #[test]
     fn default_http_port_is_80() {
         let uri = HttpUri("http://example.com".parse().unwrap());
         assert_eq!(80, uri.port());
@@ -549,7 +681,14 @@ mod tests {
         let content =
             HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
 
-        let req = http_request(&metrics, &uri, headers.into_iter(), content).unwrap();
+        let req = http_request(
+            &metrics,
+            HttpVersion::Http1,
+            &uri,
+            headers.into_iter(),
+            content,
+        )
+        .unwrap();
 
         let agent = req.headers().get("user-agent").unwrap().to_str().unwrap();
 
@@ -564,7 +703,14 @@ mod tests {
         let content =
             HttpContent::new(false, |content| Ok(content), &metrics, Json::encode(42)).unwrap();
 
-        let req = http_request(&metrics, &uri, headers.into_iter(), content).unwrap();
+        let req = http_request(
+            &metrics,
+            HttpVersion::Http1,
+            &uri,
+            headers.into_iter(),
+            content,
+        )
+        .unwrap();
 
         let agent = req.headers().get("user-agent").unwrap().to_str().unwrap();
 

--- a/emitter/otlp/src/client/http/web.rs
+++ b/emitter/otlp/src/client/http/web.rs
@@ -120,6 +120,17 @@ impl HttpResponse {
         self.status
     }
 
+    // NOTE: Only used by the gRPC transport, which fetch doesn't support
+    pub fn header(&self, _name: &str) -> Option<&str> {
+        None
+    }
+
+    pub async fn drain(self) -> Result<(), Error> {
+        // The response body isn't streamed by this transport, so there's
+        // nothing to drain
+        Ok(())
+    }
+
     pub async fn stream_trailers(self, _trailer: impl FnMut(&str, &str)) -> Result<(), Error> {
         Err(Error::msg("streaming trailers is not supported by fetch"))
     }

--- a/emitter/otlp/test/web/index.mjs
+++ b/emitter/otlp/test/web/index.mjs
@@ -18,19 +18,32 @@ otelcol.on('close', (code) => {
   console.log(`otelcol exited with ${code}`);
 });
 
+// Wait for the collector's output to contain the given fragment.
+//
+// The collector acknowledges a request before its output is necessarily
+// delivered to us; even once the bytes are written, our `data` handlers only
+// run when control returns to the event loop. Polling here yields so that
+// pending output can arrive instead of checking a possibly stale snapshot.
+async function expectOutput(fragment, label) {
+  const deadline = Date.now() + 10000;
+
+  while (!output.match(fragment)) {
+    if (Date.now() > deadline) {
+      throw new Error(`otelcol output did not contain the expected fragment '${fragment}' from ${label}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 wasm.setup();
 
 try {
     let jsonFragment = await wasm.http_json();
     let protoFragment = await wasm.http_proto();
 
-    if (!output.match(jsonFragment)) {
-        throw new Error(`otelcol output did not contain the expected fragment '${jsonFragment}' from HTTP+JSON`);
-    }
-
-    if (!output.match(protoFragment)) {
-        throw new Error(`otelcol output did not contain the expected fragment '${protoFragment}' from HTTP+protobuf`);
-    }
+    await expectOutput(jsonFragment, "HTTP+JSON");
+    await expectOutput(protoFragment, "HTTP+protobuf");
 }
 finally {
     otelcol.kill();

--- a/emitter/otlp/test/web/index.mjs
+++ b/emitter/otlp/test/web/index.mjs
@@ -18,14 +18,9 @@ otelcol.on('close', (code) => {
   console.log(`otelcol exited with ${code}`);
 });
 
-// Wait for the collector's output to contain the given fragment.
-//
-// The collector acknowledges a request before its output is necessarily
-// delivered to us; even once the bytes are written, our `data` handlers only
-// run when control returns to the event loop. Polling here yields so that
-// pending output can arrive instead of checking a possibly stale snapshot.
+// Wait for output to be delivered
 async function expectOutput(fragment, label) {
-  const deadline = Date.now() + 10000;
+  const deadline = Date.now() + 10000; // 10s
 
   while (!output.match(fragment)) {
     if (Date.now() > deadline) {

--- a/emitter/otlp/test/web/native/lib.rs
+++ b/emitter/otlp/test/web/native/lib.rs
@@ -40,7 +40,7 @@ async fn run_test(builder: emit_otlp::OtlpLogsBuilder) -> String {
     // Emit a log event
     emit::info!(rt, "A log message {fragment}");
 
-    // Flush `emit_otlp`
+    // Flush
     let flushed = rt.emitter().flush(std::time::Duration::from_secs(10)).await;
 
     emit::info!(rt: emit::runtime::internal(), "OTLP asynchronous flush returned {flushed}");


### PR DESCRIPTION
This PR reworks the internals of `emit_otlp`'s background thread processing and `emit_batcher`'s flushing to improve end-to-end OTLP throughput. The main cause of delays was a missing `TCP_NODELAY`, causing small batches to be buffered instead of sent immediately. `emit_otlp` already does batching and buffering, so we don't really benefit from holding small packets.

-----

**AI Disclosure:** This work was assisted by cloud agentic tooling.