### PR TITLE
Make receiver waking more reliable

### DIFF
--- a/batcher/src/lib.rs
+++ b/batcher/src/lib.rs
@@ -305,7 +305,7 @@ impl<T: Channel> Sender<T> {
 
             f();
         } else {
-            state.next_batch.notifiers.push_on_take(Box::new(f));
+            state.next_batch.sender_notifiers.push_on_take(Box::new(f));
             drop(state);
 
             // Notify the receiver so the callback triggers as soon as the batch
@@ -351,7 +351,7 @@ impl<T: Channel> Sender<T> {
 
             state
                 .next_batch
-                .notifiers
+                .sender_notifiers
                 .push_on_flush(requires_in_flight, Box::new(f));
 
             // Drop the lock before signaling the receiver
@@ -495,13 +495,13 @@ impl<T: Channel> Receiver<T> {
                 else {
                     state.is_in_batch = false;
 
-                    let notifiers = mem::take(&mut state.next_batch.notifiers);
+                    let notifiers = mem::take(&mut state.next_batch.sender_notifiers);
                     let open = state.is_open;
 
                     (
                         Batch {
                             channel: T::new(),
-                            notifiers,
+                            sender_notifiers: notifiers,
                         },
                         open,
                     )
@@ -509,7 +509,7 @@ impl<T: Channel> Receiver<T> {
             };
 
             // Run outside of the lock
-            current_batch.notifiers.notify_on_take();
+            current_batch.sender_notifiers.notify_on_take();
 
             // Post-take barrier: wait here after batch is taken
             #[cfg(all(not(target_arch = "wasm32"), test))]
@@ -523,7 +523,7 @@ impl<T: Channel> Receiver<T> {
                 // Re-allocate our next buffer outside of the lock
                 next_batch = Batch {
                     channel: T::with_capacity(self.capacity.next(current_batch.channel.len())),
-                    notifiers: SenderNotifiers::new(),
+                    sender_notifiers: SenderNotifiers::new(),
                 };
 
                 // Track whether the batch completed successfully or was abandoned
@@ -552,7 +552,7 @@ impl<T: Channel> Receiver<T> {
 
                                             current_batch = Batch {
                                                 channel: retryable,
-                                                notifiers: current_batch.notifiers,
+                                                sender_notifiers: current_batch.sender_notifiers,
                                             };
 
                                             self.shared.metrics.queue_batch_retry.increment();
@@ -577,7 +577,7 @@ impl<T: Channel> Receiver<T> {
 
                 // After the batch has been emitted, notify any waiting senders
                 current_batch
-                    .notifiers
+                    .sender_notifiers
                     .notify_on_flush(batch_flushed, last_batch_flushed);
                 last_batch_flushed = batch_flushed;
 
@@ -591,7 +591,7 @@ impl<T: Channel> Receiver<T> {
                 // Notifiers on an empty batch were scheduled while the previous
                 // batch was in flight; they get its outcome
                 current_batch
-                    .notifiers
+                    .sender_notifiers
                     .notify_on_flush(true, last_batch_flushed);
 
                 // Post-process barrier: wait here after empty batch
@@ -833,14 +833,14 @@ struct State<T> {
 
 struct Batch<T> {
     channel: T,
-    notifiers: SenderNotifiers,
+    sender_notifiers: SenderNotifiers,
 }
 
 impl<T: Channel> Batch<T> {
     fn new() -> Self {
         Batch {
             channel: T::new(),
-            notifiers: SenderNotifiers::new(),
+            sender_notifiers: SenderNotifiers::new(),
         }
     }
 }
@@ -919,20 +919,14 @@ impl SenderNotifiers {
 A notification channel from [`Sender`]s to the [`Receiver`].
 */
 struct ReceiverNotifier {
-    state: Mutex<ReceiverNotifierState>,
     sync: sync::Trigger,
     #[cfg(feature = "tokio")]
     tokio: tokio::Trigger,
 }
 
-struct ReceiverNotifierState {
-    notified: bool,
-}
-
 impl ReceiverNotifier {
     fn new() -> Self {
         ReceiverNotifier {
-            state: Mutex::new(ReceiverNotifierState { notified: false }),
             sync: sync::Trigger::new(),
             #[cfg(feature = "tokio")]
             tokio: tokio::Trigger::new(),
@@ -940,15 +934,6 @@ impl ReceiverNotifier {
     }
 
     fn notify(&self) {
-        let mut state = self.state.lock().unwrap();
-
-        // If a notification is already pending then any waiter has already been woken
-        if state.notified {
-            return;
-        }
-
-        state.notified = true;
-
         self.sync.trigger(true);
 
         #[cfg(feature = "tokio")]

--- a/batcher/src/sync.rs
+++ b/batcher/src/sync.rs
@@ -564,16 +564,19 @@ mod tests {
         })
         .unwrap();
 
-        // Let the receiver's idle backoff grow towards its maximum (500ms);
-        // by 550ms in it's asleep inside a ~500ms delay
-        thread::sleep(Duration::from_millis(550));
+        for _ in 0..3 {
+            // Let the receiver's idle backoff grow towards its maximum (500ms);
+            // by 550ms in it's asleep inside a ~500ms delay
+            thread::sleep(Duration::from_millis(550));
 
-        sender.send(());
+            sender.send(());
 
-        // Without a wake the flush would have to wait out the remainder of the
-        // receiver's idle delay, which is longer than this timeout
-        assert!(blocking_flush(&sender, Duration::from_millis(200)));
-        assert_eq!(1, *received.lock().unwrap());
+            // Without a wake the flush would have to wait out the remainder of the
+            // receiver's idle delay, which is longer than this timeout
+            assert!(blocking_flush(&sender, Duration::from_millis(200)));
+        }
+
+        assert_eq!(3, *received.lock().unwrap());
 
         drop(sender);
         handle.join().unwrap();

--- a/batcher/src/tokio.rs
+++ b/batcher/src/tokio.rs
@@ -80,11 +80,16 @@ impl Trigger {
 
     pub fn trigger(&self, value: bool) {
         *self.1.lock().unwrap() = Some(value);
-        self.0.notify_waiters()
+        self.0.notify_one()
     }
 
     pub async fn wait_timeout(&self, timeout: Duration) -> bool {
-        match tokio::time::timeout(timeout, self.0.notified()).await {
+        let notified = self.0.notified();
+        tokio::pin!(notified);
+
+        notified.as_mut().enable();
+
+        match tokio::time::timeout(timeout, notified).await {
             Ok(()) => self.1.lock().unwrap().take().unwrap_or(false),
             Err::<(), tokio::time::error::Elapsed>(_) => {
                 self.1.lock().unwrap().take().unwrap_or(false)
@@ -394,16 +399,19 @@ mod tests {
         })
         .unwrap();
 
-        // Let the receiver's idle backoff grow towards its maximum (500ms);
-        // by 550ms in it's asleep inside a ~500ms delay
-        tokio::time::sleep(Duration::from_millis(550)).await;
+        for _ in 0..3 {
+            // Let the receiver's idle backoff grow towards its maximum (500ms);
+            // by 550ms in it's asleep inside a ~500ms delay
+            tokio::time::sleep(Duration::from_millis(550)).await;
 
-        sender.send(());
+            sender.send(());
 
-        // Without a wake the flush would have to wait out the remainder of the
-        // receiver's idle delay, which is longer than this timeout
-        assert!(flush(&sender, Duration::from_millis(200)).await);
-        assert_eq!(1, *received.lock().unwrap());
+            // Without a wake the flush would have to wait out the remainder of the
+            // receiver's idle delay, which is longer than this timeout
+            assert!(flush(&sender, Duration::from_millis(200)).await);
+        }
+
+        assert_eq!(3, *received.lock().unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
This is a follow-up to #393 that fixes up an issue with the as yet unshipped receiver notifier. It would only reliably notify the receiver end of the channel once, then not subsequently. The impact of this is low, it would have behaved mostly like the old code without the mechanism did by timing out.